### PR TITLE
Improve use in Electron

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,11 @@ function requestAsEventEmitter(opts) {
 			return;
 		}
 
-		const fn = opts.protocol === 'https:' ? https : http;
+		let fn = opts.protocol === 'https:' ? https : http;
+
+		if (process.versions.electron) {
+			fn = require('electron').net;
+		}
 
 		const req = fn.request(opts, res => {
 			const statusCode = res.statusCode;

--- a/package.json
+++ b/package.json
@@ -44,7 +44,10 @@
     "simple",
     "curl",
     "wget",
-    "fetch"
+    "fetch",
+    "net",
+    "network",
+    "electron"
   ],
   "dependencies": {
     "decompress-response": "^3.2.0",

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,8 @@ It supports following redirects, promises, streams, retries, automagically handl
 
 Created because [`request`](https://github.com/request/request) is bloated *(several megabytes!)*.
 
+When used with Electron, it takes advantage of [`electron.net`](https://electron.atom.io/docs/api/net/).
+
 
 ## Install
 


### PR DESCRIPTION
When used in Electron, we can take advantage of its `net` module, which is documented to be compatible with the Node.js `http` module, but brings automatic proxy support and more.

It seems to work fine running in this test app:

```js
const electron = require('electron');
const got = require('got');

electron.app.on('ready', () => {
	got('https://api.npms.io/v2/search?q="author:sindresorhus"').then(console.log).catch(console.error);
});
```

```
$ electron x.js
```