### PR TITLE
Code cleanup and pathname issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,10 @@ function got(url, opts, cb) {
 		'accept-encoding': 'gzip,deflate'
 	}, lowercaseKeys(opts.headers));
 
+	if (opts.pathname) {
+		opts.path = opts.pathname;
+	}
+
 	if (opts.query) {
 		if (typeof opts.query !== 'string') {
 			opts.query = querystring.stringify(opts.query);

--- a/index.js
+++ b/index.js
@@ -35,18 +35,32 @@ function got(url, opts, cb) {
 		opts = {};
 	}
 
-	opts = objectAssign({}, opts);
+	opts = objectAssign(
+		{
+			protocol: 'http:'
+		},
+		typeof url === 'string' ? urlLib.parse(prependHttp(url)) : url,
+		opts
+	);
 
 	opts.headers = objectAssign({
 		'user-agent': 'https://github.com/sindresorhus/got',
 		'accept-encoding': 'gzip,deflate'
 	}, lowercaseKeys(opts.headers));
 
+	if (opts.query) {
+		if (typeof opts.query !== 'string') {
+			opts.query = querystring.stringify(opts.query);
+		}
+
+		opts.path = opts.pathname + '?' + opts.query;
+		delete opts.query;
+	}
+
 	var encoding = opts.encoding;
 	var body = opts.body;
 	var json = opts.json;
 	var timeout = opts.timeout;
-	var query = opts.query;
 	var proxy;
 	var redirectCount = 0;
 
@@ -54,7 +68,6 @@ function got(url, opts, cb) {
 	delete opts.body;
 	delete opts.json;
 	delete opts.timeout;
-	delete opts.query;
 
 	if (json) {
 		opts.headers.accept = opts.headers.accept || 'application/json';
@@ -90,15 +103,12 @@ function got(url, opts, cb) {
 		throw new GotError('got can not be used as stream when options.json is used');
 	}
 
-	function get(url, opts, cb) {
-		var parsedUrl = typeof url === 'string' ? urlLib.parse(prependHttp(url)) : url;
-		var fn = parsedUrl.protocol === 'https:' ? https : http;
-		var arg = objectAssign({}, parsedUrl, opts);
+	function get(opts, cb) {
+		var fn = opts.protocol === 'https:' ? https : http;
+		var url = urlLib.format(opts);
 
-		url = typeof url === 'string' ? prependHttp(url) : urlLib.format(url);
-
-		if (arg.agent === undefined) {
-			arg.agent = infinityAgent[fn === https ? 'https' : 'http'].globalAgent;
+		if (opts.agent === undefined) {
+			opts.agent = infinityAgent[fn === https ? 'https' : 'http'].globalAgent;
 
 			if (process.version.indexOf('v0.10') === 0 && fn === https && (
 				typeof opts.ca !== 'undefined' ||
@@ -108,16 +118,19 @@ function got(url, opts, cb) {
 				typeof opts.passphrase !== 'undefined' ||
 				typeof opts.pfx !== 'undefined' ||
 				typeof opts.rejectUnauthorized !== 'undefined')) {
-				arg.agent = new infinityAgent.https.Agent(opts);
+				opts.agent = new infinityAgent.https.Agent({
+					ca: opts.ca,
+					cert: opts.cert,
+					ciphers: opts.ciphers,
+					key: opts.key,
+					passphrase: opts.passphrase,
+					pfx: opts.pfx,
+					rejectUnauthorized: opts.rejectUnauthorized
+				});
 			}
 		}
 
-		if (query) {
-			arg.path = (arg.path ? arg.path.split('?')[0] : '') + '?' + (typeof query === 'string' ? query : querystring.stringify(query));
-			query = undefined;
-		}
-
-		var req = fn.request(arg, function (response) {
+		var req = fn.request(opts, function (response) {
 			var statusCode = response.statusCode;
 			var res = response;
 
@@ -135,16 +148,14 @@ function got(url, opts, cb) {
 					return;
 				}
 
-				delete opts.host;
-				delete opts.hostname;
-				delete opts.port;
-				delete opts.path;
+				var redirectUrl = urlLib.resolve(url, res.headers.location);
+				var redirectOpts = objectAssign(opts, urlLib.parse(redirectUrl));
 
 				if (proxy) {
-					proxy.emit('redirect', res, opts);
+					proxy.emit('redirect', res, redirectOpts);
 				}
 
-				get(urlLib.resolve(url, res.headers.location), opts, cb);
+				get(redirectOpts, cb);
 				return;
 			}
 
@@ -230,7 +241,7 @@ function got(url, opts, cb) {
 		req.end();
 	}
 
-	get(url, opts, cb);
+	get(opts, cb);
 
 	return proxy;
 }

--- a/test/test-arguments.js
+++ b/test/test-arguments.js
@@ -4,6 +4,11 @@ var got = require('../');
 var server = require('./server.js');
 var s = server.createServer();
 
+s.on('/', function (req, res) {
+	res.statusCode = 404;
+	res.end();
+});
+
 s.on('/test', function (req, res) {
 	res.end(req.url);
 });
@@ -26,7 +31,7 @@ test('url argument is required', function (t) {
 });
 
 test('accepts url.parse object as first argument', function (t) {
-	got({host: s.host, port: s.port, path: '/test'}, function (err, data) {
+	got({hostname: s.host, port: s.port, path: '/test'}, function (err, data) {
 		t.error(err);
 		t.equal(data, '/test');
 		t.end();
@@ -37,6 +42,14 @@ test('overrides querystring from opts', function (t) {
 	got(s.url + '/?test=doge', {query: {test: 'wow'}}, function (err, data) {
 		t.error(err);
 		t.equal(data, '/?test=wow');
+		t.end();
+	});
+});
+
+// Error says http://localhost:6767/test, but request was to http://localhost:6767/
+test('pathname confusion', function (t) {
+	got({protocol: 'http:', hostname: s.host, port: s.port, pathname: '/test'}, function (err) {
+		t.ok(/http:\/\/localhost:6767\/ response code/.test(err));
 		t.end();
 	});
 });

--- a/test/test-arguments.js
+++ b/test/test-arguments.js
@@ -48,7 +48,7 @@ test('overrides querystring from opts', function (t) {
 
 test('pathname confusion', function (t) {
 	got({protocol: 'http:', hostname: s.host, port: s.port, pathname: '/test'}, function (err) {
-		t.ok(/http:\/\/localhost:6767\/test response code/.test(err));
+		t.error(err);
 		t.end();
 	});
 });

--- a/test/test-arguments.js
+++ b/test/test-arguments.js
@@ -46,10 +46,9 @@ test('overrides querystring from opts', function (t) {
 	});
 });
 
-// Error says http://localhost:6767/test, but request was to http://localhost:6767/
 test('pathname confusion', function (t) {
 	got({protocol: 'http:', hostname: s.host, port: s.port, pathname: '/test'}, function (err) {
-		t.ok(/http:\/\/localhost:6767\/ response code/.test(err));
+		t.ok(/http:\/\/localhost:6767\/test response code/.test(err));
 		t.end();
 	});
 });

--- a/test/test-error.js
+++ b/test/test-error.js
@@ -18,7 +18,7 @@ test('setup', function (t) {
 test('error message', function (t) {
 	got(s.url, function (err) {
 		t.ok(err);
-		t.equal(err.message, 'GET http://localhost:6767 response code is 404 (Not Found)');
+		t.equal(err.message, 'GET http://localhost:6767/ response code is 404 (Not Found)');
 		t.end();
 	});
 });
@@ -26,7 +26,7 @@ test('error message', function (t) {
 test('dns error message', function (t) {
 	got('.com', function (err) {
 		t.ok(err);
-		t.equal(err.message, 'Request to http://.com failed');
+		t.equal(err.message, 'Request to http://.com/ failed');
 		t.ok(err.nested);
 		t.ok(/getaddrinfo ENOTFOUND/.test(err.nested.message));
 		t.end();

--- a/test/test-redirects.js
+++ b/test/test-redirects.js
@@ -74,8 +74,8 @@ test('query in options are not breaking redirects', function (t) {
 	});
 });
 
-test('host+path in options are not breaking redirects', function (t) {
-	got(s.url + '/relative', {host: s.url, path: '/relative'}, function (err, data) {
+test('hostname+path in options are not breaking redirects', function (t) {
+	got(s.url + '/relative', {hostname: s.host, path: '/relative'}, function (err, data) {
 		t.error(err);
 		t.equal(data, 'reached');
 		t.end();


### PR DESCRIPTION
There were some :hankey: code (by me) like this:

```js
arg.path = (arg.path ? arg.path.split('?')[0] : '') + '?' + (typeof query === 'string' ? query : querystring.stringify(query));
```

Or this:

```js
var parsedUrl = typeof url === 'string' ? urlLib.parse(prependHttp(url)) : url;
// ...
url = typeof url === 'string' ? prependHttp(url) : urlLib.format(url);
```

Which was hard to maintain and read. 

Main reason for this code - there was two different arguments for `get` function - first contains request options (as object __or__ as string) and other gets got options.

This logic was replaced by merging `url` and `opts` arguments in `got` function into one. Because (on redirect) we can reassign parsed request options.

In the process `redirect` event was fixed - it was emitting old `opts` that was not from redirect itself.

-

#72 was fixed by reassing  `path` to `pathname` (if `pathname` is present). I don't know, if this is right thing to do, but because of difference in `http.request` and `url.format` +  `url.parse` we have to normalise options or use another `url.format` implementation.

//cc @sindresorhus @sindresorhus @kevva