### PR TITLE
Improve error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,7 +198,13 @@ function requestAsEventEmitter(opts) {
 			});
 		});
 
-		cacheReq.on('error', err => ee.emit('error', new got.CacheError(err, opts)));
+		cacheReq.on('error', err => {
+			if (err instanceof CacheableRequest.RequestError) {
+				ee.emit('error', new got.RequestError(err, opts));
+			} else {
+				ee.emit('error', new got.CacheError(err, opts));
+			}
+		});
 
 		cacheReq.on('request', req => {
 			req.once('error', err => {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"electron"
 	],
 	"dependencies": {
-		"cacheable-request": "^2.0.0",
+		"cacheable-request": "^2.1.0",
 		"decompress-response": "^3.2.0",
 		"duplexer3": "^0.1.4",
 		"get-stream": "^3.0.0",

--- a/test/error.js
+++ b/test/error.js
@@ -73,8 +73,8 @@ test.serial('http.request error', async t => {
 		throw new TypeError('The header content contains invalid characters');
 	});
 	const err = await t.throws(got(s.url));
-	t.truthy(err instanceof TypeError);
-	t.regex(err.message, /The header content contains invalid characters/);
+	t.true(err instanceof got.RequestError);
+	t.is(err.message, 'The header content contains invalid characters');
 	stub.restore();
 });
 

--- a/test/error.js
+++ b/test/error.js
@@ -73,6 +73,7 @@ test.serial('http.request error', async t => {
 		throw new TypeError('The header content contains invalid characters');
 	});
 	const err = await t.throws(got(s.url));
+	t.truthy(err instanceof TypeError);
 	t.regex(err.message, /The header content contains invalid characters/);
 	stub.restore();
 });


### PR DESCRIPTION
Resolves the first part of https://github.com/sindresorhus/got/issues/392
Related: https://github.com/sindresorhus/got/pull/384

Now if the request function throws we will emit a `got.RequestError`.