### PR TITLE
Implement body option

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,12 +102,8 @@ module.exports = function (url, opts, cb) {
 			return;
 		}
 
-		if (body.pipe) {
-			body.pipe(req);
-		} else {
-			req.write(body);
-			req.end();
-		}
+		req.write(body);
+		req.end();
 	};
 
 	get(url, opts, cb);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "timed-out": "^1.0.0"
   },
   "devDependencies": {
-    "from2-array": "0.0.3",
     "mocha": "*"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ Encoding to be used on `setEncoding` of the response data. If null, the body is 
 
 ##### options.body
 
-Type: `string`, `Buffer`, `ReadableStream`  
+Type: `string`, `Buffer`  
 
 Body, that will be sent with `POST` request. If present in `options` and `options.method` is not set - `options.method` will be set to `POST`.
 

--- a/test.js
+++ b/test.js
@@ -4,7 +4,6 @@
 
 var assert = require('assert');
 var got = require('./');
-var from = require('from2-array');
 var http = require('http');
 
 it('should do HTTP request', function (done) {
@@ -129,14 +128,6 @@ describe('with POST ', function () {
 
 	it('should support Buffer as body option', function (done) {
 		got('http://0.0.0.0:8081', { body: new Buffer('string') }, function (err, data) {
-			assert.ifError(err);
-			assert.equal(data, 'string');
-			done();
-		});
-	});
-
-	it('should support ReadableStream as body option', function (done) {
-		got('http://0.0.0.0:8081', { body: from(['string']) }, function (err, data) {
 			assert.ifError(err);
 			assert.equal(data, 'string');
 			done();


### PR DESCRIPTION
This option will allow to remove all code in `sent` and leave it only as API wrapper around `got`.
##### options.body

Type: `string`, `Buffer`, `ReadableStream`  

Body, that will be sent with `POST` request. If present in `options` and `options.method` is not set - `options.method` will be set to `POST`.
