### PR TITLE
Do not throw when using a URL object with auth

### DIFF
--- a/index.js
+++ b/index.js
@@ -435,12 +435,11 @@ function normalizeArguments(url, opts) {
 	} else if (typeof url === 'string') {
 		url = url.replace(/^unix:/, 'http://$&');
 		url = urlParseLax(url);
+		if (url.auth) {
+			throw new Error('Basic authentication must be done with auth option');
+		}
 	} else if (isURL.lenient(url)) {
 		url = urlToOptions(url);
-	}
-
-	if (url.auth) {
-		throw new Error('Basic authentication must be done with auth option');
 	}
 
 	opts = Object.assign(

--- a/test/arguments.js
+++ b/test/arguments.js
@@ -53,9 +53,18 @@ test('overrides querystring from opts', async t => {
 	t.is((await got(`${s.url}/?test=doge`, {query: {test: 'wow'}})).body, '/?test=wow');
 });
 
-test('should throw with auth in url', async t => {
+test('should throw with auth in url string', async t => {
 	const err = await t.throws(got('https://test:45d3ps453@account.myservice.com/api/token'));
 	t.regex(err.message, /Basic authentication must be done with auth option/);
+});
+
+test('does not throw with auth in url object', async t => {
+	await t.notThrows(got({
+		auth: 'foo:bar',
+		hostname: s.host,
+		port: s.port,
+		path: '/test'
+	}));
 });
 
 test('should throw when body is set to object', async t => {
@@ -65,13 +74,6 @@ test('should throw when body is set to object', async t => {
 test('WHATWG URL support', async t => {
 	const wURL = new URL(`${s.url}/test`);
 	await t.notThrows(got(wURL));
-});
-
-test('throws on WHATWG URL with auth', async t => {
-	const wURL = new URL(`${s.url}/test`);
-	wURL.username = 'alex';
-	wURL.password = 'secret';
-	await t.throws(got(wURL));
 });
 
 test.after('cleanup', async () => {


### PR DESCRIPTION
Before version 7.1.0, the error was thrown only when using a URL [string](https://github.com/sindresorhus/got/pull/329/files#diff-168726dbe96b3ce427e7fedce31bb0bcL267). Now it is thrown even when using a URL object.