### PR TITLE
Add `throwHttpErrors` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -337,7 +337,7 @@ function asPromise(opts) {
 						}
 					}
 
-					if (statusCode !== 304 && (statusCode < 200 || statusCode > limitStatusCode)) {
+					if (opts.throwHttpErrors && statusCode !== 304 && (statusCode < 200 || statusCode > limitStatusCode)) {
 						throw new got.HTTPError(statusCode, res.statusMessage, res.headers, opts);
 					}
 
@@ -425,7 +425,7 @@ function asStream(opts) {
 
 		res.pipe(output);
 
-		if (statusCode !== 304 && (statusCode < 200 || statusCode > 299)) {
+		if (opts.throwHttpErrors && statusCode !== 304 && (statusCode < 200 || statusCode > 299)) {
 			proxy.emit('error', new got.HTTPError(statusCode, res.statusMessage, res.headers, opts), null, res);
 			return;
 		}
@@ -467,7 +467,8 @@ function normalizeArguments(url, opts) {
 			retries: 2,
 			cache: false,
 			decompress: true,
-			useElectronNet: false
+			useElectronNet: false,
+			throwHttpErrors: true
 		},
 		url,
 		{

--- a/readme.md
+++ b/readme.md
@@ -211,7 +211,7 @@ When used in Electron, Got will use [`electron.net`](https://electronjs.org/docs
 Type: `boolean`<br>
 Default: `true`
 
-Determines if a `got.HTTPError` is thrown for error responses.
+Determines if a `got.HTTPError` is thrown for error responses (non-2xx status codes).
 
 If this is disabled, requests that encounter an error status code will be resolved with the `response` instead of throwing. This may be useful if you are checking for resource availability and are expecting error responses.
 

--- a/readme.md
+++ b/readme.md
@@ -206,6 +206,14 @@ Default: `false`
 
 When used in Electron, Got will use [`electron.net`](https://electronjs.org/docs/api/net/) instead of the Node.js `http` module. According to the Electron docs, it should be fully compatible, but it's not entirely. See [#315](https://github.com/sindresorhus/got/issues/315).
 
+###### throwHttpErrors
+
+Type: `boolean`<br>
+Default: `true`
+
+Determines if a `got.HTTPError` is thrown for error responses.
+
+If this is disabled, requests that encounter an error status code will be resolved with the `response` instead of throwing. This may be useful if you are checking for resource availability and are expecting error responses.
 
 #### Streams
 

--- a/test/http.js
+++ b/test/http.js
@@ -60,6 +60,10 @@ test('status code 304 doesn\'t throw', async t => {
 	t.is(response.body, '');
 });
 
+test('doesn\'t throw on throwHttpErrors === false', async t => {
+	t.is((await got(`${s.url}/404`, {throwHttpErrors: false})).body, 'not');
+});
+
 test('invalid protocol throws', async t => {
 	const err = await t.throws(got('c:/nope.com', {json: true}));
 	t.is(err.constructor, got.UnsupportedProtocolError);

--- a/test/stream.js
+++ b/test/stream.js
@@ -84,6 +84,11 @@ test('have error event #2', async t => {
 	await t.throws(pEvent(stream, 'response'), /getaddrinfo ENOTFOUND/);
 });
 
+test('have response event on throwHttpErrors === false', async t => {
+	const response = await pEvent(got.stream(`${s.url}/error`, {throwHttpErrors: false}), 'response');
+	t.is(response.statusCode, 404);
+});
+
 test('accepts option.body as Stream', async t => {
 	const stream = got.stream(`${s.url}/post`, {body: intoStream(['wow'])});
 	const data = await pEvent(stream, 'data');


### PR DESCRIPTION
Implemented the `throwHttpErrors` option discussed in #430.

- [X] Documented
- [X] Default to true
- [X] Implemented for HTTP
- [X] Implemented for Streams (for consistentency)
- [X] Tested
---
Closes #430 