### PR TITLE
Do not make lower case for header keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@ var isStream = require('is-stream');
 var readAllStream = require('read-all-stream');
 var timedOut = require('timed-out');
 var prependHttp = require('prepend-http');
-var lowercaseKeys = require('lowercase-keys');
 var statuses = require('statuses');
 var NestedErrorStacks = require('nested-error-stacks');
 
@@ -32,9 +31,9 @@ function got(url, opts, cb) {
 	opts = objectAssign({}, opts);
 
 	opts.headers = objectAssign({
-		'user-agent': 'https://github.com/sindresorhus/got',
-		'accept-encoding': 'gzip,deflate'
-	}, lowercaseKeys(opts.headers));
+		'User-Agent': 'https://github.com/sindresorhus/got',
+		'Accept-Encoding': 'gzip, deflate'
+	}, opts.headers);
 
 	var encoding = opts.encoding;
 	var body = opts.body;

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "duplexify": "^3.2.0",
     "infinity-agent": "^2.0.0",
     "is-stream": "^1.0.0",
-    "lowercase-keys": "^1.0.0",
     "nested-error-stacks": "^1.0.0",
     "object-assign": "^2.0.0",
     "prepend-http": "^1.0.0",


### PR DESCRIPTION
Sended headers no need to be lower cased. Node will not camel-cased them.

Example for 'writeHead':
https://nodejs.org/docs/latest/api/http.html#http_response_writehead_statuscode_statusmessage_headers