### PR TITLE
Improve the body error message when `{json: false}` and an object is passed

### DIFF
--- a/index.js
+++ b/index.js
@@ -564,7 +564,7 @@ function normalizeArguments(url, opts) {
 	} else {
 		const {headers} = opts;
 		if (!is.nodeStream(body) && !is.string(body) && !is.buffer(body) && !(opts.form || opts.json)) {
-			throw new TypeError('The `body` option must be a stream.Readable, string, Buffer or plain Object');
+			throw new TypeError('The `body` option must be a stream.Readable, string or Buffer');
 		}
 
 		const canBodyBeStringified = is.plainObject(body) || is.array(body);

--- a/test/error.js
+++ b/test/error.js
@@ -53,8 +53,18 @@ test('dns message', async t => {
 });
 
 test('options.body error message', async t => {
-	const err = await t.throws(got(s.url, {body: () => { }}));
-	t.regex(err.message, /The `body` option must be a stream\.Readable, string, Buffer or plain Object/);
+	const err = await t.throws(got(s.url, {body: {}}));
+	t.regex(err.message, /The `body` option must be a stream\.Readable, string or Buffer/);
+});
+
+test('options.body json error message', async t => {
+	const err = await t.throws(got(s.url, {body: Buffer.from('test'), json: true}));
+	t.regex(err.message, /The `body` option must be a plain Object or Array when the `form` or `json` option is used/);
+});
+
+test('options.body form error message', async t => {
+	const err = await t.throws(got(s.url, {body: Buffer.from('test'), form: true}));
+	t.regex(err.message, /The `body` option must be a plain Object or Array when the `form` or `json` option is used/);
 });
 
 test('default status message', async t => {


### PR DESCRIPTION
Currently if both the `form` and `json` options are both `false` and you pass a plain Object, the error tells you to pass a `stream.Readable, string, Buffer or plain Object` which I found confusing.

This change makes it so that you only get told to pass an plain Object if the `form` or `json` option is `true`.