### PR TITLE
Accept backoff function in retry option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -118,11 +118,12 @@ Milliseconds after which the request will be aborted and an error event with `ET
 
 ###### retries
 
-Type: `number`  
+Type: `number`, `function`  
 Default: `5`
 
-Number of request retries when network errors happens.
+Number of request retries when network errors happens. Delays between retries counts with function `Math.pow(2, retry) + Math.random() * 100`, where `retry` is attempt number (starts from 0).
 
+Option accepts `function` with `retry` argument that must return delay in milliseconds (`0` return value cancels retry).
 
 ##### callback(error, data, response)
 

--- a/test/retry.js
+++ b/test/retry.js
@@ -5,6 +5,7 @@ import {createServer} from './_server';
 let s;
 let trys = 0;
 let knocks = 0;
+let fifth = 0;
 
 test.before('setup', async t => {
 	s = await createServer();
@@ -19,6 +20,12 @@ test.before('setup', async t => {
 
 	s.on('/try-me', () => {
 		trys++;
+	});
+
+	s.on('/fifth', (req, res) => {
+		if (fifth++ === 5) {
+			res.end('who`s there?');
+		}
 	});
 
 	await s.listen(s.port);
@@ -36,6 +43,19 @@ test('can be disabled with option', async t => {
 	}
 
 	t.is(trys, 1);
+});
+
+test('funcion gets iter count', async t => {
+	await got(`${s.url}/fifth`, {timeout: 100, retries: iter => iter < 10});
+	t.is(fifth, 6);
+});
+
+test('falsy value prevent retries', async t => {
+	try {
+		await got(`${s.url}/long`, {timeout: 1000, retries: () => 0});
+	} catch (err) {
+		t.ok(err);
+	}
 });
 
 test.after('cleanup', async t => {


### PR DESCRIPTION
Now `retries` accepts custom backoff funtion, which allows next usecases:

```js
// Constant delay of 10ms for 5 iterations
got('google.com', {
    retries: iter => iter < 5 && 10
});

// Infinity retries with constant delay - this is not possible now, 
// because delay will increase up to the MaxInt :(
got('google.com', {
    retries: () => 10
});
```

Closes #138 