### PR TITLE
Make (more) sure the error we get is the one we expect

### DIFF
--- a/test/json.js
+++ b/test/json.js
@@ -74,13 +74,8 @@ test('catches errors on invalid non-200 responses', async t => {
 });
 
 test('should have statusCode in err', async t => {
-	try {
-		await got(`${s.url}/non200-invalid`, {json: true});
-		t.fail('Exception was not thrown');
-	} catch (err) {
-		t.true(err instanceof got.ParseError);
-		t.is(err.statusCode, 500);
-	}
+	const err = await t.throws(got(`${s.url}/non200-invalid`, {json: true}), got.ParseError);
+	t.is(err.statusCode, 500);
 });
 
 test.after('cleanup', async () => {

--- a/test/json.js
+++ b/test/json.js
@@ -78,6 +78,7 @@ test('should have statusCode in err', async t => {
 		await got(`${s.url}/non200-invalid`, {json: true});
 		t.fail('Exception was not thrown');
 	} catch (err) {
+		t.true(err instanceof got.ParseError);
 		t.is(err.statusCode, 500);
 	}
 });


### PR DESCRIPTION
Since we set the statusCode to 500 in the changed test, our code triggers a HTTPError. Regardless of the parsing conditional's outcome that may or may not throw. Because of this, the test would pass even if the code does not throw a ParseError. This change makes sure the error is the got.ParseError we expect. By no means perfect but good enough to save me and hopefully others from confusion.

It is a minor change. Hopefully, you too feel this would improve, not complicate the code 😄 .