### PR TITLE
Update to cacheable-request@2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"electron"
 	],
 	"dependencies": {
-		"cacheable-request": "^2.1.0",
+		"cacheable-request": "^2.1.1",
 		"decompress-response": "^3.2.0",
 		"duplexer3": "^0.1.4",
 		"get-stream": "^3.0.0",


### PR DESCRIPTION
Automatic failover is disabled by default in `cacheable-request@2.1.1`. This prevents strange behaviour in Got (Promise mode only) where if the DB goes down the promise will reject but the request will be made behind the scenes.

Now if the DB goes down Got will just fail, the user will need to listen for DB errors and manually re-request without the cache to achieve automatic failover functionality.

Related Gitter discussion: https://gitter.im/got-dev/Lobby?at=5a0d5515614889d4758962ab