### PR TITLE
use `safe-buffer`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ node_js:
   - '6'
   - '5'
   - '4'
+  - '4.4.4'
 after_success: npm run coveralls

--- a/index.js
+++ b/index.js
@@ -15,13 +15,8 @@ const isRedirect = require('is-redirect');
 const unzipResponse = require('unzip-response');
 const createErrorClass = require('create-error-class');
 const isRetryAllowed = require('is-retry-allowed');
+const Buffer = require('safe-buffer').Buffer;
 const pkg = require('./package');
-
-const isModernBuffer = (
-	typeof Buffer.alloc === 'function' &&
-	typeof Buffer.allocUnsafe === 'function' &&
-	typeof Buffer.from === 'function'
-);
 
 function requestAsEventEmitter(opts) {
 	opts = opts || {};
@@ -46,9 +41,7 @@ function requestAsEventEmitter(opts) {
 					return;
 				}
 
-				const bufferString = isModernBuffer ?
-					Buffer.from(res.headers.location, 'binary').toString() :
-					new Buffer(res.headers.location, 'binary').toString();
+				const bufferString = Buffer.from(res.headers.location, 'binary').toString();
 
 				redirectUrl = urlLib.resolve(urlLib.format(opts), bufferString);
 				const redirectOpts = Object.assign({}, opts, urlLib.parse(redirectUrl));

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "is-retry-allowed": "^1.0.0",
     "is-stream": "^1.0.0",
     "lowercase-keys": "^1.0.0",
+    "safe-buffer": "^5.0.1",
     "timed-out": "^3.0.0",
     "unzip-response": "^2.0.1",
     "url-parse-lax": "^1.0.0"


### PR DESCRIPTION
[`safe-buffer`](https://www.npmjs.com/package/safe-buffer) implements `Buffer.from` (` Buffer.alloc`, ... ) where they are missing.