### PR TITLE
Check for pipe method only

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ function asCallback(opts, cb) {
 	var ee = requestAsEventEmitter(opts);
 
 	ee.on('request', function (req) {
-		if (isStream.readable(opts.body)) {
+		if (isStream(opts.body)) {
 			opts.body.pipe(req);
 			opts.body = undefined;
 			return;


### PR DESCRIPTION
`form-data` is not working with `body` option - because `isStream.readable` is checking for internal `_read` method, which is not implemented by `form-data`.

See discussion here - https://github.com/form-data/form-data/pull/150#issuecomment-151884281