### PR TITLE
Implement serializing Object in body to JSON

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,11 +63,13 @@ Encoding to be used on `setEncoding` of the response data. If null, the body is 
 
 ##### options.body
 
-Type: `string`, `Buffer`, `ReadableStream`  
+Type: `string`, `Buffer`, `ReadableStream`, `Object`
 
 _This option and stream mode are mutually exclusive._
 
 Body, that will be sent with `POST` request. If present in `options` and `options.method` is not set - `options.method` will be set to `POST`.
+
+If `body` is `Object`, then it will be serialized to JSON and `Content-Type` header will be set to `application/json` (if not set explicitly).
 
 ##### options.timeout
 

--- a/test/test-body.js
+++ b/test/test-body.js
@@ -1,0 +1,46 @@
+'use strict';
+var tape = require('tape');
+var got = require('../');
+var server = require('./server.js');
+var s = server.createServer();
+
+s.on('/echo', function (req, res) {
+	req.pipe(res);
+});
+
+s.on('/ct', function (req, res) {
+	res.end(req.headers['content-type']);
+});
+
+tape('setup', function (t) {
+	s.listen(s.port, function () {
+		t.end();
+	});
+});
+
+tape('Object in options.body goes through JSON.stringify', function (t) {
+	got(s.url + '/echo', {body: {data: 'wow'}}, function (err, data) {
+		t.error(err);
+		t.equal(data, '{"data":"wow"}');
+		t.end();
+	});
+});
+
+tape('Content-Type is defaulted to application/json', function (t) {
+	t.plan(4);
+
+	got(s.url + '/ct', {body: {data: 'wow'}}, function (err, data) {
+		t.error(err);
+		t.equal(data, 'application/json');
+	});
+
+	got(s.url + '/ct', {body: {data: 'wow'}, headers: {'content-type': 'text/json'}}, function (err, data) {
+		t.error(err);
+		t.equal(data, 'text/json');
+	});
+});
+
+tape('cleanup', function (t) {
+	s.close();
+	t.end();
+});


### PR DESCRIPTION
First part of #40 - serializing `body` to JSON.

Passing `Object` to `body` option gives `TypeError: first argument must be a string or Buffer`, when it could serialize `Object` to JSON and send it.

__Cons:__ user will now about bad `body` much later, but if user passing `Object` to body (and it is not `Buffer`/`String`/`Stream`) then in most cases it should be stringified to JSON.

__Pros:__ shorter code and more flexible `json` option.

```js
got('jsonendpoint.com', {
    body: JSON.stringify({ data: 'dog' }), 
    headers: { 'content-type': 'application/json' }, 
function () { });

// vs

got('jsonendpoint.com', { 
    body: { data: 'dog' } }, 
function () { });
```