### PR TITLE
Reduce retries number and make delays shorter

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,7 +215,7 @@ function normalizeArguments(url, opts) {
 	opts = Object.assign(
 		{
 			path: '',
-			retries: 5
+			retries: 2
 		},
 		url,
 		{

--- a/readme.md
+++ b/readme.md
@@ -132,7 +132,7 @@ Option accepts `object` with separate `connect` and `socket` fields for connecti
 ###### retries
 
 Type: `number`, `function`<br>
-Default: `5`
+Default: `2`
 
 Number of request retries when network errors happens. Delays between retries counts with function `1000 * Math.pow(2, retry) + Math.random() * 100`, where `retry` is attempt number (starts from 0).
 


### PR DESCRIPTION
This sets number of retries to `2`, so total number of requests including first one will be `3`.