### PR TITLE
Set AVA concurrency to 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,9 @@
 		"universal-url": "1.0.0-alpha",
 		"xo": "^0.18.0"
 	},
+	"ava": {
+		"concurrency": 4
+	},
 	"browser": {
 		"decompress-response": false,
 		"electron": false


### PR DESCRIPTION
Otherwise `os.cpus().length` will return the CPU count of the host machine not the Docker container in Travis.

[Builds consistently timeout with no concurrency set](https://travis-ci.org/lukechilds/got/builds/288678445) and consistently pass with concurrency set as 4.

You can see in [here](https://travis-ci.org/lukechilds/got/jobs/288682177) `os.cpus().length` outputs 32 on Travis.