### PR TITLE
Add json extension to require package. Fixes webpack v2 beeing unable…

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const unzipResponse = require('unzip-response');
 const createErrorClass = require('create-error-class');
 const isRetryAllowed = require('is-retry-allowed');
 const Buffer = require('safe-buffer').Buffer;
-const pkg = require('./package');
+const pkg = require('./package.json');
 
 function requestAsEventEmitter(opts) {
 	opts = opts || {};


### PR DESCRIPTION
Webpack v2 doesn't allow empty extensions anymore: https://github.com/webpack/webpack/issues/3043

Running webpack v2 on a project with `got` will result in the following error:
```
ERROR in ./~/got/index.js
Module not found: Error: Can't resolve './package' in '...'
 @ ./~/got/index.js 19:12-32
 @ ./~/is-reachable/index.js
...
```

Adding the `.json` extension to `require('./package')` => `require('./package.json')` fixes the problem.