### PR TITLE
Filter not-retryable Errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const unzipResponse = require('unzip-response');
 const createErrorClass = require('create-error-class');
 const nodeStatusCodes = require('node-status-codes');
 const isPlainObj = require('is-plain-obj');
+const isRetryAllowed = require('is-retry-allowed');
 
 function requestAsEventEmitter(opts) {
 	opts = opts || {};
@@ -254,8 +255,8 @@ function normalizeArguments(url, opts) {
 
 	if (typeof opts.retries !== 'function') {
 		const retries = opts.retries;
-		opts.retries = function backoff(iter) {
-			if (iter > retries) {
+		opts.retries = function backoff(iter, err) {
+			if (iter > retries || !isRetryAllowed(err)) {
 				return 0;
 			}
 

--- a/package.json
+++ b/package.json
@@ -45,11 +45,12 @@
     "fetch"
   ],
   "dependencies": {
-    "duplexer3": "^0.1.4",
     "create-error-class": "^3.0.0",
+    "duplexer3": "^0.1.4",
     "get-stream": "^1.1.0",
     "is-plain-obj": "^1.0.0",
     "is-redirect": "^1.0.0",
+    "is-retry-allowed": "^1.0.0",
     "is-stream": "^1.0.0",
     "lowercase-keys": "^1.0.0",
     "node-status-codes": "^2.0.0",


### PR DESCRIPTION
`ENOTFOUND` and `ENETUNREACH` are most common errors, that we get when we have typos in configs or having IPv4 to IPv6 routing problems. I think these errors (or maybe some more) should fail fast without retries.

---

Related to #119 and #156