### PR TITLE
Up read-all-stream to 1.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,9 @@ function got(url, opts, cb) {
 				return;
 			}
 
-			read(res, encoding, cb, response);
+			read(res, encoding, function (err, data) {
+				 cb.call(null, err, data, response);
+			});
 		}).once('error', cb);
 
 		if (opts.timeout) {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "is-stream": "^1.0.0",
     "object-assign": "^2.0.0",
     "prepend-http": "^1.0.0",
-    "read-all-stream": "^0.1.0",
+    "read-all-stream": "^1.0.0",
     "timed-out": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Varargs was removed in `1.0.0` version, because of slow apply call.