### PR TITLE
Add url to errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -336,7 +336,8 @@ function stdError(error, opts) {
 		hostname: opts.hostname,
 		method: opts.method,
 		path: opts.path,
-		protocol: opts.protocol
+		protocol: opts.protocol,
+		url: opts.href
 	});
 }
 

--- a/readme.md
+++ b/readme.md
@@ -176,7 +176,7 @@ Sets `options.method` to the method name and makes a request.
 
 ## Errors
 
-Each error contains (if available) `statusCode`, `statusMessage`, `host`, `hostname`, `method` and `path` properties to make debugging easier.
+Each error contains (if available) `statusCode`, `statusMessage`, `host`, `hostname`, `method`, `path`, `protocol` and `url` properties to make debugging easier.
 
 In Promise mode, the `response` is attached to the error.
 

--- a/test/error.js
+++ b/test/error.js
@@ -28,6 +28,7 @@ test('properties', async t => {
 		t.is(err.host, `${s.host}:${s.port}`);
 		t.is(err.method, 'GET');
 		t.is(err.protocol, 'http:');
+		t.is(err.url, err.response.requestUrl);
 	}
 });
 


### PR DESCRIPTION
Currently, the property is called `url`.  Another sensible choice could be `href`.

---

Fixes #282 