### PR TITLE
Emit `response` event

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,10 @@ function got(url, opts, cb) {
 			var statusCode = response.statusCode;
 			var res = response;
 
+			if (proxy) {
+				proxy.emit('response', res);
+			}
+
 			// redirect
 			if (status.redirect[statusCode] && 'location' in res.headers) {
 				res.resume(); // Discard response

--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,14 @@ The data you requested.
 
 The [response object](http://nodejs.org/api/http.html#http_http_incomingmessage).
 
+##### .on('response', response)
+
+When in stream mode, you can listen for the `response` event to get the response object.
+
+###### response
+
+The [response object](http://nodejs.org/api/http.html#http_http_incomingmessage).
+
 #### got.get(url, [options], [callback])
 #### got.post(url, [options], [callback])
 #### got.put(url, [options], [callback])

--- a/test/test-http.js
+++ b/test/test-http.js
@@ -72,6 +72,15 @@ tape('stream mode', function (t) {
 		});
 });
 
+tape('emit response object to stream', function (t) {
+	got(s.url)
+		.on('response', function (res) {
+			t.ok(res);
+			t.ok(res.headers);
+			t.end();
+		});
+});
+
 tape('proxy errors to the stream', function (t) {
 	got(s.url + '/404')
 		.on('error', function (err) {


### PR DESCRIPTION
This is a little more intuitive than using `got._readable.req`.

```js
var got = require('got');
var stream = got('http://google.com');

stream.on('response', function (res) {
    console.log(res);
});
```