### PR TITLE
Add options to response

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,6 +100,7 @@ function asPromise(opts) {
 					const statusCode = res.statusCode;
 
 					res.body = data;
+					res.request = opts;
 
 					if (opts.json && res.body) {
 						try {


### PR DESCRIPTION
Hi. I'm not sure if im doing it the correct way or if you want this in the repo, but this is the solution i found to he following problem:

I have a promise code like this:
```js
requestsPromise = [];
PackofURL.forEach((thisUrl) => {
	var thisRequest = got(thisUrl.url);
	requestsPromise.push(thisRequest);
});

return Promise.all(requestsPromise)
	.then((allRequests) => {
		allRequests.forEach((thisRequest, index) => {
			if(CheckURLForSomething(thisRequest)) {
				Requester.doSomething(thisRequest);
			}
		});
	});
```
If the request returns `200` i pass it into `CheckURLForSomething` and it will hash the url to store as a key of another part of the code.
The problem is that i could not build the full URL (protocol + host + path + query) with the response.

I could do something like this:
```js
PackofURL.forEach((thisUrl) => {
	var thisRequest = got(thisUrl.url)
		.then((response) => { return Promise.resolve({ fullUrl: thisUrl.url, response: response }); });

	requestsPromise.push(thisRequest);
});

return Promise.all(requestsPromise)
	.then((allRequests) => {
		allRequests.forEach((thisRequest, index) => {
			if(CheckURLForSomething(thisRequest.fullUrl)) {
				Requester.doSomething(thisRequest.response);
			}
		});
	});
```

But maybe more people have the same problem and with this change i can get just `thisRequest.request.href`.
If you want this in the code, let me know if i should change anything.