### PR TITLE
Set maxSockets to Infinity by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - '0.10'
+  - '0.11'

--- a/index.js
+++ b/index.js
@@ -1,13 +1,15 @@
 'use strict';
+
+var assign = require('object-assign');
+var agent = require('infinity-agent');
+var duplexify = require('duplexify');
 var http = require('http');
 var https = require('https');
-var urlLib = require('url');
-var zlib = require('zlib');
-var duplexify = require('duplexify');
-var assign = require('object-assign');
+var isReadableStream = require('isstream').isReadable;
 var read = require('read-all-stream');
 var timeout = require('timed-out');
-var isReadableStream = require('isstream').isReadable;
+var urlLib = require('url');
+var zlib = require('zlib');
 
 function got(url, opts, cb) {
 	if (typeof opts === 'function') {
@@ -54,6 +56,11 @@ function got(url, opts, cb) {
 		var parsedUrl = urlLib.parse(url);
 		var fn = parsedUrl.protocol === 'https:' ? https : http;
 		var arg = assign({}, parsedUrl, opts);
+
+		// TODO: remove this when Node 0.10 will be deprecated
+		if (arg.agent === undefined) {
+			arg.agent = agent(arg);
+		}
 
 		var req = fn.request(arg, function (response) {
 			var statusCode = response.statusCode;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   ],
   "dependencies": {
     "duplexify": "^3.2.0",
+    "infinity-agent": "^0.1.0",
     "isstream": "^0.1.1",
     "object-assign": "^2.0.0",
     "read-all-stream": "^0.1.0",

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,16 @@ Type: `number`
 
 Milliseconds after which the request will be aborted and an error event with `ETIMEDOUT` code will be emitted.
 
+##### options.agent
+
+[http.Agent](http://nodejs.org/api/http.html#http_class_http_agent) instance.
+
+Node HTTP/HTTPS [Agent in 0.10.35](https://github.com/joyent/node/blob/v0.10.35-release/lib/http.js#L1261) by default limits number of open sockets to 5 — which is a little low. By default got will use `new Agent({maxSockets: Infinity})` like new [Agent in 0.11.14](https://github.com/joyent/node/blob/v0.11.14-release/lib/_http_agent.js#L110).
+
+You can read more about in [why pooling is evil](https://github.com/substack/hyperquest#pooling-is-evil).
+
+To use default [globalAgent](http://nodejs.org/api/http.html#http_http_globalagent) just pass `null` to this option.
+
 ##### callback(err, data, response)
 
 ###### err

--- a/test/test-https.js
+++ b/test/test-https.js
@@ -51,6 +51,16 @@ tape('setup', function (t) {
 });
 
 tape('make request to https server', function (t) {
+	got('https://google.com', {
+		strictSSL: true
+	}, function (err, data) {
+		t.error(err);
+		t.ok(data);
+		t.end();
+	});
+});
+
+tape('make request to https server with ca', function (t) {
 	got(s.url, {
 		strictSSL: true,
 		ca: caRootCert,


### PR DESCRIPTION
Setting agent for requests to new http(s).Agent({maxSockets: Infinity})

This will get same maxSockets value in 0.10 and upcoming 0.12 node as @julien-f suggested.

Closes #22 