### PR TITLE
Do not set default value for opts.retiries if timeout is present.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,8 @@ const isPlainObj = require('is-plain-obj');
 const isRetryAllowed = require('is-retry-allowed');
 const pkg = require('./package.json');
 
+const DEFAULT_RETRIES = 5;
+
 function requestAsEventEmitter(opts) {
 	opts = opts || {};
 
@@ -197,8 +199,13 @@ function normalizeArguments(url, opts) {
 		}
 	}
 
+	let retries = DEFAULT_RETRIES;
+	if (typeof opts !== 'undefined') {
+		retries = opts.timeout ? (opts.retries || 0) : retries;
+	}
+
 	opts = Object.assign(
-		{protocol: 'http:', path: '', retries: 5},
+		{protocol: 'http:', path: '', retries},
 		url,
 		opts
 	);

--- a/test/retry.js
+++ b/test/retry.js
@@ -32,7 +32,7 @@ test.before('setup', async () => {
 });
 
 test('works on timeout error', async t => {
-	t.is((await got(`${s.url}/knock-twice`, {timeout: 100})).body, 'who`s there?');
+	t.is((await got(`${s.url}/knock-twice`, {timeout: 100, retries: 2})).body, 'who`s there?');
 });
 
 test('can be disabled with option', async t => {


### PR DESCRIPTION
It quite isn't right to retry request 5 times when timeout is present in options.