### PR TITLE
Strengthen expect undefined tests

### DIFF
--- a/test/post.js
+++ b/test/post.js
@@ -88,6 +88,9 @@ test('content-length header with Stream body', async t => {
 		body: intoStream(['wow']),
 		json: true
 	});
+	// since we're checking for undefined, let's make sure the rest of the
+	// reponse is there by checking another prop we expect to be there
+	t.is(body['transfer-encoding'], 'chunked', 'likely failed to get headers');
 	t.is(body['content-length'], undefined);
 });
 
@@ -110,6 +113,9 @@ test('content-length header disabled for chunked transfer-encoding', async t => 
 			'transfer-encoding': 'chunked'
 		}
 	});
+	// since we're checking for undefined, let's make sure the rest of the
+	// reponse is there by checking another prop we expect to be there
+	t.is(body['transfer-encoding'], 'chunked', 'likely failed to get headers');
 	t.is(body['content-length'], undefined);
 });
 

--- a/test/post.js
+++ b/test/post.js
@@ -88,9 +88,7 @@ test('content-length header with Stream body', async t => {
 		body: intoStream(['wow']),
 		json: true
 	});
-	// since we're checking for undefined, let's make sure the rest of the
-	// reponse is there by checking another prop we expect to be there
-	t.is(body['transfer-encoding'], 'chunked', 'likely failed to get headers');
+	t.is(body['transfer-encoding'], 'chunked', 'likely failed to get headers at all');
 	t.is(body['content-length'], undefined);
 });
 
@@ -113,9 +111,7 @@ test('content-length header disabled for chunked transfer-encoding', async t => 
 			'transfer-encoding': 'chunked'
 		}
 	});
-	// since we're checking for undefined, let's make sure the rest of the
-	// reponse is there by checking another prop we expect to be there
-	t.is(body['transfer-encoding'], 'chunked', 'likely failed to get headers');
+	t.is(body['transfer-encoding'], 'chunked', 'likely failed to get headers at all');
 	t.is(body['content-length'], undefined);
 });
 


### PR DESCRIPTION
Since we're checking for an undefined property, it becomes relevant to
check the rest of the object does look the way we expect. If the returned body object breaks, through parsing problems or otherwise, this test could break but pass.

I ran into this working on a larger PR coming up :3.

* I don't care for the comment I added. If you feel the reason is clear, I could remove it.
* If you feel there's a way to address this issue in a cleaner way, I'd happily implement it.
* If you feel breaking something like parsing but this test still passing is not something these specific tests should care about because of the assumption another test somewhere _should_ break too. I can get behind that, and you can close the PR. I like the idea of fixing tests you'd expect to break but don't, and making them break. On the other hand, you shouldn't test _all_ of the dependencies every test relies on. Your call!