### PR TITLE
Handle errors thrown synchronously by http.request().

### DIFF
--- a/test/error.js
+++ b/test/error.js
@@ -51,6 +51,15 @@ test('options.body error message', async t => {
 	}
 });
 
+test('invalid url', async t => {
+	try {
+		await got('htttp://google.com');
+		t.fail('Exception was not thrown');
+	} catch (err) {
+		t.regex(err.message, /Protocol .+ not supported/);
+	}
+});
+
 test.after('cleanup', async () => {
 	await s.close();
 });


### PR DESCRIPTION
```js
const got = require('got');

got('htttp://google.com')
.then((res) => console.log('res', res), (err) => console.log('error', err));
```

The code above fails globally because `htttp` is not a valid protocol. This PR fixes it.