### PR TITLE
Add readable streams support in options.body

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var duplexify = require('duplexify');
 var assign = require('object-assign');
 var read = require('read-all-stream');
 var timeout = require('timed-out');
+var isReadableStream = require('isstream').isReadable;
 
 function got(url, opts, cb) {
 	if (typeof opts === 'function') {
@@ -98,7 +99,7 @@ function got(url, opts, cb) {
 		}
 
 		if (!proxy) {
-			req.end(body);
+			isReadableStream(body) ? body.pipe(req) : req.end(body);
 			return;
 		}
 
@@ -106,7 +107,8 @@ function got(url, opts, cb) {
 			proxy.write = function () {
 				throw new Error('got\'s stream is not writable when options.body is used');
 			};
-			req.end(body);
+
+			isReadableStream(body) ? body.pipe(req) : req.end(body);
 			return;
 		}
 

--- a/package.json
+++ b/package.json
@@ -32,11 +32,13 @@
   ],
   "dependencies": {
     "duplexify": "^3.2.0",
+    "isstream": "^0.1.1",
     "object-assign": "^2.0.0",
     "read-all-stream": "^0.1.0",
     "timed-out": "^2.0.0"
   },
   "devDependencies": {
+    "from2-array": "0.0.3",
     "tape": "^3.0.3",
     "taper": "^0.3.0"
   }

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ Encoding to be used on `setEncoding` of the response data. If null, the body is 
 
 ##### options.body
 
-Type: `string`, `Buffer`  
+Type: `string`, `Buffer`, `ReadableStream`  
 
 Body, that will be sent with `POST` request. If present in `options` and `options.method` is not set - `options.method` will be set to `POST`.
 

--- a/test/test-post.js
+++ b/test/test-post.js
@@ -3,6 +3,7 @@
 var tape = require('tape');
 var got = require('../');
 var server = require('./server.js');
+var from = require('from2-array');
 
 var s = server.createServer();
 
@@ -17,13 +18,17 @@ tape('setup', function (t) {
 });
 
 tape('send data from options with post request', function (t) {
-	t.plan(2);
+	t.plan(3);
 
 	got(s.url, {body: 'wow'}, function (err, data) {
 		t.equal(data, 'wow');
 	});
 
 	got(s.url, {body: new Buffer('wow')}, function (err, data) {
+		t.equal(data, 'wow');
+	});
+
+	got(s.url, {body: from(['wow'])}, function (err, data) {
 		t.equal(data, 'wow');
 	});
 });


### PR DESCRIPTION
This will allow to pass ReadableStream object in **options.body**. For example, if you already have stream of data, but want to use callback:

``` js
var stream = fs.createReadStream('index.html');
got.post('http://todomvc.com', {body: stream}, function (err, data) {
    // ...
});
```
