### PR TITLE
Validate that `url` is UTF-8 encoded

### DIFF
--- a/index.js
+++ b/index.js
@@ -444,6 +444,13 @@ function normalizeArguments(url, opts) {
 		throw new TypeError(`Parameter \`url\` must be a string or object, not ${is(url)}`);
 	} else if (is.string(url)) {
 		url = url.replace(/^unix:/, 'http://$&');
+
+		try {
+			decodeURI(url);
+		} catch (err) {
+			throw new Error('Parameter `url` must contain valid UTF-8 character sequences');
+		}
+
 		url = urlParseLax(url);
 		if (url.auth) {
 			throw new Error('Basic authentication must be done with the `auth` option');

--- a/test/arguments.js
+++ b/test/arguments.js
@@ -29,6 +29,11 @@ test('url is required', async t => {
 	t.regex(err.message, /Parameter `url` must be a string or object, not undefined/);
 });
 
+test('url should be utf-8 encoded', async t => {
+	const err = await t.throws(got(`${s.url}/%D2%E0%EB%EB%E8%ED`));
+	t.regex(err.message, /Parameter `url` must contain valid UTF-8 character sequences/);
+});
+
 test('options are optional', async t => {
 	t.is((await got(`${s.url}/test`)).body, '/test');
 });


### PR DESCRIPTION
Opted to decode without assignment back to `url` so that requests and other error messages continue to display the user provided `url` value. 

---
Closes #420 