### PR TITLE
Add protocol to stdError

### DIFF
--- a/index.js
+++ b/index.js
@@ -334,7 +334,8 @@ function stdError(error, opts) {
 		host: opts.host,
 		hostname: opts.hostname,
 		method: opts.method,
-		path: opts.path
+		path: opts.path,
+		protocol: opts.protocol
 	});
 }
 

--- a/test/error.js
+++ b/test/error.js
@@ -27,6 +27,7 @@ test('properties', async t => {
 		t.is(err.message, 'Response code 404 (Not Found)');
 		t.is(err.host, `${s.host}:${s.port}`);
 		t.is(err.method, 'GET');
+		t.is(err.protocol, 'http:');
 	}
 });
 


### PR DESCRIPTION
Adds the protocol to the stdError object got uses for all its errors.
Closes #249.

(These are _so_ much fun to do. If only my lunch break was longer.)