### PR TITLE
Discard response payload on redirect response

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,8 @@ function got(url, opts, cb) {
 					return;
 				}
 
+				res.resume(); // Discard response
+
 				get(urlLib.resolve(url, res.headers.location), opts, cb);
 				return;
 			}


### PR DESCRIPTION
We don't need body of response on redirect.

Ported from https://github.com/feross/simple-get/blob/master/index.js#L49
