### PR TITLE
Exclude passed headers with values `null` or `undefined`

### DIFF
--- a/index.js
+++ b/index.js
@@ -458,10 +458,17 @@ function normalizeArguments(url, opts) {
 		opts
 	);
 
+	const headers = lowercaseKeys(opts.headers);
+	for (const key of Object.keys(headers)) {
+		if (headers[key] === null || headers[key] === undefined) {
+			delete headers[key];
+		}
+	}
+
 	opts.headers = Object.assign({
 		'user-agent': `${pkg.name}/${pkg.version} (https://github.com/sindresorhus/got)`,
 		'accept-encoding': 'gzip,deflate'
-	}, lowercaseKeys(opts.headers));
+	}, headers);
 
 	const query = opts.query;
 

--- a/test/headers.js
+++ b/test/headers.js
@@ -89,6 +89,24 @@ test('form-data automatic content-type', async t => {
 	t.is(headers['content-type'], `multipart/form-data; boundary=${form.getBoundary()}`);
 });
 
+test('remove null value headers', async t => {
+	const headers = (await got(s.url, {
+		headers: {
+			unicorns: null
+		}
+	})).body;
+	t.false(Object.prototype.hasOwnProperty.call(headers, 'unicorns'));
+});
+
+test('remove undefined value headers', async t => {
+	const headers = (await got(s.url, {
+		headers: {
+			unicorns: undefined
+		}
+	})).body;
+	t.false(Object.prototype.hasOwnProperty.call(headers, 'unicorns'));
+});
+
 test.after('cleanup', async () => {
 	await s.close();
 });


### PR DESCRIPTION
**Notes:**
- Extract call to `lowercaseKeys` to leverage the object-safety it provides
- Delete headers with a value of `null` or `undefined`
- Considered exclusion of `''` as well, but this seems more common / legitimate from my research

Closes #410 
