### PR TITLE
enable sending plain string over rest

### DIFF
--- a/index.js
+++ b/index.js
@@ -503,7 +503,7 @@ function normalizeArguments(url, opts) {
 			throw new TypeError('The `body` option must be a stream.Readable, string, Buffer or plain Object');
 		}
 
-		const canBodyBeStringified = is.plainObject(body) || is.array(body);
+		const canBodyBeStringified = is.plainObject(body) || is.array(body) || headers['content-type'] == 'application/json';
 		if ((opts.form || opts.json) && !canBodyBeStringified) {
 			throw new TypeError('The `body` option must be a plain Object or Array when the `form` or `json` option is used');
 		}


### PR DESCRIPTION
while working with a private API i need the functionality to send simple strings with content-type='application/json'. This was not possible with got (or i didnt find a correct way to do it). 

I change the "canBodyBeStringified" calculation so that it is also true if the content-type headers are set to application/json.