### PR TITLE
Deferred response event

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,9 @@ function requestAsEventEmitter(opts) {
 				return;
 			}
 
-			ee.emit('response', typeof unzipResponse === 'function' ? unzipResponse(res) : res);
+			setImmediate(function () {
+				ee.emit('response', typeof unzipResponse === 'function' ? unzipResponse(res) : res);
+			});
 		}).once('error', function (err) {
 			if (retryCount < opts.retries) {
 				setTimeout(get, backoff(retryCount++), opts);

--- a/test/redirects.js
+++ b/test/redirects.js
@@ -92,7 +92,7 @@ test('redirects - redirect only GET and HEAD requests', t => {
 	});
 });
 
-test.after('redirect - cleanup', t => {
+test.after('redirects - cleanup', t => {
 	s.close();
 	t.end();
 });


### PR DESCRIPTION
On request-heavy applications (with short `timeout` option) lots of requests will be rejected, because of `response` handlers.

For example, if `timeout` is `50ms` and `response` from `http` module was on `48ms` - chances are, that user will get `ETIMEDOUT` error.