### PR TITLE
Discard response before throw

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,12 +61,12 @@ function got(url, opts, cb) {
 
 			// redirect
 			if (statusCode >= 300 && statusCode < 400 && 'location' in res.headers) {
+				res.resume(); // Discard response
+
 				if (++redirectCount > 10) {
 					cb(new Error('Redirected 10 times. Aborting.'), undefined, res);
 					return;
 				}
-
-				res.resume(); // Discard response
 
 				get(urlLib.resolve(url, res.headers.location), opts, cb);
 				return;

--- a/test/test-redirects.js
+++ b/test/test-redirects.js
@@ -54,7 +54,7 @@ tape('follows relative redirect', function (t) {
 });
 
 tape('throws on endless redirect', function (t) {
-	got(s.url + '/endless', {agent: false}, function (err) {
+	got(s.url + '/endless', function (err) {
 		t.ok(err, 'should get error');
 		t.equal(err.message, 'Redirected 10 times. Aborting.');
 		t.end();


### PR DESCRIPTION
This will not leave hanging sockets for 2 minutes (if server does not provide `Connection: close` header).

Downside of it - you will not get content of 3xx response, but almost always it does not contain anything.