### PR TITLE
Allow calling of `got.stream` via options

### DIFF
--- a/index.js
+++ b/index.js
@@ -585,7 +585,13 @@ function normalizeArguments(url, opts) {
 
 function got(url, opts) {
 	try {
-		return asPromise(normalizeArguments(url, opts));
+		const normalizedArgs = normalizeArguments(url, opts);
+
+		if (normalizedArgs.stream) {
+			return asStream(normalizedArgs);
+		}
+
+		return asPromise(normalizedArgs);
 	} catch (err) {
 		return Promise.reject(err);
 	}

--- a/readme.md
+++ b/readme.md
@@ -105,6 +105,13 @@ Type: `Object`
 
 Any of the [`http.request`](http://nodejs.org/api/http.html#http_http_request_options_callback) options.
 
+###### stream
+
+Type: `boolean`<br>
+Default: `false`
+
+Returns a `stream` instead of a Promise. This is equivalent to calling `got.stream(url, [options])`.
+
 ###### body
 
 Type: `string` `Buffer` `stream.Readable`

--- a/readme.md
+++ b/readme.md
@@ -110,7 +110,7 @@ Any of the [`http.request`](http://nodejs.org/api/http.html#http_http_request_op
 Type: `boolean`<br>
 Default: `false`
 
-Returns a `stream` instead of a Promise. This is equivalent to calling `got.stream(url, [options])`.
+Returns a `Stream` instead of a `Promise`. This is equivalent to calling `got.stream(url, [options])`.
 
 ###### body
 

--- a/test/arguments.js
+++ b/test/arguments.js
@@ -1,5 +1,6 @@
 import {URL} from 'universal-url';
 import test from 'ava';
+import pEvent from 'p-event';
 import got from '..';
 import {createServer} from './helpers/server';
 
@@ -19,6 +20,10 @@ test.before('setup', async () => {
 
 	s.on('/?test=wow', (req, res) => {
 		res.end(req.url);
+	});
+
+	s.on('/stream', (req, res) => {
+		res.end('ok');
 	});
 
 	await s.listen(s.port);
@@ -79,6 +84,17 @@ test('should throw when body is set to object', async t => {
 test('WHATWG URL support', async t => {
 	const wURL = new URL(`${s.url}/test`);
 	await t.notThrows(got(wURL));
+});
+
+test('should return streams when using stream option', async t => {
+	const data = await pEvent(got(`${s.url}/stream`, {stream: true}), 'data');
+	t.is(data.toString(), 'ok');
+});
+
+test('should not allow stream and JSON option at the same time', async t => {
+	const error = await t.throws(got(`${s.url}/stream`, {stream: true, json: true}));
+
+	t.is(error.message, 'Got can not be used as a stream when the `json` option is used');
 });
 
 test.after('cleanup', async () => {

--- a/test/arguments.js
+++ b/test/arguments.js
@@ -93,7 +93,6 @@ test('should return streams when using stream option', async t => {
 
 test('should not allow stream and JSON option at the same time', async t => {
 	const error = await t.throws(got(`${s.url}/stream`, {stream: true, json: true}));
-
 	t.is(error.message, 'Got can not be used as a stream when the `json` option is used');
 });
 


### PR DESCRIPTION
Fixes #362.

This commit allows the user to pass a `stream` flag to `opts`. When this flag is `true`, `got` returns a stream just as if it was called with `got.stream`.