### PR TITLE
Return HTTPError if response body failed to parse as JSON

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ function asCallback(opts, cb) {
 				try {
 					data = JSON.parse(data);
 				} catch (e) {
-					err = new got.ParseError(e, opts);
+					err = err || new got.ParseError(e, opts);
 				}
 			}
 

--- a/test/test-json.js
+++ b/test/test-json.js
@@ -69,7 +69,8 @@ test('json option should catch errors on invalid non-200 responses', function (t
 	got(s.url + '/non200-invalid', {json: true}, function (err, json) {
 		t.ok(err);
 		t.deepEqual(json, 'Internal error');
-		t.equal(err.message, 'Unexpected token I');
+		t.equal(err.statusCode, 500);
+		t.equal(err.message, 'Response code 500 (Internal Server Error)');
 		t.equal(err.path, '/non200-invalid');
 		t.end();
 	});


### PR DESCRIPTION
Currently

```js
got('http://registry.npmjs.com/nonexistent', { json: true }, function (err) {
  console.error(err);
})
```

results in this rather cryptic error message:

```
{ [ParseError: Unexpected end of input]
  message: 'Unexpected end of input',
  code: undefined,
  host: 'registry.npmjs.org',
  hostname: 'registry.npmjs.org',
  method: 'GET',
  path: '/nonexistent' }
```

With this patch, `HTTPError` is returned instead if response is not a valid JSON.

```js
{ [HTTPError: Response code 404 (Not Found)]
  message: 'Response code 404 (Not Found)',
  code: undefined,
  host: 'registry.npmjs.com',
  hostname: 'registry.npmjs.com',
  method: 'GET',
  path: '/nonexistent',
  statusCode: 404,
  statusMessage: 'Not Found' }
```