### PR TITLE
Improved errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "infinity-agent": "^1.0.0",
     "is-stream": "^1.0.0",
     "lowercase-keys": "^1.0.0",
+    "nested-error-stacks": "^1.0.0",
     "object-assign": "^2.0.0",
     "prepend-http": "^1.0.0",
     "read-all-stream": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lowercase-keys": "^1.0.0",
     "object-assign": "^2.0.0",
     "prepend-http": "^1.0.0",
-    "read-all-stream": "^1.0.0",
+    "read-all-stream": "^2.0.0",
     "statuses": "^1.2.1",
     "timed-out": "^2.0.0"
   },

--- a/test/test-error.js
+++ b/test/test-error.js
@@ -23,6 +23,14 @@ tape('error message', function (t) {
 	});
 });
 
+tape('dns error message', function (t) {
+	got('.com', function (err) {
+		t.ok(err);
+		t.equal(err.message, 'Request to .com failed');
+		t.end();
+	});
+});
+
 tape('cleanup', function (t) {
 	s.close();
 	t.end();


### PR DESCRIPTION
This will allow tracking errors with broken gzipped content from server, broken urls and etc.

Similar discussion here - https://github.com/sindresorhus/cp-file/pull/6

Article by Joyent: [Error Handling in Node.js](https://www.joyent.com/developers/node/design/errors).

---
```js
got('.com', function (err, data) {
    console.log(err.stack);
});
```

Before:

```
Error: getaddrinfo ENOTFOUND
    at errnoException (dns.js:37:11)
    at Object.onanswer [as oncomplete] (dns.js:124:16)
```

After:

```
GotError: Request to .com failed
    at ClientRequest.<anonymous> (/Users/floatdrop/got/index.js:123:7)
    at ClientRequest.g (events.js:180:16)
    at ClientRequest.emit (events.js:95:17)
    at Socket.socketErrorListener (http.js:1552:9)
    at Socket.emit (events.js:95:17)
    at net.js:834:16
    at process._tickCallback (node.js:442:13)
Caused By: Error: getaddrinfo ENOTFOUND
    at errnoException (dns.js:37:11)
    at Object.onanswer [as oncomplete] (dns.js:124:16)
```