### PR TITLE
Explicit Error classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,11 +41,11 @@
     "fetch"
   ],
   "dependencies": {
+    "create-error-class": "^2.0.0",
     "duplexify": "^3.2.0",
     "is-redirect": "^1.0.0",
     "is-stream": "^1.0.0",
     "lowercase-keys": "^1.0.0",
-    "nested-error-stacks": "^1.0.0",
     "object-assign": "^3.0.0",
     "pinkie-promise": "^1.0.0",
     "prepend-http": "^1.0.0",

--- a/readme.md
+++ b/readme.md
@@ -152,6 +152,29 @@ When in stream mode, you can listen for events:
 
 Sets `options.method` to the method name and makes a request.
 
+## Errors
+
+Each Error contains (if available) `host`, `hostname`, `method` and `path` properties to make debug easier.
+
+#### got.RequestError
+
+Happens, when making request failed. Should contain `code` property with error class code (like `ECONNREFUSED`).
+
+#### got.ReadError
+
+Happens, when reading from response stream failed.
+
+#### got.ParseError
+
+Happens, when `json` option is enabled and `JSON.parse` failed.
+
+#### got.HTTPError
+
+Happens, when server response code is not 2xx. Contains `statusCode` and `statusMessage`.
+
+#### got.MaxRedirectsError
+
+Happens, when server redirects you more than 10 times.
 
 ## Proxy
 
@@ -201,8 +224,6 @@ This should only ever be done if you have Node version 0.10.x and at the top-lev
 ## Related
 
 - [gh-got](https://github.com/sindresorhus/gh-got) - Convenience wrapper for interacting with the GitHub API
-- [got-promise](https://github.com/floatdrop/got-promise) - Promise wrapper
-
 
 ## Created by
 

--- a/test/test-arguments.js
+++ b/test/test-arguments.js
@@ -46,13 +46,6 @@ test('overrides querystring from opts', function (t) {
 	});
 });
 
-test('pathname confusion', function (t) {
-	got({protocol: 'http:', hostname: s.host, port: s.port, pathname: '/test'}, function (err) {
-		t.error(err);
-		t.end();
-	});
-});
-
 test('cleanup', function (t) {
 	s.close();
 	t.end();

--- a/test/test-error.js
+++ b/test/test-error.js
@@ -18,7 +18,9 @@ test('setup', function (t) {
 test('error message', function (t) {
 	got(s.url, function (err) {
 		t.ok(err);
-		t.equal(err.message, 'GET http://localhost:6767/ response code is 404 (Not Found)');
+		t.equal(err.message, 'Response code 404 (Not Found)');
+		t.equal(err.host, 'localhost:6767');
+		t.equal(err.method, 'GET');
 		t.end();
 	});
 });
@@ -26,9 +28,9 @@ test('error message', function (t) {
 test('dns error message', function (t) {
 	got('.com', function (err) {
 		t.ok(err);
-		t.equal(err.message, 'Request to http://.com/ failed');
-		t.ok(err.nested);
-		t.ok(/getaddrinfo ENOTFOUND/.test(err.nested.message));
+		t.ok(/getaddrinfo ENOTFOUND/.test(err.message));
+		t.equal(err.host, '.com');
+		t.equal(err.method, 'GET');
 		t.end();
 	});
 });

--- a/test/test-gzip.js
+++ b/test/test-gzip.js
@@ -39,7 +39,9 @@ test('ungzip content', function (t) {
 test('ungzip error', function (t) {
 	got(s.url + '/corrupted', function (err) {
 		t.ok(err);
-		t.equal(err.message, 'Reading ' + s.url + '/corrupted response failed');
+		t.equal(err.message, 'incorrect header check');
+		t.equal(err.path, '/corrupted');
+		t.equal(err.name, 'ReadError');
 		t.end();
 	});
 });

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -37,7 +37,6 @@ test('promise mode', function (t) {
 
 	got.get(s.url + '/404')
 		.catch(function (err) {
-			t.equal(err.message, 'GET http://localhost:6767/404 response code is 404 (Not Found)');
 			t.equal(err.response.body, 'not found');
 		});
 });

--- a/test/test-http.js
+++ b/test/test-http.js
@@ -56,7 +56,7 @@ test('empty response', function (t) {
 test('error with code', function (t) {
 	got(s.url + '/404', function (err, data) {
 		t.ok(err);
-		t.equal(err.code, 404);
+		t.equal(err.statusCode, 404);
 		t.equal(data, 'not');
 		t.end();
 	});

--- a/test/test-json.js
+++ b/test/test-json.js
@@ -51,9 +51,8 @@ test('json option should not parse responses without a body', function (t) {
 test('json option wrap parsing errors', function (t) {
 	got(s.url + '/invalid', {json: true}, function (err) {
 		t.ok(err);
-		t.equal(err.message, 'Parsing ' + s.url + '/invalid response failed');
-		t.ok(err.nested);
-		t.equal(err.nested.message, 'Unexpected token /');
+		t.equal(err.message, 'Unexpected token /');
+		t.equal(err.path, '/invalid');
 		t.end();
 	});
 });
@@ -70,11 +69,8 @@ test('json option should catch errors on invalid non-200 responses', function (t
 	got(s.url + '/non200-invalid', {json: true}, function (err, json) {
 		t.ok(err);
 		t.deepEqual(json, 'Internal error');
-		t.equal(err.message, 'Parsing http://localhost:6767/non200-invalid response failed');
-		t.ok(err.nested);
-		t.equal(err.nested.message, 'Unexpected token I');
-		t.ok(err.nested.nested);
-		t.equal(err.nested.nested.message, 'GET http://localhost:6767/non200-invalid response code is 500 (Internal Server Error)');
+		t.equal(err.message, 'Unexpected token I');
+		t.equal(err.path, '/non200-invalid');
 		t.end();
 	});
 });

--- a/test/test-redirects.js
+++ b/test/test-redirects.js
@@ -84,8 +84,9 @@ test('hostname+path in options are not breaking redirects', function (t) {
 
 test('redirect only GET and HEAD requests', function (t) {
 	got(s.url + '/relative', {body: 'wow'}, function (err) {
-		t.equal(err.message, 'POST http://localhost:6767/relative response code is 302 (Moved Temporarily)');
-		t.equal(err.code, 302);
+		t.equal(err.message, 'Response code 302 (Moved Temporarily)');
+		t.equal(err.path, '/relative');
+		t.equal(err.statusCode, 302);
 		t.end();
 	});
 });

--- a/test/test-stream.js
+++ b/test/test-stream.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var test = require('tap').test;
-var from2Array = require('from2-array');
 var got = require('../');
 var server = require('./server.js');
 var s = server.createServer();


### PR DESCRIPTION
Replacement for `nested-error-stacks`.

* All error messages now retained and additional properties added (like `host` and `method`).
* `code` property now comes from internal errors of Node (with `ECONNREFUSED` and so on values) and HTTP status code stored in `statusCode` property.
* `pathname` support dropped (since there is no such option in `http.request`).
* `statusMessage` added.