### PR TITLE
Detect formdata body and set content-type header.

### DIFF
--- a/index.js
+++ b/index.js
@@ -242,7 +242,10 @@ function normalizeArguments(url, opts) {
 
 		opts.method = opts.method || 'POST';
 
-		if (isPlainObj(body)) {
+		if (isStream(body) && typeof body.getBoundary === 'function') {
+			// Special case for https://github.com/form-data/form-data
+			opts.headers['content-type'] = opts.headers['content-type'] || 'multipart/form-data; boundary=' + body.getBoundary();
+		} else if (isPlainObj(body)) {
 			opts.headers['content-type'] = opts.headers['content-type'] || 'application/x-www-form-urlencoded';
 			body = opts.body = querystring.stringify(body);
 		}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "ava": "^0.16.0",
     "coveralls": "^2.11.4",
+    "form-data": "^1.0.1",
     "get-port": "^2.0.0",
     "get-stream": "^2.3.0",
     "into-stream": "^2.0.0",

--- a/readme.md
+++ b/readme.md
@@ -244,7 +244,6 @@ const form = new FormData();
 form.append('my_file', fs.createReadStream('/foo/bar.jpg'));
 
 got.post('google.com', {
-	headers: form.getHeaders(),
 	body: form
 });
 ```

--- a/test/headers.js
+++ b/test/headers.js
@@ -1,4 +1,5 @@
 import test from 'ava';
+import FormData from 'form-data';
 import got from '../';
 import pkg from '../package.json';
 import {createServer} from './helpers/server';
@@ -63,6 +64,29 @@ test('zero content-length', async t => {
 		json: true
 	})).body;
 	t.is(headers['content-length'], '0');
+});
+
+test('form-data manual content-type', async t => {
+	const form = new FormData();
+	form.append('a', 'b');
+	const headers = (await got(s.url, {
+		headers: {
+			'content-type': 'custom'
+		},
+		body: form,
+		json: true
+	})).body;
+	t.is(headers['content-type'], 'custom');
+});
+
+test('form-data automatic content-type', async t => {
+	const form = new FormData();
+	form.append('a', 'b');
+	const headers = (await got(s.url, {
+		body: form,
+		json: true
+	})).body;
+	t.is(headers['content-type'], `multipart/form-data; boundary=${form.getBoundary()}`);
 });
 
 test.after('cleanup', async () => {


### PR DESCRIPTION
This PR adds a check for [Form-Data](https://github.com/form-data/form-data) which makes it easier for users to submit form data bodies (no longer have to manually get headers from form-data).

This is similar to https://github.com/bitinn/node-fetch/pull/31, the idea is just to make it easier on end users since [Form-Data](https://github.com/form-data/form-data) is commonly used throughout the community. It will also make isomorphic code easier in the future with [isomorphic-form-data](https://github.com/form-data/isomorphic-form-data).

I realize this is missing a new test, I wasn't sure what the best way to go about it was.
If I got some direction I could go ahead with tests or someone else could take over from here.