### PR TITLE
add api of `got.stream()` to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -135,6 +135,8 @@ Defines if redirect responses should be followed automatically.
 
 #### Streams
 
+#### got.stream(url, [options])
+
 `stream` method will return Duplex stream with additional events:
 
 ##### .on('request', request)


### PR DESCRIPTION
I look at the source just to check almost every time I pick up `got` after leaving it for a few months. Figured if I do it, others might too.