### PR TITLE
Throw when callback is passed to stream mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -288,7 +288,11 @@ helpers.forEach(function (el) {
 	};
 });
 
-got.stream = function (url, opts) {
+got.stream = function (url, opts, cb) {
+	if (cb || typeof opts === 'function') {
+		throw new Error('callback can not be used with stream mode');
+	}
+
 	return asStream(normalizeArguments(url, opts));
 };
 

--- a/test/test-stream.js
+++ b/test/test-stream.js
@@ -37,6 +37,18 @@ test('json option can not be used in stream mode', function (t) {
 	t.end();
 });
 
+test('callback can not be used in stream mode', function (t) {
+	t.throws(function () {
+		got.stream(s.url, {json: true}, function () {});
+	}, 'callback can not be used in stream mode');
+
+	t.throws(function () {
+		got.stream(s.url, function () {});
+	}, 'callback can not be used in stream mode');
+
+	t.end();
+});
+
 test('return readable stream', function (t) {
 	got.stream(s.url)
 		.on('data', function (data) {


### PR DESCRIPTION
Follow up for https://github.com/sindresorhus/got/issues/102 - stream mode can not be used with callback. Added guard for this situation:

```js
got.stream.put(url, options, function() {}); // Should throw
```