### PR TITLE
Add package.json extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const isPlainObj = require('is-plain-obj');
 const PCancelable = require('p-cancelable');
 const pTimeout = require('p-timeout');
 const pify = require('pify');
-const pkg = require('./package');
+const pkg = require('./package.json');
 
 const getMethodRedirectCodes = new Set([300, 301, 302, 303, 304, 305, 307, 308]);
 const allMethodRedirectCodes = new Set([300, 303, 307, 308]);


### PR DESCRIPTION
When used with rollup.js, the absence of the file extension makes a warning and create the need to add a rollup plugin.
It may not be perceived well to modify Got to fit with a tierce lib, but I don't think it is a very big change :)

Regards,
Tom