### PR TITLE
Set up proxy event emitter before making a request

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,9 @@ function requestAsEventEmitter(opts) {
 		});
 	};
 
-	get(opts);
+	setImmediate(() => {
+		get(opts);
+	});
 	return ee;
 }
 


### PR DESCRIPTION
Recently, every time I run the full test suite `nyc` pesters me with its angry red uncovered L34 (in this PR). I decided to dive in and find out why. The reason is: we emit the protocol error before we've had the chance to attach an error listener. So Node blows up, and indeed we never execute the return statement.

Wrapping the first request in a `setImmediate` so the proxy event emitter can get set up makes more sense to me than removing the return statement. ~Maybe you feel the alternative works better. Your call!~ 

EDIT: Spotting our code never hits that return statement or the rest of the function body the statement returns flow to is unlikely. On second thought, I'm strongly for my current approach; the only potential problem is practical issues with altering the code flow this way.