### PR TITLE
Accept http.request object as first argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,9 +70,11 @@ function got(url, opts, cb) {
 	}
 
 	function get(url, opts, cb) {
-		var parsedUrl = urlLib.parse(prependHttp(url));
+		var parsedUrl = typeof url === 'string' ? urlLib.parse(prependHttp(url)) : url;
 		var fn = parsedUrl.protocol === 'https:' ? https : http;
 		var arg = objectAssign({}, parsedUrl, opts);
+
+		url = typeof url === 'string' ? prependHttp(url) : urlLib.format(url);
 
 		if (arg.agent === undefined) {
 			arg.agent = infinityAgent[fn === https ? 'https' : 'http'].globalAgent;

--- a/readme.md
+++ b/readme.md
@@ -44,9 +44,9 @@ It's a `GET` request by default, but can be changed in `options`.
 ##### url
 
 *Required*  
-Type: `string`
+Type: `string`, `Object`
 
-The URL to request.
+The URL to request or bare [http.request options](https://nodejs.org/api/http.html#http_http_request_options_callback) object.
 
 ##### options
 

--- a/test/server.js
+++ b/test/server.js
@@ -2,32 +2,37 @@
 var http = require('http');
 var https = require('https');
 
+exports.host = 'localhost';
 exports.port = 6767;
 exports.portSSL = 16167;
 
 exports.createServer =  function (port) {
+	var host = exports.host;
 	port = port || exports.port;
 
 	var s = http.createServer(function (req, resp) {
 		s.emit(req.url, req, resp);
 	});
 
+	s.host = host;
 	s.port = port;
-	s.url = 'http://localhost:' + port;
+	s.url = 'http://' + host + ':' + port;
 	s.protocol = 'http';
 
 	return s;
 };
 
 exports.createSSLServer = function (port, opts) {
+	var host = exports.host;
 	port = port || exports.portSSL;
 
 	var s = https.createServer(opts, function (req, resp) {
 		s.emit(req.url, req, resp);
 	});
 
+	s.host = host;
 	s.port = port;
-	s.url = 'https://localhost:' + port;
+	s.url = 'https://' + host + ':' + port;
 	s.protocol = 'https';
 
 	return s;

--- a/test/test-arguments.js
+++ b/test/test-arguments.js
@@ -1,0 +1,40 @@
+'use strict';
+var tape = require('tape');
+var got = require('../');
+var server = require('./server.js');
+var s = server.createServer();
+
+s.on('/test', function (req, res) {
+	res.end(req.url);
+});
+
+s.on('/?test=wow', function (req, res) {
+	res.end(req.url);
+});
+
+tape('setup', function (t) {
+	s.listen(s.port, function () {
+		t.end();
+	});
+});
+
+tape('accepts url.parse object as first argument', function (t) {
+	got({host: s.host, port: s.port, path: '/test'}, function (err, data) {
+		t.error(err);
+		t.equal(data, '/test');
+		t.end();
+	});
+});
+
+tape('extends parsed string with opts', function (t) {
+	got(s.url, {path: '/test'}, function (err, data) {
+		t.error(err);
+		t.equal(data, '/test');
+		t.end();
+	});
+});
+
+tape('cleanup', function (t) {
+	s.close();
+	t.end();
+});

--- a/test/test-error.js
+++ b/test/test-error.js
@@ -26,7 +26,7 @@ tape('error message', function (t) {
 tape('dns error message', function (t) {
 	got('.com', function (err) {
 		t.ok(err);
-		t.equal(err.message, 'Request to .com failed');
+		t.equal(err.message, 'Request to http://.com failed');
 		t.ok(err.nested);
 		t.ok(/getaddrinfo ENOTFOUND/.test(err.nested.message));
 		t.end();


### PR DESCRIPTION
Cont. of https://github.com/sindresorhus/got/pull/51

If I want to pass `url.parse` result to `got` from my own parse logic - I need to do this hack:

```js
got('', { host: 'yada.com' }, function (err, data) {
    console.log(data);
});
```

Which is not nice and `got` will try to parse `''`.

This will make `got` compatible with `http.request` method:

```js
got({ host: 'yada.com' }, function (err, data) {
    console.log(data);
});
```