### PR TITLE
Use query-string instead of querystring

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const PassThrough = require('stream').PassThrough;
 const Transform = require('stream').Transform;
 const urlLib = require('url');
 const fs = require('fs');
-const querystring = require('querystring');
+const queryString = require('query-string');
 const CacheableRequest = require('cacheable-request');
 const duplexer3 = require('duplexer3');
 const intoStream = require('into-stream');
@@ -535,7 +535,7 @@ function normalizeArguments(url, opts) {
 
 	if (query) {
 		if (!is.string(query)) {
-			opts.query = querystring.stringify(query);
+			opts.query = queryString.stringify(query);
 		}
 
 		opts.path = `${opts.path.split('?')[0]}?${opts.query}`;
@@ -565,7 +565,7 @@ function normalizeArguments(url, opts) {
 			headers['content-type'] = headers['content-type'] || `multipart/form-data; boundary=${body.getBoundary()}`;
 		} else if (opts.form && canBodyBeStringified) {
 			headers['content-type'] = headers['content-type'] || 'application/x-www-form-urlencoded';
-			opts.body = querystring.stringify(body);
+			opts.body = queryString.stringify(body);
 		} else if (opts.json && canBodyBeStringified) {
 			headers['content-type'] = headers['content-type'] || 'application/json';
 			opts.body = JSON.stringify(body);

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"p-cancelable": "^0.4.0",
 		"p-timeout": "^2.0.1",
 		"pify": "^3.0.0",
-		"query-string": "^6.0.0",
+		"query-string": "^5.1.1",
 		"safe-buffer": "^5.1.1",
 		"timed-out": "^4.0.1",
 		"url-parse-lax": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
 		"p-cancelable": "^0.4.0",
 		"p-timeout": "^2.0.1",
 		"pify": "^3.0.0",
+		"query-string": "^6.0.0",
 		"safe-buffer": "^5.1.1",
 		"timed-out": "^4.0.1",
 		"url-parse-lax": "^3.0.0",


### PR DESCRIPTION
Since Node's native `querystring` is incompatible with RFC3986, possible conflict can happen with the letters `!*'()`.

Added query-string for more strict encoding instead of `querystring`.