### PR TITLE
Clarify readme section about retries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -120,9 +120,9 @@ Default: `5`
 
 Number of request retries when network errors happens. Delays between retries counts with function `1000 * Math.pow(2, retry) + Math.random() * 100`, where `retry` is attempt number (starts from 0).
 
-**Note:** `ENOTFOUND` and `ENETUNREACH` error will not be retried (see full list in [`is-retry-allowed`](https://github.com/floatdrop/is-retry-allowed/blob/master/index.js#L12) module).
-
 Option accepts `function` with `retry` and `error` arguments. Function must return delay in milliseconds (`0` return value cancels retry).
+
+**Note:** if `retries` is `number`, `ENOTFOUND` and `ENETUNREACH` error will not be retried (see full list in [`is-retry-allowed`](https://github.com/floatdrop/is-retry-allowed/blob/master/index.js#L12) module).
 
 
 #### Streams


### PR DESCRIPTION
In current readme version it is not obvious that requests failed with "blacklisted" errors are not retried only if value of `retries` option is number, not function. 