### PR TITLE
Clear the progress interval if the socket has been destroyed

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,6 +200,7 @@ function requestAsEventEmitter(opts) {
 						progressInterval = setInterval(() => {
 							if (socket.destroyed) {
 								clearInterval(progressInterval);
+								return;
 							}
 							const lastUploaded = uploaded;
 							const headersSize = Buffer.byteLength(req._header);

--- a/index.js
+++ b/index.js
@@ -198,6 +198,9 @@ function requestAsEventEmitter(opts) {
 						const uploadEventFrequency = 150;
 
 						progressInterval = setInterval(() => {
+							if (socket.destroyed) {
+								clearInterval(progressInterval);
+							}
 							const lastUploaded = uploaded;
 							const headersSize = Buffer.byteLength(req._header);
 							uploaded = socket.bytesWritten - headersSize;

--- a/index.js
+++ b/index.js
@@ -202,6 +202,7 @@ function requestAsEventEmitter(opts) {
 								clearInterval(progressInterval);
 								return;
 							}
+
 							const lastUploaded = uploaded;
 							const headersSize = Buffer.byteLength(req._header);
 							uploaded = socket.bytesWritten - headersSize;

--- a/test/socket-destroyed.js
+++ b/test/socket-destroyed.js
@@ -1,0 +1,15 @@
+import test from 'ava';
+import got from '..';
+
+test.serial('Clear the progressInterval if the socket has been destroyed', async t => {
+	// There are 2 handles at this point
+	// const handleCount = process._getActiveHandles().length;
+
+	const err = await t.throws(got(`http://127.0.0.1:55555/`, {retry: 0}));
+	// Without the code from #469 there are 5 handles here. With #469's changes
+	// there are 4 handles. I can't figure out where the other two handles are
+	// getting creacted, so the best I can do is hard-code this 4 and hope someone
+	// else can figure out a better solution.
+	t.is(process._getActiveHandles().length, 4);
+	t.is(err.code, 'ECONNREFUSED');
+});

--- a/test/socket-destroyed.js
+++ b/test/socket-destroyed.js
@@ -1,15 +1,9 @@
 import test from 'ava';
 import got from '..';
 
-test.serial('Clear the progressInterval if the socket has been destroyed', async t => {
-	// There are 2 handles at this point
-	// const handleCount = process._getActiveHandles().length;
-
-	const err = await t.throws(got(`http://127.0.0.1:55555/`, {retry: 0}));
-	// Without the code from #469 there are 5 handles here. With #469's changes
-	// there are 4 handles. I can't figure out where the other two handles are
-	// getting creacted, so the best I can do is hard-code this 4 and hope someone
-	// else can figure out a better solution.
-	t.is(process._getActiveHandles().length, 4);
+test.serial('clear the progressInterval if the socket has been destroyed', async t => {
+	const handlesComingFromAVA = 2;
+	const err = await t.throws(got(`http://127.0.0.1:55555`, {retry: 0}));
+	t.is(process._getActiveHandles().length - handlesComingFromAVA, 2);
 	t.is(err.code, 'ECONNREFUSED');
 });


### PR DESCRIPTION
At work recently we ran into a problem where we used `got` in a script and the `progressInterval` is preventing node from being able to shut down.

If you make a request to a local server that is not running, [`req.once('error', ...`](https://github.com/sindresorhus/got/blob/7d1aa01e69229ad50ce355589681ff1d1a765627/index.js#L168) fires before [`req.once('request', ...`](https://github.com/sindresorhus/got/blob/7d1aa01e69229ad50ce355589681ff1d1a765627/index.js#L185). This causes the `progressInterval` to be cleared before it is set. Then `setInterval` gets called and your process will never exit. This is reliable using both `127.0.0.1` and my computer's local IP `192.168.1.165`. This does not trigger if you use the hostname `localhost`.

Because the result of this is that node just never exits, I don't know how to add this to your existing tests. I have this example that I just put in the root of the project to verify the bug and fix.

```js
// example.js
const got = require('./index.js')

got('http://127.0.0.1:55555', { retries: 0 })
.then(function (response) {
  console.log('response', response)
})
.catch(function (error) {
  console.log('error', error)
})
```

With the following local modifications for debugging

<details>
<summary>diff</summary>

```diff
diff --git a/index.js b/index.js
index 3cd9d09..ea2bc6a 100644
--- a/index.js
+++ b/index.js
@@ -166,6 +166,7 @@ function requestAsEventEmitter(opts) {
                        });
 
                        req.once('error', err => {
+                               console.log(`clearInterval(${progressInterval})`)
                                clearInterval(progressInterval);
 
                                if (aborted) {
@@ -197,6 +198,7 @@ function requestAsEventEmitter(opts) {
                                        const onSocketConnect = () => {
                                                const uploadEventFrequency = 150;
 
+                                               console.log('onSocketConnect')
                                                progressInterval = setInterval(() => {
                                                        if (socket.destroyed) {
                                                                clearInterval(progressInterval)

```

</details>

I get this output and the process hangs forever.

```
asa:~/repos/got$ node example.js 
clearInterval(undefined)
error { Error: connect ECONNREFUSED 127.0.0.1:55555
    at ClientRequest.req.once.err (/home/asa/repos/got/index.js:183:22)
    at Object.onceWrapper (events.js:316:30)
    at emitOne (events.js:115:13)
    at ClientRequest.emit (events.js:210:7)
    at Socket.socketErrorListener (_http_client.js:401:9)
    at emitOne (events.js:115:13)
    at Socket.emit (events.js:210:7)
    at emitErrorNT (internal/streams/destroy.js:64:8)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
  name: 'RequestError',
  code: 'ECONNREFUSED',
  host: '127.0.0.1:55555',
  hostname: '127.0.0.1',
  method: 'GET',
  path: '/',
  protocol: 'http:',
  url: 'http://127.0.0.1:55555/' }
onSocketConnect
```
