### PR TITLE
Add json option

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,11 +40,13 @@ function got(url, opts, cb) {
 
 	var encoding = opts.encoding;
 	var body = opts.body;
+	var json = opts.json;
 	var proxy;
 	var redirectCount = 0;
 
 	delete opts.encoding;
 	delete opts.body;
+	delete opts.json;
 
 	if (body) {
 		opts.method = opts.method || 'POST';
@@ -59,6 +61,10 @@ function got(url, opts, cb) {
 		cb = function (err) {
 			proxy.emit('error', err);
 		};
+	}
+
+	if (proxy && json) {
+		throw new GotError('got can not be used as stream when options.json is used');
 	}
 
 	function get(url, opts, cb) {
@@ -116,6 +122,12 @@ function got(url, opts, cb) {
 			read(res, encoding, function (err, data) {
 				if (err) {
 					err = new GotError('Reading ' + url + ' response failed', err);
+				} else if (json) {
+					try {
+						data = JSON.parse(data);
+					} catch (e) {
+						err = new GotError('Parsing ' + url + ' response failed', err);
+					}
 				}
 
 				cb(err, data, response);

--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,15 @@ _This option and stream mode are mutually exclusive._
 
 Body, that will be sent with `POST` request. If present in `options` and `options.method` is not set - `options.method` will be set to `POST`.
 
+##### options.json
+
+Type: `Boolean`  
+Default: `false`
+
+_This option and stream mode are mutually exclusive._
+
+If enabled, response body will be parsed with `JSON.parse`.
+
 ##### options.timeout
 
 Type: `number`

--- a/test/test-json.js
+++ b/test/test-json.js
@@ -1,0 +1,48 @@
+'use strict';
+var tape = require('tape');
+var got = require('../');
+var server = require('./server.js');
+var s = server.createServer();
+
+s.on('/', function (req, res) {
+	res.end('{"data":"dog"}');
+});
+
+s.on('/invalid', function (req, res) {
+	res.end('/');
+});
+
+
+tape('setup', function (t) {
+	s.listen(s.port, function () {
+		t.end();
+	});
+});
+
+tape('json option can not be used in stream mode', function (t) {
+	t.throws(function () {
+		got(s.url, {json: true});
+	}, 'got can not be used as stream when options.json is used');
+	t.end();
+});
+
+tape('json option should parse response', function (t) {
+	got(s.url, {json: true}, function (err, json) {
+		t.error(err);
+		t.deepEqual(json, {data: 'dog'});
+		t.end();
+	});
+});
+
+tape('json option wrap parsing errors', function (t) {
+	got(s.url + '/invalid', {json: true}, function (err) {
+		t.ok(err);
+		t.equal(err.message, 'Parsing ' + s.url + '/invalid response failed');
+		t.end();
+	});
+});
+
+tape('cleanup', function (t) {
+	s.close();
+	t.end();
+});


### PR DESCRIPTION
Second part of #40

Parsing JSON in response.

Option ignores `Content-Type` header, because they are often not set by server. Errors from `JSON.parse` wrapped and pushed to callback with raw data.

Before:

```js
got('jsonendpoint.com', function (err, data) {
    if (err) { return cb(err); }

    var json;

    try {
        json = JSON.parse(data);
    } catch (e) {
        return cb(new Error('Reponse from jsonendpoint.com broken: ' + e.message));
    }
    
    // working with json
});
```

After:

```js
got('jsonendpoint.com', {json: true}, function (err, json) {
    if (err) { return cb(err); }

    // working with json
});
```