### PR TITLE
Fix unix address parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -342,7 +342,7 @@ function normalizeArguments(url, opts) {
 	}
 
 	if (opts.hostname === 'unix') {
-		const matches = /(.+):(.+)/.exec(opts.path);
+		const matches = /(.+?):(.+)/.exec(opts.path);
 
 		if (matches) {
 			opts.socketPath = matches[1];

--- a/test/unix-socket.js
+++ b/test/unix-socket.js
@@ -15,6 +15,10 @@ test.before('setup', async () => {
 		res.end('ok');
 	});
 
+	s.on('/foo:bar', (req, res) => {
+		res.end('ok');
+	});
+
 	await s.listen(socketPath);
 });
 
@@ -25,6 +29,11 @@ test('works', async t => {
 
 test('protocol-less works', async t => {
 	const url = format('unix:%s:%s', socketPath, '/');
+	t.is((await got(url)).body, 'ok');
+});
+
+test('address with : works', async t => {
+	const url = format('unix:%s:%s', socketPath, '/foo:bar');
 	t.is((await got(url)).body, 'ok');
 });
 


### PR DESCRIPTION
When request
```
unix:/var/run/docker.sock:/images/alpine:latest/json
```
It will return socketPath `unix:/var/run/docker.sock:/images/alpine`

so fix regex to `(.+?):(.+)`