### PR TITLE
Don't set `accept-encoding` if decompress is false

### DIFF
--- a/index.js
+++ b/index.js
@@ -484,9 +484,12 @@ function normalizeArguments(url, opts) {
 	}
 
 	opts.headers = Object.assign({
-		'user-agent': `${pkg.name}/${pkg.version} (https://github.com/sindresorhus/got)`,
-		'accept-encoding': 'gzip,deflate'
+		'user-agent': `${pkg.name}/${pkg.version} (https://github.com/sindresorhus/got)`
 	}, headers);
+
+	if (opts.decompress) {
+		opts.headers['accept-encoding'] = 'gzip,deflate';
+	}
 
 	const query = opts.query;
 

--- a/test/headers.js
+++ b/test/headers.js
@@ -29,7 +29,7 @@ test('accept-encoding', async t => {
 
 test('do not set accept-encoding header when decompress options is false', async t => {
 	const headers = (await got(s.url, {json: true, decompress: false})).body;
-	t.false(Reflect.has(headers, 'accept-encoding'));
+	t.false(Object.prototype.hasOwnProperty.call(headers, 'accept-encoding'));
 });
 
 test('accept header with json option', async t => {

--- a/test/headers.js
+++ b/test/headers.js
@@ -29,7 +29,7 @@ test('accept-encoding', async t => {
 
 test('do not set accept-encoding header when decompress options is false', async t => {
 	const headers = (await got(s.url, {json: true, decompress: false})).body;
-	t.false(Object.prototype.hasOwnProperty.call(headers, 'accept-encoding'));
+	t.false(Reflect.has(headers, 'accept-encoding'));
 });
 
 test('accept header with json option', async t => {

--- a/test/headers.js
+++ b/test/headers.js
@@ -29,6 +29,7 @@ test('accept-encoding', async t => {
 
 test('do not set accept-encoding header when decompress options is false', async t => {
 	const headers = (await got(s.url, {json: true, decompress: false})).body;
+	// TODO: Use `Reflect.has()` when we target Node.js 6
 	t.false(Object.prototype.hasOwnProperty.call(headers, 'accept-encoding'));
 });
 
@@ -100,6 +101,7 @@ test('remove null value headers', async t => {
 			unicorns: null
 		}
 	})).body;
+	// TODO: Use `Reflect.has()` when we target Node.js 6
 	t.false(Object.prototype.hasOwnProperty.call(headers, 'unicorns'));
 });
 

--- a/test/headers.js
+++ b/test/headers.js
@@ -27,7 +27,7 @@ test('accept-encoding', async t => {
 	t.is(headers['accept-encoding'], 'gzip,deflate');
 });
 
-test('do not set accept-encoding if decompress not enabled', async t => {
+test('do not set accept-encoding header when decompress options is false', async t => {
 	const headers = (await got(s.url, {json: true, decompress: false})).body;
 	t.false(Object.prototype.hasOwnProperty.call(headers, 'accept-encoding'));
 });

--- a/test/headers.js
+++ b/test/headers.js
@@ -109,6 +109,7 @@ test('remove undefined value headers', async t => {
 			unicorns: undefined
 		}
 	})).body;
+	// TODO: Use `Reflect.has()` when we target Node.js 6
 	t.false(Object.prototype.hasOwnProperty.call(headers, 'unicorns'));
 });
 

--- a/test/headers.js
+++ b/test/headers.js
@@ -27,6 +27,11 @@ test('accept-encoding', async t => {
 	t.is(headers['accept-encoding'], 'gzip,deflate');
 });
 
+test('do not set accept-encoding if decompress not enabled', async t => {
+	const headers = (await got(s.url, {json: true, decompress: false})).body;
+	t.false(Object.prototype.hasOwnProperty.call(headers, 'accept-encoding'));
+});
+
 test('accept header with json option', async t => {
 	let headers = (await got(s.url, {json: true})).body;
 	t.is(headers.accept, 'application/json');


### PR DESCRIPTION
Fixes #419.

Let me know if you want to move this somewhere else or use a different style 👍 . I originally wanted to put this inline under `user-agent` but then if disabled the headers object would still have an `accept-encoding` instead of none at all.