### PR TITLE
add `.json` to require('./package')

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const isPlainObj = require('is-plain-obj');
 const PCancelable = require('p-cancelable');
 const pTimeout = require('p-timeout');
 const pify = require('pify');
-const pkg = require('./package');
+const pkg = require('./package.json');
 
 const getMethodRedirectCodes = new Set([300, 301, 302, 303, 304, 305, 307, 308]);
 const allMethodRedirectCodes = new Set([300, 303, 307, 308]);


### PR DESCRIPTION
This fixes issues for people using `got` with webpack, which by default has problems with the missing extension. 

I know that [extensions are optional](https://github.com/sindresorhus/got/issues/266#issuecomment-274361530), but this simple change shouldn't cause any problems but would resolve the problem of all wbepack users trying to use `got` (or libraries using `got`).

I agree that normally libraries shouldn't have to adapt to the ecosystem, but in this case the code becomes even more readable and clearer (I at least didn't know that you could just leave off the file extension.)

Why not just use the workaround? Well, it seems to [not work in all cases](https://github.com/ionic-team/ionic-app-scripts/issues/1148) - and I found one of them.