### PR TITLE
Add a `requestUrl` property to the response object

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,6 +106,7 @@ function asPromise(opts) {
 					const limitStatusCode = opts.followRedirect ? 299 : 399;
 
 					res.body = data;
+					res.requestUrl = opts.href;
 
 					if (opts.json && res.body) {
 						try {

--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ function asPromise(opts) {
 					const limitStatusCode = opts.followRedirect ? 299 : 399;
 
 					res.body = data;
-					res.requestUrl = opts.href;
+					res.requestUrl = opts.href || urlLib.resolve(urlLib.format(opts), opts.path);
 
 					if (opts.json && res.body) {
 						try {

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ It's a `GET` request by default, but can be changed in `options`.
 
 #### got(url, [options])
 
-Returns a Promise, that resolves to `response` object with `body` property and a `url` property (which contains the final URL after redirects).
+Returns a Promise, that resolves to `response` object with `body` property, a `url` property that contains the final URL after redirects and a `requestUrl` that contains the URL requested originally
 
 ##### url
 
@@ -127,7 +127,7 @@ Option accepts `function` with `retry` and `error` arguments. Function must retu
 
 ###### followRedirect
 
-Type: `boolean`  
+Type: `boolean`
 Default: `true`
 
 Defines if redirect responses should be followed automatically.

--- a/readme.md
+++ b/readme.md
@@ -127,7 +127,7 @@ Option accepts `function` with `retry` and `error` arguments. Function must retu
 
 ###### followRedirect
 
-Type: `boolean`
+Type: `boolean`<br>
 Default: `true`
 
 Defines if redirect responses should be followed automatically.

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ It's a `GET` request by default, but can be changed in `options`.
 
 #### got(url, [options])
 
-Returns a Promise, that resolves to `response` object with `body` property, a `url` property that contains the final URL after redirects and a `requestUrl` that contains the URL requested originally
+Returns a Promise for a `response` object with a `body` property, a `url` property with the final URL after redirects, and a `requestUrl` property with the original request URL.
 
 ##### url
 

--- a/test/arguments.js
+++ b/test/arguments.js
@@ -44,6 +44,14 @@ test('accepts url.parse object as first argument', async t => {
 	})).body, '/test');
 });
 
+test('requestUrl with url.parse object as first argument', async t => {
+	t.is((await got({
+		hostname: s.host,
+		port: s.port,
+		path: '/test'
+	})).requestUrl, `${s.url}/test`);
+});
+
 test('overrides querystring from opts', async t => {
 	t.is((await got(`${s.url}/?test=doge`, {query: {test: 'wow'}})).body, '/?test=wow');
 });

--- a/test/http.js
+++ b/test/http.js
@@ -43,6 +43,7 @@ test('empty response', async t => {
 
 test('requestUrl response', async t => {
 	t.is((await got(s.url)).requestUrl, `${s.url}/`);
+	t.is((await got(`${s.url}/empty`)).requestUrl, `${s.url}/empty`);
 });
 
 test('error with code', async t => {
@@ -75,6 +76,11 @@ test('timeout option', async t => {
 test('query option', async t => {
 	t.is((await got(s.url, {query: {recent: true}})).body, 'recent');
 	t.is((await got(s.url, {query: 'recent=true'})).body, 'recent');
+});
+
+test('requestUrl response when sending url as param', async t => {
+	t.is((await got(s.url, {hostname: s.host, port: s.port})).requestUrl, `${s.url}/`);
+	t.is((await got({hostname: s.host, port: s.port})).requestUrl, `${s.url}/`);
 });
 
 test.after('cleanup', async () => {

--- a/test/http.js
+++ b/test/http.js
@@ -41,6 +41,10 @@ test('empty response', async t => {
 	t.is((await got(`${s.url}/empty`)).body, '');
 });
 
+test('requestUrl response', async t => {
+	t.is((await got(s.url)).requestUrl, `${s.url}/`);
+});
+
 test('error with code', async t => {
 	try {
 		await got(`${s.url}/404`);

--- a/test/redirects.js
+++ b/test/redirects.js
@@ -142,6 +142,11 @@ test('redirect response contains new url', async t => {
 	t.is(url, `${http.url}/`);
 });
 
+test('redirect response contains old url', async t => {
+	const requestUrl = (await got(`${http.url}/finite`)).requestUrl;
+	t.is(requestUrl, `${http.url}/finite`);
+});
+
 test.after('cleanup', async () => {
 	await http.close();
 	await https.close();


### PR DESCRIPTION
Update from #188 

Needed a new PR because the previous repository doesn't exist anymore and because of this is impossible to update that one. (Sorry about that)

@sindresorhus Is this what you meant in #188?
By the way: My writing in english os not very good so please take a look if it doesn't have any gramatical mistakes

cc @floatdrop 