### PR TITLE
Prevent uncaught exception in some cases

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "xo.enable": true,
+    "tslint.autoFixOnSave": false,
+    "editor.formatOnSave": false,
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "xo.enable": true,
-    "tslint.autoFixOnSave": false,
-    "editor.formatOnSave": false,
-}

--- a/index.js
+++ b/index.js
@@ -196,10 +196,10 @@ function requestAsEventEmitter(opts) {
 					});
 
 					res.pipe(progressStream);
-				});
-			} catch (e) {
-				ee.emit('error', e);
-			}
+				} catch (e) {
+					ee.emit('error', e);
+				}
+			});
 		});
 
 		cacheReq.on('error', err => {

--- a/index.js
+++ b/index.js
@@ -142,60 +142,9 @@ function requestAsEventEmitter(opts) {
 				return;
 			}
 
-			const downloadBodySize = Number(res.headers['content-length']) || null;
-			let downloaded = 0;
-
 			setImmediate(() => {
 				try {
-					const progressStream = new Transform({
-						transform(chunk, encoding, callback) {
-							downloaded += chunk.length;
-
-							const percent = downloadBodySize ? downloaded / downloadBodySize : 0;
-
-							// Let flush() be responsible for emitting the last event
-							if (percent < 1) {
-								ee.emit('downloadProgress', {
-									percent,
-									transferred: downloaded,
-									total: downloadBodySize
-								});
-							}
-
-							callback(null, chunk);
-						},
-
-						flush(callback) {
-							ee.emit('downloadProgress', {
-								percent: 1,
-								transferred: downloaded,
-								total: downloadBodySize
-							});
-
-							callback();
-						}
-					});
-
-					mimicResponse(res, progressStream);
-					progressStream.redirectUrls = redirects;
-
-					const response = opts.decompress === true &&
-						is.function(decompressResponse) &&
-						opts.method !== 'HEAD' ? decompressResponse(progressStream) : progressStream;
-
-					if (!opts.decompress && ['gzip', 'deflate'].indexOf(res.headers['content-encoding']) !== -1) {
-						opts.encoding = null;
-					}
-
-					ee.emit('response', response);
-
-					ee.emit('downloadProgress', {
-						percent: 0,
-						transferred: 0,
-						total: downloadBodySize
-					});
-
-					res.pipe(progressStream);
+					getResponse(res, opts, ee, redirects);
 				} catch (e) {
 					ee.emit('error', e);
 				}
@@ -285,6 +234,61 @@ function requestAsEventEmitter(opts) {
 	});
 
 	return ee;
+}
+
+function getResponse(res, opts, ee, redirects) {
+	const downloadBodySize = Number(res.headers['content-length']) || null;
+	let downloaded = 0;
+
+	const progressStream = new Transform({
+		transform(chunk, encoding, callback) {
+			downloaded += chunk.length;
+
+			const percent = downloadBodySize ? downloaded / downloadBodySize : 0;
+
+			// Let flush() be responsible for emitting the last event
+			if (percent < 1) {
+				ee.emit('downloadProgress', {
+					percent,
+					transferred: downloaded,
+					total: downloadBodySize
+				});
+			}
+
+			callback(null, chunk);
+		},
+
+		flush(callback) {
+			ee.emit('downloadProgress', {
+				percent: 1,
+				transferred: downloaded,
+				total: downloadBodySize
+			});
+
+			callback();
+		}
+	});
+
+	mimicResponse(res, progressStream);
+	progressStream.redirectUrls = redirects;
+
+	const response = opts.decompress === true &&
+		is.function(decompressResponse) &&
+		opts.method !== 'HEAD' ? decompressResponse(progressStream) : progressStream;
+
+	if (!opts.decompress && ['gzip', 'deflate'].indexOf(res.headers['content-encoding']) !== -1) {
+		opts.encoding = null;
+	}
+
+	ee.emit('response', response);
+
+	ee.emit('downloadProgress', {
+		percent: 0,
+		transferred: 0,
+		total: downloadBodySize
+	});
+
+	res.pipe(progressStream);
 }
 
 function asPromise(opts) {

--- a/index.js
+++ b/index.js
@@ -146,56 +146,60 @@ function requestAsEventEmitter(opts) {
 			let downloaded = 0;
 
 			setImmediate(() => {
-				const progressStream = new Transform({
-					transform(chunk, encoding, callback) {
-						downloaded += chunk.length;
+				try {
+					const progressStream = new Transform({
+						transform(chunk, encoding, callback) {
+							downloaded += chunk.length;
 
-						const percent = downloadBodySize ? downloaded / downloadBodySize : 0;
+							const percent = downloadBodySize ? downloaded / downloadBodySize : 0;
 
-						// Let flush() be responsible for emitting the last event
-						if (percent < 1) {
+							// Let flush() be responsible for emitting the last event
+							if (percent < 1) {
+								ee.emit('downloadProgress', {
+									percent,
+									transferred: downloaded,
+									total: downloadBodySize
+								});
+							}
+
+							callback(null, chunk);
+						},
+
+						flush(callback) {
 							ee.emit('downloadProgress', {
-								percent,
+								percent: 1,
 								transferred: downloaded,
 								total: downloadBodySize
 							});
+
+							callback();
 						}
+					});
 
-						callback(null, chunk);
-					},
+					mimicResponse(res, progressStream);
+					progressStream.redirectUrls = redirects;
 
-					flush(callback) {
-						ee.emit('downloadProgress', {
-							percent: 1,
-							transferred: downloaded,
-							total: downloadBodySize
-						});
+					const response = opts.decompress === true &&
+						is.function(decompressResponse) &&
+						opts.method !== 'HEAD' ? decompressResponse(progressStream) : progressStream;
 
-						callback();
+					if (!opts.decompress && ['gzip', 'deflate'].indexOf(res.headers['content-encoding']) !== -1) {
+						opts.encoding = null;
 					}
+
+					ee.emit('response', response);
+
+					ee.emit('downloadProgress', {
+						percent: 0,
+						transferred: 0,
+						total: downloadBodySize
+					});
+
+					res.pipe(progressStream);
 				});
-
-				mimicResponse(res, progressStream);
-				progressStream.redirectUrls = redirects;
-
-				const response = opts.decompress === true &&
-					is.function(decompressResponse) &&
-					opts.method !== 'HEAD' ? decompressResponse(progressStream) : progressStream;
-
-				if (!opts.decompress && ['gzip', 'deflate'].indexOf(res.headers['content-encoding']) !== -1) {
-					opts.encoding = null;
-				}
-
-				ee.emit('response', response);
-
-				ee.emit('downloadProgress', {
-					percent: 0,
-					transferred: 0,
-					total: downloadBodySize
-				});
-
-				res.pipe(progressStream);
-			});
+			} catch (e) {
+				ee.emit('error', e);
+			}
 		});
 
 		cacheReq.on('error', err => {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 	},
 	"scripts": {
 		"test": "xo && nyc ava",
+		"xo:fix": "xo --fix",
 		"coveralls": "nyc report --reporter=text-lcov | coveralls"
 	},
 	"files": [
@@ -77,6 +78,7 @@
 		"nyc": "^11.0.2",
 		"p-event": "^1.3.0",
 		"pem": "^1.4.4",
+		"proxyquire": "^1.8.0",
 		"sinon": "^4.0.0",
 		"slow-stream": "0.0.4",
 		"tempfile": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
 	},
 	"scripts": {
 		"test": "xo && nyc ava",
-		"xo:fix": "xo --fix",
 		"coveralls": "nyc report --reporter=text-lcov | coveralls"
 	},
 	"files": [

--- a/test/error.js
+++ b/test/error.js
@@ -2,8 +2,8 @@ import http from 'http';
 import test from 'ava';
 import sinon from 'sinon';
 import proxyquire from 'proxyquire';
-import {createServer} from './helpers/server';
 import got from '..';
+import {createServer} from './helpers/server';
 
 let s;
 

--- a/test/error.js
+++ b/test/error.js
@@ -1,8 +1,9 @@
 import http from 'http';
 import test from 'ava';
 import sinon from 'sinon';
-import got from '..';
+import proxyquire from 'proxyquire';
 import {createServer} from './helpers/server';
+import got from '..';
 
 let s;
 
@@ -52,7 +53,7 @@ test('dns message', async t => {
 });
 
 test('options.body error message', async t => {
-	const err = await t.throws(got(s.url, {body: () => {}}));
+	const err = await t.throws(got(s.url, {body: () => { }}));
 	t.regex(err.message, /The `body` option must be a stream\.Readable, string, Buffer or plain Object/);
 });
 
@@ -76,6 +77,17 @@ test.serial('http.request error', async t => {
 	t.true(err instanceof got.RequestError);
 	t.is(err.message, 'The header content contains invalid characters');
 	stub.restore();
+});
+
+test.serial('catch error in mimicResponse', async t => {
+	const proxiedGot = proxyquire('..', {
+		'mimic-response'() {
+			throw new Error('Error in mimic-response');
+		}
+	});
+
+	const err = await t.throws(proxiedGot(s.url));
+	t.is(err.message, 'Error in mimic-response');
 });
 
 test.after('cleanup', async () => {

--- a/test/unix-socket.js
+++ b/test/unix-socket.js
@@ -8,35 +8,37 @@ const socketPath = tempy.file({extension: 'socket'});
 
 let s;
 
-test.before('setup', async () => {
-	s = await createServer();
+if (process.platform !== 'win32') {
+	test.before('setup', async () => {
+		s = await createServer();
 
-	s.on('/', (req, res) => {
-		res.end('ok');
+		s.on('/', (req, res) => {
+			res.end('ok');
+		});
+
+		s.on('/foo:bar', (req, res) => {
+			res.end('ok');
+		});
+
+		await s.listen(socketPath);
 	});
 
-	s.on('/foo:bar', (req, res) => {
-		res.end('ok');
+	test('works', async t => {
+		const url = format('http://unix:%s:%s', socketPath, '/');
+		t.is((await got(url)).body, 'ok');
 	});
 
-	await s.listen(socketPath);
-});
+	test('protocol-less works', async t => {
+		const url = format('unix:%s:%s', socketPath, '/');
+		t.is((await got(url)).body, 'ok');
+	});
 
-test('works', async t => {
-	const url = format('http://unix:%s:%s', socketPath, '/');
-	t.is((await got(url)).body, 'ok');
-});
+	test('address with : works', async t => {
+		const url = format('unix:%s:%s', socketPath, '/foo:bar');
+		t.is((await got(url)).body, 'ok');
+	});
 
-test('protocol-less works', async t => {
-	const url = format('unix:%s:%s', socketPath, '/');
-	t.is((await got(url)).body, 'ok');
-});
-
-test('address with : works', async t => {
-	const url = format('unix:%s:%s', socketPath, '/foo:bar');
-	t.is((await got(url)).body, 'ok');
-});
-
-test.after('cleanup', async () => {
-	await s.close();
-});
+	test.after('cleanup', async () => {
+		await s.close();
+	});
+}


### PR DESCRIPTION
If something goes wrong in the code contained by setImmediate, an uncaughtException is thrown.

The code in this pull requests wraps the code in a try/catch block and emits an error if an error is thrown.