### PR TITLE
Request timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,21 +102,16 @@ function requestAsEventEmitter(opts) {
 }
 
 function asPromise(opts) {
-	let timeoutFn;
-
 	const timeout = opts.gotTimeout && typeof opts.gotTimeout.request === 'number' ?
 		opts.gotTimeout.request :
 		typeof opts.gotTimeout === 'number' ?
 			opts.gotTimeout :
 			false;
 
-	if (timeout) {
-		timeoutFn = p => pTimeout(p, timeout, new got.RequestError({message: 'Request timed out', code: 'ETIMEDOUT'}, opts));
-	} else {
-		timeoutFn = p => p;
-	}
-
-	return timeoutFn(new PCancelable((onCancel, resolve, reject) => {
+	return (requestPromise => timeout ?
+		pTimeout(requestPromise, timeout, new got.RequestError({message: 'Request timed out', code: 'ETIMEDOUT'}, opts)) :
+		requestPromise
+	)(new PCancelable((onCancel, resolve, reject) => {
 		const ee = requestAsEventEmitter(opts);
 		let cancelOnRequest = false;
 

--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ function asPromise(opts) {
 		if (timeoutDuration) {
 			timeout = setTimeout(() => {
 				reject(new got.RequestError({message: 'Request timed out', code: 'ETIMEDOUT'}, opts));
-			});
+			}, timeoutDuration);
 		}
 
 		onCancel(() => {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "isurl": "^1.0.0-alpha5",
     "lowercase-keys": "^1.0.0",
     "p-cancelable": "^0.2.0",
+    "p-timeout": "^1.1.1",
     "safe-buffer": "^5.0.1",
     "timed-out": "^4.0.0",
     "url-parse-lax": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "isurl": "^1.0.0-alpha5",
     "lowercase-keys": "^1.0.0",
     "p-cancelable": "^0.2.0",
-    "p-timeout": "^1.1.1",
     "safe-buffer": "^5.0.1",
     "timed-out": "^4.0.0",
     "url-parse-lax": "^1.0.0"

--- a/readme.md
+++ b/readme.md
@@ -127,7 +127,7 @@ Type: `number`, `object`
 
 Milliseconds to wait for the server to end the response before aborting request with `ETIMEDOUT` error.
 
-Option accepts `object` with separate `connect`, `socket`, and `request` fields for connection, socket, and entire request timeouts.
+This also accepts an object with separate `connect`, `socket`, and `request` fields for connection, socket, and entire request timeouts.
 
 ###### retries
 

--- a/readme.md
+++ b/readme.md
@@ -125,9 +125,9 @@ Query string object that will be added to the request URL. This will override th
 
 Type: `number`, `object`
 
-Milliseconds to wait for a server to send response headers before aborting request with `ETIMEDOUT` error.
+Milliseconds to wait for the server to end the response before aborting request with `ETIMEDOUT` error.
 
-Option accepts `object` with separate `connect` and `socket` fields for connection and socket inactivity timeouts.
+Option accepts `object` with separate `connect`, `socket`, and `request` fields for connection, socket, and entire request timeouts.
 
 ###### retries
 

--- a/test/arguments.js
+++ b/test/arguments.js
@@ -54,12 +54,8 @@ test('overrides querystring from opts', async t => {
 });
 
 test('should throw with auth in url', async t => {
-	try {
-		await got('https://test:45d3ps453@account.myservice.com/api/token');
-		t.fail('Exception was not thrown');
-	} catch (err) {
-		t.regex(err.message, /Basic authentication must be done with auth option/);
-	}
+	const err = await t.throws(got('https://test:45d3ps453@account.myservice.com/api/token'));
+	t.regex(err.message, /Basic authentication must be done with auth option/);
 });
 
 test('should throw when body is set to object', async t => {

--- a/test/error.js
+++ b/test/error.js
@@ -16,42 +16,30 @@ test.before('setup', async () => {
 });
 
 test('properties', async t => {
-	try {
-		await got(s.url);
-		t.fail('Exception was not thrown');
-	} catch (err) {
-		t.truthy(err);
-		t.truthy(err.response);
-		t.false({}.propertyIsEnumerable.call(err, 'response'));
-		t.false({}.hasOwnProperty.call(err, 'code'));
-		t.is(err.message, 'Response code 404 (Not Found)');
-		t.is(err.host, `${s.host}:${s.port}`);
-		t.is(err.method, 'GET');
-		t.is(err.protocol, 'http:');
-		t.is(err.url, err.response.requestUrl);
-		t.is(err.headers.connection, 'close');
-	}
+	const err = await t.throws(got(s.url));
+	t.truthy(err);
+	t.truthy(err.response);
+	t.false({}.propertyIsEnumerable.call(err, 'response'));
+	t.false({}.hasOwnProperty.call(err, 'code'));
+	t.is(err.message, 'Response code 404 (Not Found)');
+	t.is(err.host, `${s.host}:${s.port}`);
+	t.is(err.method, 'GET');
+	t.is(err.protocol, 'http:');
+	t.is(err.url, err.response.requestUrl);
+	t.is(err.headers.connection, 'close');
 });
 
 test('dns message', async t => {
-	try {
-		await got('.com', {retries: 0});
-		t.fail('Exception was not thrown');
-	} catch (err) {
-		t.truthy(err);
-		t.regex(err.message, /getaddrinfo ENOTFOUND/);
-		t.is(err.host, '.com');
-		t.is(err.method, 'GET');
-	}
+	const err = await t.throws(got('.com', {retries: 0}));
+	t.truthy(err);
+	t.regex(err.message, /getaddrinfo ENOTFOUND/);
+	t.is(err.host, '.com');
+	t.is(err.method, 'GET');
 });
 
 test('options.body error message', async t => {
-	try {
-		await got(s.url, {body: () => {}});
-		t.fail('Exception was not thrown');
-	} catch (err) {
-		t.regex(err.message, /options.body must be a ReadableStream, string, Buffer or plain Object/);
-	}
+	const err = await t.throws(got(s.url, {body: () => {}}));
+	t.regex(err.message, /options.body must be a ReadableStream, string, Buffer or plain Object/);
 });
 
 test.after('cleanup', async () => {

--- a/test/gzip.js
+++ b/test/gzip.js
@@ -50,14 +50,10 @@ test('decompress content - stream', async t => {
 });
 
 test('handles gzip error', async t => {
-	try {
-		await got(`${s.url}/corrupted`);
-		t.fail('Exception was not thrown');
-	} catch (err) {
-		t.is(err.message, 'incorrect header check');
-		t.is(err.path, '/corrupted');
-		t.is(err.name, 'ReadError');
-	}
+	const err = await t.throws(got(`${s.url}/corrupted`));
+	t.is(err.message, 'incorrect header check');
+	t.is(err.path, '/corrupted');
+	t.is(err.name, 'ReadError');
 });
 
 test('preserve headers property', async t => {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -22,19 +22,11 @@ test.before('setup', async () => {
 test('promise mode', async t => {
 	t.is((await got.get(s.url)).body, 'ok');
 
-	try {
-		await got.get(`${s.url}/404`);
-		t.fail('Exception was not thrown');
-	} catch (err) {
-		t.is(err.response.body, 'not found');
-	}
+	const err = await t.throws(got.get(`${s.url}/404`));
+	t.is(err.response.body, 'not found');
 
-	try {
-		await got.get('.com', {retries: 0});
-		t.fail('Exception was not thrown');
-	} catch (err) {
-		t.truthy(err);
-	}
+	const err2 = await t.throws(got.get('.com', {retries: 0}));
+	t.truthy(err2);
 });
 
 test.after('cleanup', async () => {

--- a/test/http.js
+++ b/test/http.js
@@ -50,13 +50,9 @@ test('requestUrl response', async t => {
 });
 
 test('error with code', async t => {
-	try {
-		await got(`${s.url}/404`);
-		t.fail('Exception was not thrown');
-	} catch (err) {
-		t.is(err.statusCode, 404);
-		t.is(err.response.body, 'not');
-	}
+	const err = await t.throws(got(`${s.url}/404`));
+	t.is(err.statusCode, 404);
+	t.is(err.response.body, 'not');
 });
 
 test('status code 304 doesn\'t throw', async t => {

--- a/test/http.js
+++ b/test/http.js
@@ -77,30 +77,6 @@ test('buffer on encoding === null', async t => {
 	t.truthy(Buffer.isBuffer(data));
 });
 
-test('timeout option', async t => {
-	try {
-		await got(`${s.url}/404`, {
-			timeout: 1,
-			retries: 0
-		});
-		t.fail('Exception was not thrown');
-	} catch (err) {
-		t.is(err.code, 'ETIMEDOUT');
-	}
-});
-
-test('timeout option as object', async t => {
-	try {
-		await got(`${s.url}/404`, {
-			timeout: {connect: 1},
-			retries: 0
-		});
-		t.fail('Exception was not thrown');
-	} catch (err) {
-		t.is(err.code, 'ETIMEDOUT');
-	}
-});
-
 test('query option', async t => {
 	t.is((await got(s.url, {query: {recent: true}})).body, 'recent');
 	t.is((await got(s.url, {query: 'recent=true'})).body, 'recent');

--- a/test/json-parse.js
+++ b/test/json-parse.js
@@ -47,34 +47,22 @@ test('not parses responses without a body', async t => {
 });
 
 test('wraps parsing errors', async t => {
-	try {
-		await got(`${s.url}/invalid`, {json: true});
-		t.fail('Exception was not thrown');
-	} catch (err) {
-		t.regex(err.message, /Unexpected token/);
-		t.true(err.message.indexOf(err.hostname) !== -1, err.message);
-		t.is(err.path, '/invalid');
-	}
+	const err = await t.throws(got(`${s.url}/invalid`, {json: true}));
+	t.regex(err.message, /Unexpected token/);
+	t.true(err.message.indexOf(err.hostname) !== -1, err.message);
+	t.is(err.path, '/invalid');
 });
 
 test('parses non-200 responses', async t => {
-	try {
-		await got(`${s.url}/non200`, {json: true});
-		t.fail('Exception was not thrown');
-	} catch (err) {
-		t.deepEqual(err.response.body, {data: 'dog'});
-	}
+	const err = await t.throws(got(`${s.url}/non200`, {json: true}));
+	t.deepEqual(err.response.body, {data: 'dog'});
 });
 
 test('ignores errors on invalid non-200 responses', async t => {
-	try {
-		await got(`${s.url}/non200-invalid`, {json: true});
-		t.fail('Exception was not thrown');
-	} catch (err) {
-		t.is(err.message, 'Response code 500 (Internal Server Error)');
-		t.is(err.response.body, 'Internal error');
-		t.is(err.path, '/non200-invalid');
-	}
+	const err = await t.throws(got(`${s.url}/non200-invalid`, {json: true}));
+	t.is(err.message, 'Response code 500 (Internal Server Error)');
+	t.is(err.response.body, 'Internal error');
+	t.is(err.path, '/non200-invalid');
 });
 
 test('should have statusCode in err', async t => {

--- a/test/redirects.js
+++ b/test/redirects.js
@@ -111,13 +111,9 @@ test('relative redirect works', async t => {
 });
 
 test('throws on endless redirect', async t => {
-	try {
-		await got(`${http.url}/endless`);
-		t.fail('Exception was not thrown');
-	} catch (err) {
-		t.is(err.message, 'Redirected 10 times. Aborting.');
-		t.deepEqual(err.redirectUrls, Array(10).fill(`${http.url}/endless`));
-	}
+	const err = await t.throws(got(`${http.url}/endless`));
+	t.is(err.message, 'Redirected 10 times. Aborting.');
+	t.deepEqual(err.redirectUrls, Array(10).fill(`${http.url}/endless`));
 });
 
 test('query in options are not breaking redirects', async t => {
@@ -132,14 +128,10 @@ test('hostname+path in options are not breaking redirects', async t => {
 });
 
 test('redirect only GET and HEAD requests', async t => {
-	try {
-		await got(`${http.url}/relative`, {body: 'wow'});
-		t.fail('Exception was not thrown');
-	} catch (err) {
-		t.is(err.message, 'Response code 302 (Found)');
-		t.is(err.path, '/relative');
-		t.is(err.statusCode, 302);
-	}
+	const err = await t.throws(got(`${http.url}/relative`, {body: 'wow'}));
+	t.is(err.message, 'Response code 302 (Found)');
+	t.is(err.path, '/relative');
+	t.is(err.statusCode, 302);
 });
 
 test('redirects from http to https works', async t => {

--- a/test/retry.js
+++ b/test/retry.js
@@ -36,16 +36,12 @@ test('works on timeout error', async t => {
 });
 
 test('can be disabled with option', async t => {
-	try {
-		await got(`${s.url}/try-me`, {
-			timeout: {connect: 500, socket: 500},
-			retries: 0
-		});
-		t.fail();
-	} catch (err) {
-		t.truthy(err);
-		t.is(trys, 1);
-	}
+	const err = await t.throws(got(`${s.url}/try-me`, {
+		timeout: {connect: 500, socket: 500},
+		retries: 0
+	}));
+	t.truthy(err);
+	t.is(trys, 1);
 });
 
 test('function gets iter count', async t => {
@@ -57,28 +53,22 @@ test('function gets iter count', async t => {
 });
 
 test('falsy value prevents retries', async t => {
-	try {
-		await got(`${s.url}/long`, {
-			timeout: {connect: 100, socket: 100},
-			retries: () => 0
-		});
-	} catch (err) {
-		t.truthy(err);
-	}
+	const err = await t.throws(got(`${s.url}/long`, {
+		timeout: {connect: 100, socket: 100},
+		retries: () => 0
+	}));
+	t.truthy(err);
 });
 
 test('falsy value prevents retries #2', async t => {
-	try {
-		await got(`${s.url}/long`, {
-			timeout: {connect: 100, socket: 100},
-			retries: (iter, err) => {
-				t.truthy(err);
-				return false;
-			}
-		});
-	} catch (err) {
-		t.truthy(err);
-	}
+	const err = await t.throws(got(`${s.url}/long`, {
+		timeout: {connect: 100, socket: 100},
+		retries: (iter, err) => {
+			t.truthy(err);
+			return false;
+		}
+	}));
+	t.truthy(err);
 });
 
 test.after('cleanup', async () => {

--- a/test/timeout.js
+++ b/test/timeout.js
@@ -16,49 +16,37 @@ test.before('setup', async () => {
 });
 
 test('timeout option', async t => {
-	try {
-		await got(`${s.url}/`, {
-			timeout: 1,
-			retries: 0
-		});
-		t.fail('Exception was not thrown');
-	} catch (err) {
-		t.is(err.code, 'ETIMEDOUT');
-	}
+	const err = await t.throws(got(`${s.url}/`, {
+		timeout: 1,
+		retries: 0
+	}));
+
+	t.is(err.code, 'ETIMEDOUT');
 });
 
 test('timeout option as object', async t => {
-	try {
-		await got(`${s.url}/404`, {
-			timeout: {socket: 50, request: 1},
-			retries: 0
-		});
-		t.fail('Exception was not thrown');
-	} catch (err) {
-		t.is(err.code, 'ETIMEDOUT');
-	}
+	const err = await t.throws(got(`${s.url}/404`, {
+		timeout: {socket: 50, request: 1},
+		retries: 0
+	}));
+
+	t.is(err.code, 'ETIMEDOUT');
 });
 
 test('socket timeout', async t => {
-	try {
-		await got(`${s.url}/404`, {
-			timeout: {socket: 1},
-			retries: 0
-		});
-		t.fail('Exception was not thrown');
-	} catch (err) {
-		t.is(err.code, 'ESOCKETTIMEDOUT');
-	}
+	const err = await t.throws(got(`${s.url}/404`, {
+		timeout: {socket: 1},
+		retries: 0
+	}));
+
+	t.is(err.code, 'ESOCKETTIMEDOUT');
 });
 
 test('connection, request timeout', async t => {
-	try {
-		await got(`${s.url}/404`, {
-			timeout: {socket: 50, request: 1},
-			retries: 0
-		});
-		t.fail('Exception was not thrown');
-	} catch (err) {
-		t.is(err.code, 'ETIMEDOUT');
-	}
+	const err = await t.throws(got(`${s.url}/404`, {
+		timeout: {socket: 50, request: 1},
+		retries: 0
+	}));
+
+	t.is(err.code, 'ETIMEDOUT');
 });

--- a/test/timeout.js
+++ b/test/timeout.js
@@ -1,0 +1,64 @@
+import test from 'ava';
+import got from '..';
+import {createServer} from './helpers/server';
+
+let s;
+
+test.before('setup', async () => {
+	s = await createServer();
+
+	s.on('/', (req, res) => {
+		res.statusCode = 200;
+		res.end('OK');
+	});
+
+	await s.listen(s.port);
+});
+
+test('timeout option', async t => {
+	try {
+		await got(`${s.url}/`, {
+			timeout: 1,
+			retries: 0
+		});
+		t.fail('Exception was not thrown');
+	} catch (err) {
+		t.is(err.code, 'ETIMEDOUT');
+	}
+});
+
+test('timeout option as object', async t => {
+	try {
+		await got(`${s.url}/404`, {
+			timeout: {socket: 50, request: 1},
+			retries: 0
+		});
+		t.fail('Exception was not thrown');
+	} catch (err) {
+		t.is(err.code, 'ETIMEDOUT');
+	}
+});
+
+test('socket timeout', async t => {
+	try {
+		await got(`${s.url}/404`, {
+			timeout: {socket: 1},
+			retries: 0
+		});
+		t.fail('Exception was not thrown');
+	} catch (err) {
+		t.is(err.code, 'ESOCKETTIMEDOUT');
+	}
+});
+
+test('connection, request timeout', async t => {
+	try {
+		await got(`${s.url}/404`, {
+			timeout: {socket: 50, request: 1},
+			retries: 0
+		});
+		t.fail('Exception was not thrown');
+	} catch (err) {
+		t.is(err.code, 'ETIMEDOUT');
+	}
+});

--- a/test/timeout.js
+++ b/test/timeout.js
@@ -50,3 +50,12 @@ test('connection, request timeout', async t => {
 
 	t.is(err.code, 'ETIMEDOUT');
 });
+
+test.cb('timeout with streams', t => {
+	got.stream(s.url, {timeout: 1, retries: 0})
+		.on('error', err => {
+			t.is(err.code, 'ETIMEDOUT');
+			t.end();
+		})
+		.on('data', t.end);
+});


### PR DESCRIPTION
Fixes #257.

Changes timeout option so that if a number is supplied, that is the timeout for the entire request to be completed; if an object is supplied, the keys `connect`, `socket`, and `request` set connection, socket, and entire request timeouts, respectively.

Open questions:
- Is "request" the right name for the full request timeout option? Should it be "response" instead?