### PR TITLE
Make response property non enumerable on error

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,10 @@ function asPromise(opts) {
 			}
 
 			if (err) {
-				err.response = response;
+				Object.defineProperty(err, 'response', {
+					value: response,
+					enumerable: false
+				});
 				reject(err);
 				return;
 			}

--- a/test/error.js
+++ b/test/error.js
@@ -15,12 +15,14 @@ test.before('setup', async t => {
 	await s.listen(s.port);
 });
 
-test('message', async t => {
+test('properties', async t => {
 	try {
 		await got(s.url);
 		t.fail('Exception was not thrown');
 	} catch (err) {
 		t.ok(err);
+		t.ok(err.response);
+		t.ok(!err.propertyIsEnumerable('response'));
 		t.is(err.message, 'Response code 404 (Not Found)');
 		t.is(err.host, `${s.host}:${s.port}`);
 		t.is(err.method, 'GET');


### PR DESCRIPTION
Often in debugging I find rather difficult to read this output:

```js
got('google.com/wat').catch(err => console.log(err));

/*
{ [HTTPError: Response code 404 (Not Found)]
  message: 'Response code 404 (Not Found)',
  code: undefined,
  host: 'google.com',
  hostname: 'google.com',
  method: 'GET',
  path: '/wat',
  statusCode: 404,
  statusMessage: 'Not Found',
  response:
   IncomingMessage {
      <here goes huge amount of properties, like couple of screens>
   } }
*/
```