### PR TITLE
Host or path in options breaks redirects

### DIFF
--- a/test/test-redirects.js
+++ b/test/test-redirects.js
@@ -59,6 +59,14 @@ tape('throws on endless redirect', function (t) {
 	});
 });
 
+tape('host+path in options are not breaking redirects', function (t) {
+	got(s.url + '/relative', {host: s.url, path: '/relative'}, function (err, data) {
+		t.error(err);
+		t.equal(data, 'reached');
+		t.end();
+	});
+});
+
 tape('cleanup', function (t) {
 	s.close();
 	t.end();


### PR DESCRIPTION
This is quite rare bug, but it takes place - if you add `host`, `port`, `path` or any option, that redefine `http.request` options from `url.parse` of redirect url - it will break everything.

Cause is [order of `assign` call](https://github.com/sindresorhus/got/blob/master/index.js#L80):

```js
var arg = objectAssign({}, parsedUrl, opts);
```

Possible fix is to swap `parsedUrl` and `opts`, but this will cause following code to be useless:

```js
got('server.com/?test=doge', {query: {test: 'wow'}}, function (err, data) {
    // query was ignored
});
```