### PR TITLE
Implement got as WritableStream on POST and PUT

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "simple"
   ],
   "dependencies": {
+    "duplexify": "^3.2.0",
     "object-assign": "^2.0.0",
     "read-all-stream": "^0.1.0",
     "timed-out": "^2.0.0"

--- a/readme.md
+++ b/readme.md
@@ -27,8 +27,12 @@ got('http://todomvc.com', function (err, data, res) {
 	//=> <!doctype html> ...
 });
 
+
 // Stream mode.
 got('http://todomvc.com').pipe(fs.createWriteStream('index.html'));
+
+// For POST and PUT methods got returns WritableStream
+fs.createReadStream('index.html').pipe(got.post('http://todomvc.com'));
 ```
 
 ### API
@@ -63,6 +67,8 @@ Type: `string`, `Buffer`
 
 Body, that will be sent with `POST` request. If present in `options` and `options.method` is not set - `options.method` will be set to `POST`.
 
+This option and stream mode are mutually exclusive.
+
 ##### options.timeout
 
 Type: `number`
@@ -83,6 +89,13 @@ The data you requested.
 
 The [response object](http://nodejs.org/api/http.html#http_http_incomingmessage).
 
+#### got.post(url, [options], [callback])
+
+Sets options.method to POST and makes a request.
+
+#### got.put(url, [options], [callback])
+
+Sets options.method to PUT and makes a request.
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -133,4 +133,47 @@ describe('with POST ', function () {
 			done();
 		});
 	});
+
+	it('should take data from options.body in stream mode', function (done) {
+		got.post('http://0.0.0.0:8081', { body: 'Hello' })
+			.on('error', done)
+			.on('data', function (chunk) {
+				assert.equal(chunk, 'Hello');
+				done();
+			});
+	});
+
+	it('should throw an error on options.body and write operations', function (done) {
+		assert.throws(function () {
+			got.post('http://0.0.0.0:8081', { body: 'Hello' })
+				.end('Hello');
+		}, 'got\'s stream is not writable when options.body is used');
+
+		assert.throws(function () {
+			got.post('http://0.0.0.0:8081', { body: 'Hello' })
+				.write('Hello');
+		}, 'got\'s stream is not writable when options.body is used');
+
+		done();
+	});
+
+	it('should be a writeable stream on POST', function (done) {
+		got.post('http://0.0.0.0:8081')
+			.on('error', done)
+			.on('data', function (chunk) {
+				assert.equal(chunk, 'Hello');
+				done();
+			})
+			.end('Hello');
+	});
+
+	it('should be a writeable stream on PUT', function (done) {
+		got.put('http://0.0.0.0:8081')
+			.on('error', done)
+			.on('data', function (chunk) {
+				assert.equal(chunk, 'Hello');
+				done();
+			})
+			.end('Hello');
+	});
 });


### PR DESCRIPTION
This will allow write to Stream, that returned from got, if method is `POST` or `PUT`.

Would it be useful to add some shortcuts?

``` js
stream.pipe(got('http://devnull-as-a-service.com/', { method: 'POST' }))
// vs
stream.pipe(got.post('http://devnull-as-a-service.com/'))
```
