### PR TITLE
Add ability to cancel in-progress requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const createErrorClass = require('create-error-class');
 const isRetryAllowed = require('is-retry-allowed');
 const Buffer = require('safe-buffer').Buffer;
 const isPlainObj = require('is-plain-obj');
+const PCancelable = require('p-cancelable');
 const pkg = require('./package');
 
 function requestAsEventEmitter(opts) {
@@ -93,10 +94,23 @@ function requestAsEventEmitter(opts) {
 }
 
 function asPromise(opts) {
-	return new Promise((resolve, reject) => {
+	return new PCancelable((onCancel, resolve, reject) => {
 		const ee = requestAsEventEmitter(opts);
+		let cancelOnRequest = false;
+
+		onCancel(() => {
+			cancelOnRequest = true;
+		});
 
 		ee.on('request', req => {
+			if (cancelOnRequest) {
+				req.abort();
+			}
+
+			onCancel(() => {
+				req.abort();
+			});
+
 			if (isStream(opts.body)) {
 				opts.body.pipe(req);
 				opts.body = undefined;
@@ -357,6 +371,7 @@ function stdError(error, opts) {
 
 got.RequestError = createErrorClass('RequestError', stdError);
 got.ReadError = createErrorClass('ReadError', stdError);
+got.InvalidCancelError = createErrorClass('InvalidCancelError', stdError);
 got.ParseError = createErrorClass('ParseError', function (e, statusCode, opts, data) {
 	stdError.call(this, e, opts);
 	this.statusCode = statusCode;

--- a/index.js
+++ b/index.js
@@ -371,7 +371,6 @@ function stdError(error, opts) {
 
 got.RequestError = createErrorClass('RequestError', stdError);
 got.ReadError = createErrorClass('ReadError', stdError);
-got.InvalidCancelError = createErrorClass('InvalidCancelError', stdError);
 got.ParseError = createErrorClass('ParseError', function (e, statusCode, opts, data) {
 	stdError.call(this, e, opts);
 	this.statusCode = statusCode;

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "devDependencies": {
     "ava": "^0.18.0",
     "coveralls": "^2.11.4",
+    "delay": "^2.0.0",
     "form-data": "^2.1.1",
     "get-port": "^3.0.0",
     "into-stream": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
   "devDependencies": {
     "ava": "^0.18.0",
     "coveralls": "^2.11.4",
-    "delay": "^2.0.0",
     "form-data": "^2.1.1",
     "get-port": "^3.0.0",
     "into-stream": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "is-retry-allowed": "^1.0.0",
     "is-stream": "^1.0.0",
     "lowercase-keys": "^1.0.0",
+    "p-cancelable": "^0.2.0",
     "safe-buffer": "^5.0.1",
     "timed-out": "^4.0.0",
     "unzip-response": "^2.0.1",

--- a/readme.md
+++ b/readme.md
@@ -359,6 +359,7 @@ request(`https://${config.host}/production/`, {
 });
 ```
 
+
 ## Tips
 
 ### User Agent

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@
 
 A nicer interface to the built-in [`http`](http://nodejs.org/api/http.html) module.
 
-It supports following redirects, promises, streams, retries, automagically handling gzip/deflate and some convenience options.
+It supports following redirects, promises, streams, retries, automagically handling gzip/deflate, canceling of requests, and some convenience options.
 
 Created because [`request`](https://github.com/request/request) is bloated *(several megabytes!)*.
 
@@ -217,6 +217,9 @@ When server redirects you more than 10 times.
 
 When given an unsupported protocol.
 
+## Aborting the request
+
+The promise returned by Got has a `.cancel()` function which, when called, aborts the request.
 
 ## Proxies
 
@@ -355,7 +358,6 @@ request(`https://${config.host}/production/`, {
 	// All usual `got` options
 });
 ```
-
 
 ## Tips
 

--- a/readme.md
+++ b/readme.md
@@ -217,9 +217,11 @@ When server redirects you more than 10 times.
 
 When given an unsupported protocol.
 
+
 ## Aborting the request
 
 The promise returned by Got has a `.cancel()` function which, when called, aborts the request.
+
 
 ## Proxies
 

--- a/test/cancel.js
+++ b/test/cancel.js
@@ -52,11 +52,11 @@ test('cancel immediately', async t => {
 	const aborted = new Promise((resolve, reject) => {
     // We won't get an abort or even a connection
     // We assume no request within 1000ms equals a (client side) aborted request
-		setTimeout(resolve, 1000);
 		s.on('/abort', (req, res) => {
 			res.on('finish', reject.bind(this, new Error('Request finished instead of aborting.')));
 			res.end();
 		});
+		setTimeout(resolve, 1000);
 	});
 
 	await s.listen(s.port);

--- a/test/cancel.js
+++ b/test/cancel.js
@@ -1,0 +1,53 @@
+import test from 'ava';
+import getPort from 'get-port';
+import getStream from 'get-stream';
+import PCancelable from 'p-cancelable';
+import stream from 'stream';
+import got from '../';
+import {createServer} from './helpers/server';
+
+const Readable = stream.Readable;
+
+async function createAbortServer() {
+  const t = await createServer();
+  const aborted = new Promise((resolve, reject) => {
+    t.on('/abort', (req, res) => {
+      req.on('aborted', () => {
+        resolve();
+      });
+      res.on('finish', reject.bind(this, new Error('Request finished instead of aborting')));
+
+      getStream(req).then(() => {
+        res.end();
+      });
+    });
+  });
+
+  await t.listen(t.port);
+
+  return {
+    aborted,
+    url: `${t.url}/abort`
+  };
+}
+
+test('cancel in-progress request', async t => {
+	const helper = await createAbortServer();
+	const body = new Readable({
+		read() {}
+	});
+	body.push('1');
+
+	const p = got(helper.url, {body});
+
+	// Wait for the stream to be established before canceling
+	setTimeout(() => {
+		p.cancel();
+		body.push(null);
+	}, 100);
+
+	await t.throws(p, PCancelable.CancelError);
+	await t.notThrows(helper.aborted, 'Request finished instead of aborting.');
+});
+
+test.todo('cancel immediately');

--- a/test/http.js
+++ b/test/http.js
@@ -147,7 +147,7 @@ test.serial('cancel in-progress request', async t => {
 	});
 
 	await t.throws(p, PCancelable.CancelError);
-	await t.notThrows(cancelPromise);
+	await t.notThrows(() => cancelPromise);
 });
 
 test.serial('cancel immediately', async t => {
@@ -155,7 +155,7 @@ test.serial('cancel immediately', async t => {
 	p.cancel();
 
 	await t.throws(p, PCancelable.CancelError);
-	await t.notThrows(cancelPromise);
+	await t.notThrows(() => cancelPromise);
 });
 
 test.after('cleanup', async () => {

--- a/test/http.js
+++ b/test/http.js
@@ -1,8 +1,13 @@
+import stream from 'stream';
 import test from 'ava';
+import getStream from 'get-stream';
+import PCancelable from 'p-cancelable';
 import got from '../';
 import {createServer} from './helpers/server';
 
+const Readable = stream.Readable;
 let s;
+let cancelPromise = null;
 
 test.before('setup', async () => {
 	s = await createServer();
@@ -27,6 +32,19 @@ test.before('setup', async () => {
 
 	s.on('/?recent=true', (req, res) => {
 		res.end('recent');
+	});
+
+	s.on('/no-res-store-id', (req, res) => {
+		cancelPromise = new Promise((resolve, reject) => {
+			req.on('aborted', resolve);
+			res.on('finish', () => {
+				reject(new Error('Request finished instead of aborting'));
+			});
+		});
+
+		getStream(req).then(() => {
+			res.end();
+		});
 	});
 
 	await s.listen(s.port);
@@ -113,6 +131,31 @@ test('requestUrl response when sending url as param', async t => {
 
 test('response contains url', async t => {
 	t.is((await got(s.url)).url, `${s.url}/`);
+});
+
+test.serial('cancel in-progress request', async t => {
+	const body = new Readable({
+		read() {}
+	});
+	body.push('1');
+
+	const p = got(`${s.url}/no-res-store-id`, {body});
+
+	setImmediate(() => {
+		p.cancel();
+		body.push(null); // Complete the request that should now be canceled
+	});
+
+	await t.throws(p, PCancelable.CancelError);
+	await t.notThrows(cancelPromise);
+});
+
+test.serial('cancel immediately', async t => {
+	const p = got(`${s.url}/no-res-store-id`, {body: '', retries: 0});
+	p.cancel();
+
+	await t.throws(p, PCancelable.CancelError);
+	await t.notThrows(cancelPromise);
 });
 
 test.after('cleanup', async () => {


### PR DESCRIPTION
* [x] Test canceling in progress request.
  * [x] Call `.cancel()` at the right moment.
* [x] Check if it's possible to abort during an in-progress request.
* [x] Fix the PCancelable rejection blowing up instead of hitting our catch handler.
* [x] Document cancel option

The documentation on aborting is unfortunately pretty skimpy. It appears Node destroys the socket on abort, so it sounds like we can abort during any phase of the request.

---
Fixes #274 