### PR TITLE
Expose CancelError

### DIFF
--- a/index.js
+++ b/index.js
@@ -640,4 +640,6 @@ got.UnsupportedProtocolError = class extends StdError {
 	}
 };
 
+got.CancelError = PCancelable.CancelError;
+
 module.exports = got;

--- a/readme.md
+++ b/readme.md
@@ -279,7 +279,7 @@ When given an unsupported protocol.
 
 #### got.CancelError
 
-When the request is aborted.
+When the request is aborted with `.cancel()`.
 
 
 ## Aborting the request

--- a/readme.md
+++ b/readme.md
@@ -277,6 +277,10 @@ When server redirects you more than 10 times. Includes a `redirectUrls` property
 
 When given an unsupported protocol.
 
+#### got.CancelError
+
+When the request is aborted.
+
 
 ## Aborting the request
 
@@ -289,7 +293,16 @@ request.catch(err => {
   if (request.canceled) {
     // Handle cancelation
   }
-  
+
+  // Handle other errors
+});
+
+// or
+request.catch(err => {
+  if (err instanceof got.CancelError) {
+    // Handle cancelation
+  }
+
   // Handle other errors
 });
 

--- a/test/cancel.js
+++ b/test/cancel.js
@@ -85,3 +85,19 @@ test('cancel immediately', async t => {
 	await t.throws(p);
 	await t.notThrows(aborted, 'Request finished instead of aborting.');
 });
+
+test('recover from cancellation using cancelable promise attribute', async t => {
+	// Cancelled before connection started
+	const p = got('http://example.com');
+	const recover = p.catch(err => {
+		if (p.canceled) {
+			return;
+		}
+
+		throw err;
+	});
+
+	p.cancel();
+
+	await t.notThrows(recover);
+});

--- a/test/cancel.js
+++ b/test/cancel.js
@@ -101,3 +101,19 @@ test('recover from cancellation using cancelable promise attribute', async t => 
 
 	await t.notThrows(recover);
 });
+
+test('recover from cancellation using error instance', async t => {
+	// Cancelled before connection started
+	const p = got('http://example.com');
+	const recover = p.catch(err => {
+		if (err instanceof got.CancelError) {
+			return;
+		}
+
+		throw err;
+	});
+
+	p.cancel();
+
+	await t.notThrows(recover);
+});

--- a/test/cancel.js
+++ b/test/cancel.js
@@ -86,8 +86,8 @@ test('cancel immediately', async t => {
 	await t.notThrows(aborted, 'Request finished instead of aborting.');
 });
 
-test('recover from cancellation using cancelable promise attribute', async t => {
-	// Cancelled before connection started
+test('recover from cancelation using cancelable promise attribute', async t => {
+	// Canceled before connection started
 	const p = got('http://example.com');
 	const recover = p.catch(err => {
 		if (p.canceled) {
@@ -103,7 +103,7 @@ test('recover from cancellation using cancelable promise attribute', async t => 
 });
 
 test('recover from cancellation using error instance', async t => {
-	// Cancelled before connection started
+	// Canceled before connection started
 	const p = got('http://example.com');
 	const recover = p.catch(err => {
 		if (err instanceof got.CancelError) {


### PR DESCRIPTION
Expose `CancelError` from `p-cancelable` as `got.CancelError`. The alternative is to keep the original promise in the chain to test if the request is cancelled or to import `p-cancelable`, which might not be the same package imported by `got`.