### PR TITLE
Add the ability to explicitly omit certain headers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,14 +60,6 @@ function requestAsEventEmitter(opts) {
 			});
 		});
 
-		// this method is not documented, prints a warning if used while
-		// not available
-		if (!req.removeHeader) {
-			req.removeHeader = function (headerName) {
-				console.error('could not remove', headerName, 'header');
-			};
-		}
-
 		// provide the ability to explicitly not send a header by setting
 		// it to `null`
 		var headerName;

--- a/index.js
+++ b/index.js
@@ -60,6 +60,23 @@ function requestAsEventEmitter(opts) {
 			});
 		});
 
+		// this method is not documented, prints a warning if used while
+		// not available
+		if (!req.removeHeader) {
+			req.removeHeader = function (headerName) {
+				console.error('could not remove', headerName, 'header');
+			};
+		}
+
+		// provide the ability to explicitly not send a header by setting
+		// it to `null`
+		var headerName;
+		for (headerName in opts.headers) {
+			if (opts.headers[headerName] === null) {
+				req.removeHeader(headerName);
+			}
+		}
+
 		req.once('error', function (err) {
 			if (retryCount < opts.retries) {
 				setTimeout(get, backoff(retryCount++), opts);
@@ -231,8 +248,8 @@ function normalizeArguments(url, opts) {
 		delete opts.query;
 	}
 
-	if (opts.json) {
-		opts.headers.accept = opts.headers.accept || 'application/json';
+	if (opts.json && opts.headers.accept === undefined) {
+		opts.headers.accept = 'application/json';
 	}
 
 	var body = opts.body;
@@ -245,11 +262,13 @@ function normalizeArguments(url, opts) {
 		opts.method = opts.method || 'POST';
 
 		if (isPlainObj(body)) {
-			opts.headers['content-type'] = opts.headers['content-type'] || 'application/x-www-form-urlencoded';
+			if (opts.headers['content-type'] === undefined) {
+				opts.headers['content-type'] = 'application/x-www-form-urlencoded';
+			}
 			body = opts.body = querystring.stringify(body);
 		}
 
-		if (!opts.headers['content-length'] && !opts.headers['transfer-encoding'] && !isStream.readable(body)) {
+		if (opts.headers['content-length'] === undefined && !opts.headers['transfer-encoding'] && !isStream.readable(body)) {
 			var length = typeof body === 'string' ? Buffer.byteLength(body) : body.length;
 			opts.headers['content-length'] = length;
 		}

--- a/readme.md
+++ b/readme.md
@@ -78,9 +78,9 @@ Any of the [`http.request`](http://nodejs.org/api/http.html#http_http_request_op
 
 Type: `object`
 
-Headers that will be sent wit a request.
+Headers that will be sent with a request.
 
-Any header can be set to `null` to explicitly omit them, even if they are implicit headers that would be added by Node (i.e. `tranfer-encoding` if `content-length` is not present).
+Any header can be set to `null` to explicitly omit them, even if they are implicit headers that would be added by Node.js (i.e. `tranfer-encoding` if `content-length` is not present).
 
 ###### body
 

--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,14 @@ Type: `object`
 
 Any of the [`http.request`](http://nodejs.org/api/http.html#http_http_request_options_callback) options.
 
+###### headers
+
+Type: `object`
+
+Headers that will be sent wit a request.
+
+Any header can be set to `null` to explicitly omit them, even if they are implicit headers that would be added by Node (i.e. `tranfer-encoding` if `content-length` is not present).
+
 ###### body
 
 Type: `string`, `Buffer`, `ReadableStream`, `Object`  

--- a/test/headers.js
+++ b/test/headers.js
@@ -39,6 +39,18 @@ test('transform names to lowercase', async t => {
 	t.is(headers['user-agent'], 'test');
 });
 
+test('explicitly remove headers', async t => {
+	const headers = await got.put(s.url, {
+		body: '',
+		headers: {
+			'content-length': null,
+			'transfer-encoding': null
+		}
+	});
+
+	t.is(headers['content-length'], undefined);
+});
+
 test.after('cleanup', async t => {
 	await s.close();
 });


### PR DESCRIPTION
For instance, `transfer-encoding` is automatically set by Node if `content-length` is not present.