### PR TITLE
Update p-timeout to version 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"lowercase-keys": "^1.0.0",
 		"mimic-response": "^1.0.0",
 		"p-cancelable": "^0.3.0",
-		"p-timeout": "^1.2.0",
+		"p-timeout": "^2.0.1",
 		"pify": "^3.0.0",
 		"safe-buffer": "^5.1.1",
 		"timed-out": "^4.0.1",


### PR DESCRIPTION
Currently the request is not aborted if the connection cannot be established and the timeout expires. This prevents the process from exiting.

Test case:

```js
const got = require('.');

// 192.0.2.1 is non-routable.
got('http://192.0.2.1', { timeout: 1000, retries: 0 }).then(null, (err) => {
  console.error(err);
});
```