### PR TITLE
Document how to test for cancelation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -280,20 +280,20 @@ When given an unsupported protocol.
 
 ## Aborting the request
 
-The promise returned by Got has a `.cancel()` function which, when called, aborts the request.
+The promise returned by Got has a [`.cancel()`](https://github.com/sindresorhus/p-cancelable) method which, when called, aborts the request.
 
 ```js
 const request = got(url, options);
 
-request.cancel();
-
 request.catch(err => {
   if (request.canceled) {
-    // handle cancellation
+    // Handle cancelation
   }
   
-  // handle other errors
+  // Handle other errors
 });
+
+request.cancel();
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -282,6 +282,20 @@ When given an unsupported protocol.
 
 The promise returned by Got has a `.cancel()` function which, when called, aborts the request.
 
+```js
+const request = got(url, options);
+
+request.cancel();
+
+request.catch(err => {
+  if (request.canceled) {
+    // handle cancellation
+  }
+  
+  // handle other errors
+});
+```
+
 
 ## Proxies
 


### PR DESCRIPTION
Add example showing how the catch cancellation error.

Note that it requires the catch handler to have access to the cancellable promise. Exposing the CancelError to check the Error instance type would be useful.