### PR TITLE
Support Object opts[,Function cb] signature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,11 +39,10 @@ fs.createReadStream('index.html').pipe(got.post('todomvc.com'));
 
 It's a `GET` request by default, but can be changed in `options`.
 
-#### got(url, [options], [callback])
+#### got([url][, options][, callback])
 
 ##### url
 
-*Required*  
 Type: `string`
 
 The URL to request.
@@ -114,12 +113,12 @@ When in stream mode, you can listen for the `response` event to get the response
 
 The [response object](http://nodejs.org/api/http.html#http_http_incomingmessage).
 
-#### got.get(url, [options], [callback])
-#### got.post(url, [options], [callback])
-#### got.put(url, [options], [callback])
-#### got.patch(url, [options], [callback])
-#### got.head(url, [options], [callback])
-#### got.delete(url, [options], [callback])
+#### got.get([url][, options][, callback])
+#### got.post([url][, options][, callback])
+#### got.put([url][, options][, callback])
+#### got.patch([url][, options][, callback])
+#### got.head([url][, options][, callback])
+#### got.delete([url][, options][, callback])
 
 Sets `options.method` to the method name and makes a request.
 

--- a/test/test-error.js
+++ b/test/test-error.js
@@ -18,7 +18,7 @@ tape('setup', function (t) {
 tape('error message', function (t) {
 	got(s.url, function (err) {
 		t.ok(err);
-		t.equal(err.message, 'http://localhost:6767 response code is 404 (Not Found)');
+		t.equal(err.message, 'http://localhost:6767/ response code is 404 (Not Found)');
 		t.end();
 	});
 });
@@ -26,7 +26,7 @@ tape('error message', function (t) {
 tape('dns error message', function (t) {
 	got('.com', function (err) {
 		t.ok(err);
-		t.equal(err.message, 'Request to .com failed');
+		t.equal(err.message, 'Request to http://.com/ failed');
 		t.ok(err.nested);
 		t.ok(/getaddrinfo ENOTFOUND/.test(err.nested.message));
 		t.end();

--- a/test/test-signature.js
+++ b/test/test-signature.js
@@ -1,0 +1,68 @@
+'use strict';
+var tape = require('tape');
+var got = require('../');
+var server = require('./server.js');
+var s = server.createServer();
+var urlLib = require('url');
+var infinityAgent = require('infinity-agent');
+
+s.on('/', function (req, res) {
+	res.end('ok');
+});
+
+s.on('/redirect', function (req, res) {
+	res.setHeader('Location', '/');
+	res.statusCode = 302;
+	res.end();
+});
+
+tape('setup', function (t) {
+	s.listen(s.port, function () {
+		t.end();
+	});
+});
+
+tape('String url, Object opts, Function, cb', function (t) {
+	var urlObj = urlLib.parse(s.url);
+	got(s.url + '/404', urlObj, function (err, data) {
+		t.equal(data, 'ok');
+		t.end();
+	});
+});
+
+tape('Object url, Function, cb', function (t) {
+	got(urlLib.parse(s.url), function (err, data) {
+		t.equal(data, 'ok');
+		t.end();
+	});
+});
+
+tape('Should not modify original options', function (t) {
+	var opts = urlLib.parse(s.url + '/redirect');
+	t.equal(opts.path, '/redirect');
+	got(opts, function (err, data) {
+		t.equal(data, 'ok');
+		t.equal(opts.path, '/redirect');
+		t.end();
+	});
+});
+
+tape('Should not rewrite passed agent on redirects', function (t) {
+	var agent = new infinityAgent.http.Agent();
+	var addRequest = agent.addRequest;
+	var spy = [];
+	agent.addRequest = function (req) {
+		spy.push(req.path);
+		return addRequest.apply(this, arguments);
+	};
+	got(s.url + '/redirect', {agent: agent}, function (err, data) {
+		t.equal(data, 'ok');
+		t.deepEqual(spy, ['/redirect', '/']);
+		t.end();
+	});
+});
+
+tape('cleanup', function (t) {
+	s.close();
+	t.end();
+});


### PR DESCRIPTION
Now, `got` supports also (opts[, cb]) signature. Url is not required.

Example:

```js
got({host: 'example.com', path: '/example'}, function (err, data, res) {
   // stuff
});
```

Convenient thing to keep (hostname, port, etc.) in project config separately, and no need to format `url`.