### PR TITLE
auto-redirect only on GET and HEAD methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,8 @@ function got(url, opts, cb) {
 		opts.method = opts.method || 'POST';
 	}
 
+	opts.method = opts.method || 'GET';
+
 	// returns a proxy stream to the response
 	// if no callback has been provided
 	if (!cb) {
@@ -114,8 +116,8 @@ function got(url, opts, cb) {
 				proxy.emit('response', res);
 			}
 
-			// redirect
-			if (statuses.redirect[statusCode] && 'location' in res.headers) {
+			// auto-redirect only for GET and HEAD methods
+			if (statuses.redirect[statusCode] && 'location' in res.headers && (opts.method === 'GET' || opts.method === 'HEAD')) {
 				res.resume(); // Discard response
 
 				if (++redirectCount > 10) {
@@ -138,7 +140,7 @@ function got(url, opts, cb) {
 
 			if (statusCode < 200 || statusCode > 299) {
 				readAllStream(res, encoding, function (err, data) {
-					err = new GotError(url + ' response code is ' + statusCode + ' (' + statuses[statusCode] + ')', err);
+					err = new GotError(opts.method + ' ' + url + ' response code is ' + statusCode + ' (' + statuses[statusCode] + ')', err);
 					err.code = statusCode;
 
 					if (data && json) {

--- a/test/test-error.js
+++ b/test/test-error.js
@@ -18,7 +18,7 @@ tape('setup', function (t) {
 tape('error message', function (t) {
 	got(s.url, function (err) {
 		t.ok(err);
-		t.equal(err.message, 'http://localhost:6767 response code is 404 (Not Found)');
+		t.equal(err.message, 'GET http://localhost:6767 response code is 404 (Not Found)');
 		t.end();
 	});
 });

--- a/test/test-json.js
+++ b/test/test-json.js
@@ -69,7 +69,7 @@ tape('json option should catch errors on invalid non-200 responses', function (t
 		t.ok(err.nested);
 		t.equal(err.nested.message, 'Unexpected token I');
 		t.ok(err.nested.nested);
-		t.equal(err.nested.nested.message, 'http://localhost:6767/non200-invalid response code is 500 (Internal Server Error)');
+		t.equal(err.nested.nested.message, 'GET http://localhost:6767/non200-invalid response code is 500 (Internal Server Error)');
 		t.end();
 	});
 });

--- a/test/test-redirects.js
+++ b/test/test-redirects.js
@@ -82,6 +82,14 @@ tape('host+path in options are not breaking redirects', function (t) {
 	});
 });
 
+tape('redirect only GET and HEAD requests', function (t) {
+	got(s.url + '/relative', {body: 'wow'}, function (err, data) {
+		t.equal(err.message, 'POST http://localhost:6767/relative response code is 302 (Found)');
+		t.equal(err.code, 302);
+		t.end();
+	});
+});
+
 tape('cleanup', function (t) {
 	s.close();
 	t.end();


### PR DESCRIPTION
As [rfc2616 HTTP 1.1](http://tools.ietf.org/html/rfc2616#section-10.3.3) says:

```
If the 302 status code is received in response to a request other
than GET or HEAD, the user agent MUST NOT automatically redirect the
request unless it can be confirmed by the user, since this might
change the conditions under which the request was issued.
```

I think we should return error on POST redirect, because (in case of body as a Stream) we can not POST again same content and buffering it is not an option.

There are `302` and `303` codes, that require user approval - in case of HTTP client it should be an error I guess.

-

Interesting discussion about this in https://github.com/request/request/issues/29