### PR TITLE
Was not working in Firefox under FF 52+

### DIFF
--- a/index.js
+++ b/index.js
@@ -320,7 +320,7 @@ helpers.forEach(el => {
 
 got.stream = (url, opts) => asStream(normalizeArguments(url, opts));
 
-for (const el of helpers) {
+for (let el of helpers) {
 	got.stream[el] = (url, opts) => got.stream(url, Object.assign({}, opts, {method: el}));
 }
 


### PR DESCRIPTION
Was not working in Firefox under FF 52+. Firefox did not support "for (const ...".
More info: https://bugzilla.mozilla.org/show_bug.cgi?id=1101653