### PR TITLE
fix Buffer.byteLength(req._header) throwing error

### DIFF
--- a/index.js
+++ b/index.js
@@ -203,7 +203,7 @@ function requestAsEventEmitter(opts) {
 							}
 
 							const lastUploaded = uploaded;
-							const headersSize = Buffer.byteLength(req._header);
+							const headersSize = req._header ? Buffer.byteLength(req._header) : 0;
 							uploaded = socket.bytesWritten - headersSize;
 
 							// Prevent the known issue of `bytesWritten` being larger than body size


### PR DESCRIPTION
according to #458, `got` throws error in some cases when trying to pipe one `got.stream` into another one:

```bash
buffer.js:514
    throw new ERR_INVALID_ARG_TYPE(
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "string" argument must be one of type string, Buffer, or ArrayBuffer. Received type object
    at Function.byteLength (buffer.js:514:11)
    at Timeout.setInterval [as _onTimeout] (/Users/egorovli/Dev/project/api/node_modules/got/index.js:207:35)
    at ontimeout (timers.js:427:11)
    at tryOnTimeout (timers.js:289:5)
    at listOnTimeout (timers.js:252:5)
    at Timer.processTimers (timers.js:212:10)
```

this commit should fix this behavior, according to https://github.com/sindresorhus/got/issues/458#issuecomment-392847828