### PR TITLE
Do not override `Accept-Encoding` header if already provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -527,8 +527,8 @@ function normalizeArguments(url, opts) {
 		'user-agent': `${pkg.name}/${pkg.version} (https://github.com/sindresorhus/got)`
 	}, headers);
 
-	if (opts.decompress) {
-		opts.headers['accept-encoding'] = 'gzip,deflate';
+	if (opts.decompress && opts.headers['accept-encoding'] == null) {
+		opts.headers['accept-encoding'] = 'gzip, deflate';
 	}
 
 	const query = opts.query;

--- a/index.js
+++ b/index.js
@@ -527,7 +527,7 @@ function normalizeArguments(url, opts) {
 		'user-agent': `${pkg.name}/${pkg.version} (https://github.com/sindresorhus/got)`
 	}, headers);
 
-	if (opts.decompress && opts.headers['accept-encoding'] == null) {
+	if (opts.decompress && !is.undefined(opts.headers['accept-encoding'])) {
 		opts.headers['accept-encoding'] = 'gzip, deflate';
 	}
 

--- a/index.js
+++ b/index.js
@@ -527,7 +527,7 @@ function normalizeArguments(url, opts) {
 		'user-agent': `${pkg.name}/${pkg.version} (https://github.com/sindresorhus/got)`
 	}, headers);
 
-	if (opts.decompress && !is.undefined(opts.headers['accept-encoding'])) {
+	if (opts.decompress && is.undefined(opts.headers['accept-encoding'])) {
 		opts.headers['accept-encoding'] = 'gzip, deflate';
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -195,7 +195,7 @@ request the resource pointed to in the location header via `GET`. This is in acc
 Type: `boolean`<br>
 Default: `true`
 
-Decompress the response automatically.
+Decompress the response automatically. This will set the `accept-encoding` header to `gzip, deflate` unless you set it yourself.
 
 If this is disabled, a compressed response is returned as a `Buffer`. This may be useful if you want to handle decompression yourself or stream the raw compressed data.
 

--- a/test/headers.js
+++ b/test/headers.js
@@ -24,7 +24,7 @@ test('user-agent', async t => {
 
 test('accept-encoding', async t => {
 	const headers = (await got(s.url, {json: true})).body;
-	t.is(headers['accept-encoding'], 'gzip,deflate');
+	t.is(headers['accept-encoding'], 'gzip, deflate');
 });
 
 test('do not set accept-encoding header when decompress options is false', async t => {

--- a/test/headers.js
+++ b/test/headers.js
@@ -27,6 +27,16 @@ test('accept-encoding', async t => {
 	t.is(headers['accept-encoding'], 'gzip, deflate');
 });
 
+test('do not override accept-encoding', async t => {
+	const headers = (await got(s.url, {
+		json: true,
+		headers: {
+			'accept-encoding': 'gzip'
+		}
+	})).body;
+	t.is(headers['accept-encoding'], 'gzip');
+});
+
 test('do not set accept-encoding header when decompress options is false', async t => {
 	const headers = (await got(s.url, {json: true, decompress: false})).body;
 	// TODO: Use `Reflect.has()` when we target Node.js 6


### PR DESCRIPTION
It's currently not possible to set the `Accept-Encoding` header to `gzip` only. We would like to do so because we've noticed some servers sending malformed `deflate` responses that Node is not able to inflate.