### PR TITLE
Remove StdError constructor call from error stack traces

### DIFF
--- a/index.js
+++ b/index.js
@@ -567,6 +567,7 @@ for (const method of methods) {
 class StdError extends Error {
 	constructor(message, error, opts) {
 		super(message);
+		Error.captureStackTrace(this, this.constructor);
 		this.name = 'StdError';
 
 		if (error.code !== undefined) {


### PR DESCRIPTION
Used [`Error.captureStackTrace`](https://nodejs.org/api/errors.html#errors_error_capturestacktrace_targetobject_constructoropt) to strip out the useless stack traces through the constructors.

Quoting the above docs:
>The `constructorOpt` argument is useful for hiding implementation details of error generation from an end user


`/foobar/index.js`:
```js
const libUrl = require('url')
const got = require('got')

throw new got.ReadError(new Error('ERROR MESSAGE'), libUrl.parse('https://google.com'))
```

Running:
`node index.js`

Before:
```
/foobar/index.js:4
throw new got.ReadError(new Error('ERROR MESSAGE'), libUrl.parse('https://google.com'))
^

ReadError: ERROR MESSAGE
    at StdError (/foobar/node_modules/got/index.js:410:3)
    at /foobar/node_modules/got/index.js:438:3
    at Object.<anonymous> (/foobar/index.js:4:7)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:389:7)
```

After:
```
/foobar/index.js:4
throw new got.ReadError(new Error('ERROR MESSAGE'), libUrl.parse('https://google.com'))
^

ReadError: ERROR MESSAGE
    at Object.<anonymous> (/foobar/index.js:4:7)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:389:7)
```