### PR TITLE
Use backported agents from Node core

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var urlLib = require('url');
 var util = require('util');
 var zlib = require('zlib');
 var objectAssign = require('object-assign');
-var agent = require('infinity-agent');
+var infinityAgent = require('infinity-agent');
 var duplexify = require('duplexify');
 var isStream = require('is-stream');
 var readAllStream = require('read-all-stream');
@@ -72,9 +72,20 @@ function got(url, opts, cb) {
 		var fn = parsedUrl.protocol === 'https:' ? https : http;
 		var arg = objectAssign({}, parsedUrl, opts);
 
-		// TODO: remove this when Node 0.10 will be deprecated
 		if (arg.agent === undefined) {
-			arg.agent = agent(arg);
+			arg.agent = infinityAgent[fn === https ? 'https' : 'http'].globalAgent;
+
+			// TODO: remove this when Node 0.10 will be deprecated
+			if (process.version.indexOf('v0.10') === 0 && fn === https && (
+				typeof opts.ca !== 'undefined' ||
+				typeof opts.cert !== 'undefined' ||
+				typeof opts.ciphers !== 'undefined' ||
+				typeof opts.key !== 'undefined' ||
+				typeof opts.passphrase !== 'undefined' ||
+				typeof opts.pfx !== 'undefined' ||
+				typeof opts.rejectUnauthorized !== 'undefined')) {
+				arg.agent = new (infinityAgent.https.Agent)(opts);
+			}
 		}
 
 		var req = fn.request(arg, function (response) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "duplexify": "^3.2.0",
-    "infinity-agent": "^1.0.0",
+    "infinity-agent": "^2.0.0",
     "is-stream": "^1.0.0",
     "lowercase-keys": "^1.0.0",
     "nested-error-stacks": "^1.0.0",

--- a/readme.md
+++ b/readme.md
@@ -88,9 +88,7 @@ Milliseconds after which the request will be aborted and an error event with `ET
 
 [http.Agent](http://nodejs.org/api/http.html#http_class_http_agent) instance.
 
-Node HTTP/HTTPS Agent in [0.10](https://github.com/joyent/node/blob/v0.10.35-release/lib/http.js#L1261) by default limits number of open sockets to 5 — which is too low. If `options.agent` is not defined `got` will use [infinity-agent](https://github.com/floatdrop/infinity-agent) to backport `defaultMaxSockets` from [0.12](https://github.com/joyent/node/blob/v0.12.2-release/lib/_http_agent.js#L110).
-
-[Why pooling is evil](https://github.com/substack/hyperquest#pooling-is-evil).
+If `undefined` - [`infinity-agent`](https://github.com/floatdrop/infinity-agent) will be used to backport Agent class from Node core.
 
 To use default [globalAgent](http://nodejs.org/api/http.html#http_http_globalagent) just pass `null` to this option.
 


### PR DESCRIPTION
So... Long story short: in Node 0.10 with `maxSockets` set to `Infinity` default Agent will have `shouldKeepAlive` flag set on - which is pretty bad (because sockets will be not reused), but remote system will think, that we will.

What have I done (!?):

 * [infinity-agent](https://github.com/floatdrop/infinity-agent) was bumped to `2.0.0` with backported Agent from Node core
 * Little [patch](https://github.com/floatdrop/infinity-agent/blob/master/http.js#L135-L140) was added to ported code, that disables `shouldKeepAlive` (same as [http module does](https://github.com/joyent/node/blob/master/lib/_http_client.js#L149-L152) in recent Node) in case of `maxSockets === Infinity`

Since `infinity-agent` now is just a backport of Node core Agent, [code under TODO](https://github.com/sindresorhus/got/compare/infinity-agent-2.0?expand=1#diff-168726dbe96b3ce427e7fedce31bb0bcR79) is now in module. It looks bad, but there is nothing, that we can do about it.

