### PR TITLE
Fix EventEmitter memory leak

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ function requestAsEventEmitter(opts) {
 			});
 		});
 
-		cacheReq.once('error', err => {
+		cacheReq.on('error', err => {
 			if (err instanceof CacheableRequest.RequestError) {
 				ee.emit('error', new got.RequestError(err, opts));
 			} else {
@@ -427,7 +427,7 @@ function asStream(opts) {
 		proxy.emit('response', res);
 	});
 
-	ee.once('error', proxy.emit.bind(proxy, 'error'));
+	ee.on('error', proxy.emit.bind(proxy, 'error'));
 	ee.on('redirect', proxy.emit.bind(proxy, 'redirect'));
 	ee.on('uploadProgress', proxy.emit.bind(proxy, 'uploadProgress'));
 	ee.on('downloadProgress', proxy.emit.bind(proxy, 'downloadProgress'));

--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ function requestAsEventEmitter(opts) {
 			});
 		});
 
-		cacheReq.on('error', err => {
+		cacheReq.once('error', err => {
 			if (err instanceof CacheableRequest.RequestError) {
 				ee.emit('error', new got.RequestError(err, opts));
 			} else {
@@ -206,7 +206,7 @@ function requestAsEventEmitter(opts) {
 			}
 		});
 
-		cacheReq.on('request', req => {
+		cacheReq.once('request', req => {
 			req.once('error', err => {
 				clearInterval(progressInterval);
 
@@ -220,7 +220,7 @@ function requestAsEventEmitter(opts) {
 				ee.emit('error', new got.RequestError(err, opts));
 			});
 
-			ee.on('request', req => {
+			ee.once('request', req => {
 				ee.emit('uploadProgress', {
 					percent: 0,
 					transferred: 0,
@@ -347,10 +347,10 @@ function asPromise(opts) {
 				});
 		});
 
-		ee.on('error', reject);
+		ee.once('error', reject);
+		ee.on('redirect', proxy.emit.bind(proxy, 'redirect'));
 		ee.on('uploadProgress', proxy.emit.bind(proxy, 'uploadProgress'));
 		ee.on('downloadProgress', proxy.emit.bind(proxy, 'downloadProgress'));
-		ee.on('redirect', proxy.emit.bind(proxy, 'redirect'));
 	});
 
 	const promise = timeoutFn(cancelable);
@@ -427,8 +427,8 @@ function asStream(opts) {
 		proxy.emit('response', res);
 	});
 
+	ee.once('error', proxy.emit.bind(proxy, 'error'));
 	ee.on('redirect', proxy.emit.bind(proxy, 'redirect'));
-	ee.on('error', proxy.emit.bind(proxy, 'error'));
 	ee.on('uploadProgress', proxy.emit.bind(proxy, 'uploadProgress'));
 	ee.on('downloadProgress', proxy.emit.bind(proxy, 'downloadProgress'));
 


### PR DESCRIPTION
Fixes #399 // @timdp

Currently, when you run the Got tests it outputs warnings about EventEmitter memory leaks.

Tip: Run the tests with `NODE_OPTIONS=--trace-warnings ava` to see the stack trace of the warnings