### PR TITLE
Passing response object to callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = function (url, opts, cb) {
 					return;
 				}
 
-				get(urlLib.resolve(url, res.headers.location), cb);
+				get(urlLib.resolve(url, res.headers.location), opts, cb);
 				return;
 			}
 
@@ -63,7 +63,7 @@ module.exports = function (url, opts, cb) {
 			res.once('error', cb);
 
 			res.once('end', function () {
-				cb(null, ret);
+				cb(null, ret, res);
 			});
 		}).once('error', cb);
 	};

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ Type: `object`
 
 Any of the [`http.request`](http://nodejs.org/api/http.html#http_http_request_options_callback) options.
 
-##### callback(err, data)
+##### callback(err, data, res)
 
 
 ## License

--- a/test.js
+++ b/test.js
@@ -43,6 +43,14 @@ it('should support optional options', function (done) {
 	});
 });
 
+it('should get headers only with HEAD method', function (done) {
+	got('http://google.com', {method: 'HEAD'}, function (err, data, res) {
+		assert(!data, data);
+		assert.ok(res.headers);
+		done();
+	});
+});
+
 it('should support gzip', function (done) {
 	got('http://sindresorhus.com', function (err, data) {
 		assert(!err, err);


### PR DESCRIPTION
This PR contains next features:
- Passing response object to callback - which allows user to read headers (useful with `method: 'head'` option)
- Passing options on redirect - this preserves `method: 'head'` option, when getting `google.com`
