### PR TITLE
Update timed-out to get nice error.messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "object-assign": "^2.0.0",
     "read-all-stream": "^0.1.0",
-    "timed-out": "^1.0.0"
+    "timed-out": "^2.0.0"
   },
   "devDependencies": {
     "mocha": "*"


### PR DESCRIPTION
`ETIMEDOUT` error message is useless in debug. timed-out@2 contains host, that caused error, which reduce much frustration in debugging in production.
