### PR TITLE
Add WHATWG URL support

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,6 +209,10 @@ function normalizeArguments(url, opts) {
 
 	if (isURL.lenient(url)) {
 		url = urlParseLax(url.href);
+
+		if (url.auth) {
+			throw new Error('Basic authentication must be done with auth option');
+		}
 	}
 
 	opts = Object.assign(

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ const unzipResponse = require('unzip-response');
 const createErrorClass = require('create-error-class');
 const isRetryAllowed = require('is-retry-allowed');
 const Buffer = require('safe-buffer').Buffer;
+const isURL = require('isurl');
 const pkg = require('./package');
 
 function requestAsEventEmitter(opts) {
@@ -204,6 +205,10 @@ function normalizeArguments(url, opts) {
 		if (url.auth) {
 			throw new Error('Basic authentication must be done with auth option');
 		}
+	}
+
+	if (isURL.lenient(url)) {
+		url = urlParseLax(url.href);
 	}
 
 	opts = Object.assign(

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "pem": "^1.4.4",
     "pify": "^2.3.0",
     "tempfile": "^1.1.1",
-    "whatwg-url": "^4.7.1",
+    "universal-url": "^1.0.0-alpha",
     "xo": "^0.18.0"
   },
   "ava": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "is-redirect": "^1.0.0",
     "is-retry-allowed": "^1.0.0",
     "is-stream": "^1.0.0",
-    "isurl": "^1.0.0-alpha3",
+    "isurl": "^1.0.0-alpha5",
     "lowercase-keys": "^1.0.0",
     "safe-buffer": "^5.0.1",
     "timed-out": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "is-redirect": "^1.0.0",
     "is-retry-allowed": "^1.0.0",
     "is-stream": "^1.0.0",
+    "isurl": "^1.0.0-alpha3",
     "lowercase-keys": "^1.0.0",
     "safe-buffer": "^5.0.1",
     "timed-out": "^4.0.0",
@@ -64,6 +65,7 @@
     "pem": "^1.4.4",
     "pify": "^2.3.0",
     "tempfile": "^1.1.1",
+    "whatwg-url": "^4.7.1",
     "xo": "^0.18.0"
   },
   "ava": {

--- a/package.json
+++ b/package.json
@@ -70,9 +70,9 @@
     "nyc": "^10.0.0",
     "pem": "^1.4.4",
     "pify": "^2.3.0",
-    "universal-url": "^1.0.0-alpha",
     "tempfile": "^1.1.1",
     "tempy": "^0.1.0",
+    "universal-url": "^1.0.0-alpha",
     "xo": "^0.18.0"
   },
   "ava": {

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ Returns a Promise for a `response` object with a `body` property, a `url` proper
 
 Type: `string`, `object`
 
-The URL to request as simple string, a [`http.request` options](https://nodejs.org/api/http.html#http_http_request_options_callback), or a [`WHATWG-URL`](https://nodejs.org/api/url.html#url_class_url).
+The URL to request as simple string, a [`http.request` options](https://nodejs.org/api/http.html#http_http_request_options_callback), or a [WHATWG `URL`](https://nodejs.org/api/url.html#url_class_url).
 
 Properties from `options` will override properties in the parsed `url`.
 

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ Returns a Promise for a `response` object with a `body` property, a `url` proper
 
 Type: `string`, `object`
 
-The URL to request or a [`http.request` options](https://nodejs.org/api/http.html#http_http_request_options_callback) object.
+The URL to request as simple string, a [`http.request` options](https://nodejs.org/api/http.html#http_http_request_options_callback), or a [`WHATWG-URL`](https://nodejs.org/api/url.html#url_class_url).
 
 Properties from `options` will override properties in the parsed `url`.
 

--- a/test/arguments.js
+++ b/test/arguments.js
@@ -1,3 +1,4 @@
+import {URL} from 'whatwg-url';
 import test from 'ava';
 import got from '../';
 import {createServer} from './helpers/server';
@@ -63,6 +64,11 @@ test('should throw with auth in url', async t => {
 	} catch (err) {
 		t.regex(err.message, /Basic authentication must be done with auth option/);
 	}
+});
+
+test('whatwg-url support', async () => {
+	const wURL = new URL(`${s.url}/test`);
+	await got(wURL);
 });
 
 test.after('cleanup', async () => {

--- a/test/arguments.js
+++ b/test/arguments.js
@@ -66,9 +66,9 @@ test('should throw with auth in url', async t => {
 	}
 });
 
-test('whatwg-url support', async () => {
+test('WHATWG URL support', async t => {
 	const wURL = new URL(`${s.url}/test`);
-	await got(wURL);
+	await t.notThrows(got(wURL));
 });
 
 test('throws on WHATWG URL with auth', async t => {

--- a/test/arguments.js
+++ b/test/arguments.js
@@ -1,4 +1,4 @@
-import {URL} from 'whatwg-url';
+import {URL} from 'universal-url';
 import test from 'ava';
 import got from '../';
 import {createServer} from './helpers/server';

--- a/test/arguments.js
+++ b/test/arguments.js
@@ -71,6 +71,13 @@ test('whatwg-url support', async () => {
 	await got(wURL);
 });
 
+test('throws on WHATWG URL with auth', async t => {
+	const wURL = new URL(`${s.url}/test`);
+	wURL.username = 'alex';
+	wURL.password = 'secret';
+	await t.throws(got(wURL));
+});
+
 test.after('cleanup', async () => {
 	await s.close();
 });


### PR DESCRIPTION
So I've gotten stuck implementing this.
The way I imagine things, this PR is a _bad_ idea or I've been way overthinking the whole time. With this PR the nuances between the way Node handles a [Node urlObject](https://nodejs.org/api/url.html#url_url_strings_and_url_objects) or [whatwg urlObject](https://nodejs.org/api/url.html#url_the_whatwg_url_api) would be lost. I tried to dig into the Node v8 nightly to confirm but couldn't find anything. I assumed this can't be done because this PR trivially supports whatwg-urls on any Node and I thought that wasn't possible.

The second suggestion was keeping the URL object intact and supporting whatwg-url on Node >= v8. This makes less sense the more I think about it. Some issues I can think of:
* Any place you read from or write to the URL you'd have to be aware of which type you're dealing with. (If you normalize you're effectively doing what this PR is)
* We currently support all of the `http.request` options, which we use to overwrite the URL object. 
* How does one pass node's `http.request` options that are not Node URL properties? If you have to serialize the whatwg-url in order to do that what's the point keeping it intact in the first place? The current Node implementation runs it through [url.parse](https://nodejs.org/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost) anyway. If that is going to stay the same in v8, this PR seems like an adequate solution.

I guess the core question I'm asking is: does it matter if you serialize a whatwg-url then parse it with node's url.parse or directly pass it to node? I can't tell from skimming the whatwg-url spec.

Note to self: if we're going with normalizing whatwg-url's take care of sneaking in auth. 
Sidenote to self: dealing with features supported in some versions of Node is tricky 😓.

---

Fixes #228 