### PR TITLE
Update create-error-class dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "fetch"
   ],
   "dependencies": {
-    "create-error-class": "^2.0.0",
+    "create-error-class": "^3.0.1",
     "duplexer2": "^0.1.4",
     "is-plain-obj": "^1.0.0",
     "is-redirect": "^1.0.0",


### PR DESCRIPTION
I was running in to an issue with running got in the browser because create-error-class version 2.0.0 uses eval and I was trying to set a strict Content Security Policy - so updating the dependency.