### PR TITLE
Add query option

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var https = require('https');
 var urlLib = require('url');
 var util = require('util');
 var zlib = require('zlib');
+var querystring = require('querystring');
 var objectAssign = require('object-assign');
 var infinityAgent = require('infinity-agent');
 var duplexify = require('duplexify');
@@ -88,6 +89,10 @@ function got(url, opts, cb) {
 				typeof opts.rejectUnauthorized !== 'undefined')) {
 				arg.agent = new (infinityAgent.https.Agent)(opts);
 			}
+		}
+
+		if (opts.query) {
+			arg.path = (arg.path ? arg.path.split('?')[0] : '') + '?' + (typeof opts.query === 'string' ? opts.query : querystring.stringify(opts.query));
 		}
 
 		var req = fn.request(arg, function (response) {

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,12 @@ _This option and stream mode are mutually exclusive._
 
 If enabled, response body will be parsed with `JSON.parse`.
 
+##### options.query
+
+Type: `string`, `Object`  
+
+Query string object, that will be added to request url. This will override query string in `url`.
+
 ##### options.timeout
 
 Type: `number`

--- a/test/test-http.js
+++ b/test/test-http.js
@@ -19,6 +19,10 @@ s.on('/404', function (req, res) {
 	}, 10);
 });
 
+s.on('/?recent=true', function (req, res) {
+	res.end('recent');
+});
+
 tape('setup', function (t) {
 	s.listen(s.port, function () {
 		t.end();
@@ -97,6 +101,18 @@ tape('timeout option', function (t) {
 			t.equal(err.code, 'ETIMEDOUT');
 			t.end();
 		});
+});
+
+tape('query option', function (t) {
+	t.plan(2);
+
+	got(s.url, {query: {recent: true}}, function (err, data) {
+		t.equal(data, 'recent');
+	});
+
+	got(s.url, {query: 'recent=true'}, function (err, data) {
+		t.equal(data, 'recent');
+	});
 });
 
 tape('cleanup', function (t) {


### PR DESCRIPTION
I have written a lot of such code lately:

```js
got(config.backend.host + '?' + qs.stringify(opts), function (err, data) { /* ... */ });
```

It would be nicer, if we have `query` option support:

```js
got(config.backend.host, {query: opts}, function (err, data) { /* ... */ });
```