### PR TITLE
Add `decompress` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,6 +89,10 @@ function requestAsEventEmitter(opts) {
 					typeof decompressResponse === 'function' &&
 					req.method !== 'HEAD' ? decompressResponse(res) : res;
 
+				if (!opts.decompress && ['gzip', 'deflate'].indexOf(res.headers['content-encoding']) !== -1) {
+					opts.encoding = null;
+				}
+
 				response.redirectUrls = redirects;
 
 				ee.emit('response', response);

--- a/index.js
+++ b/index.js
@@ -85,7 +85,8 @@ function requestAsEventEmitter(opts) {
 			}
 
 			setImmediate(() => {
-				const response = typeof decompressResponse === 'function' &&
+				const response = opts.decompress === true &&
+					typeof decompressResponse === 'function' &&
 					req.method !== 'HEAD' ? decompressResponse(res) : res;
 
 				response.redirectUrls = redirects;
@@ -280,6 +281,7 @@ function normalizeArguments(url, opts) {
 		{
 			path: '',
 			retries: 2,
+			decompress: true,
 			useElectronNet: true
 		},
 		url,

--- a/readme.md
+++ b/readme.md
@@ -152,6 +152,15 @@ Defines if redirect responses should be followed automatically.
 Note that if a `303` is sent by the server in response to any request type (`POST`, `DELETE`, etc.), got will automatically
 request the resource pointed to in the location header via `GET`. This is in accordance with [the spec](https://tools.ietf.org/html/rfc7231#section-6.4.4).
 
+###### decompress
+
+Type: `boolean`<br>
+Default: `true`
+
+Defines if compressed responses should be decompressed automatically.
+
+If this is disabled the body is returned as a compressed Buffer. This may be useful if you want to handle decompression yourself or stream the raw compressed data.
+
 ###### useElectronNet
 
 Type: `boolean`<br>

--- a/readme.md
+++ b/readme.md
@@ -157,9 +157,9 @@ request the resource pointed to in the location header via `GET`. This is in acc
 Type: `boolean`<br>
 Default: `true`
 
-Defines if compressed responses should be decompressed automatically.
+Decompress the response automatically.
 
-If this is disabled the body is returned as a compressed Buffer. This may be useful if you want to handle decompression yourself or stream the raw compressed data.
+If this is disabled, a compressed response is returned as a `Buffer`. This may be useful if you want to handle decompression yourself or stream the raw compressed data.
 
 ###### useElectronNet
 

--- a/test/gzip.js
+++ b/test/gzip.js
@@ -6,6 +6,7 @@ import got from '..';
 import {createServer} from './helpers/server';
 
 const testContent = 'Compressible response content.\n';
+const testContentUncompressed = 'Uncompressed response content.\n';
 
 let s;
 let gzipData;
@@ -41,6 +42,12 @@ test.before('setup', async () => {
 		res.end(gzipData.slice(0, -1));
 	});
 
+	s.on('/uncompressed', (req, res) => {
+		res.statusCode = 200;
+		res.setHeader('Content-Type', 'text/plain');
+		res.end(testContentUncompressed);
+	});
+
 	await s.listen(s.port);
 });
 
@@ -62,6 +69,11 @@ test('handles gzip error', async t => {
 test('decompress option opts out of decompressing', async t => {
 	const response = await got(s.url, {decompress: false});
 	t.true(Buffer.compare(response.body, gzipData) === 0);
+});
+
+test('decompress option doesn\'t alter encoding of uncompressed responses', async t => {
+	const response = await got(`${s.url}/uncompressed`, {decompress: false});
+	t.is(response.body, testContentUncompressed);
 });
 
 test('preserve headers property', async t => {

--- a/test/gzip.js
+++ b/test/gzip.js
@@ -60,7 +60,7 @@ test('handles gzip error', async t => {
 });
 
 test('decompress option opts out of decompressing', async t => {
-	const response = await got(s.url, {decompress: false, encoding: null});
+	const response = await got(s.url, {decompress: false});
 	t.true(Buffer.compare(response.body, gzipData) === 0);
 });
 


### PR DESCRIPTION
Adds `opts.decompress` option. By default it's `true` and functionality remains the same. Setting `opts.decompress` to false allows you to opt out of Got's automatic decompression.

Resolves #319 