### PR TITLE
Support discrete client configuration via `got.create([options])`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"cacheable-request": "^2.1.1",
 		"decompress-response": "^3.3.0",
 		"duplexer3": "^0.1.4",
+		"extend": "^3.0.1",
 		"get-stream": "^3.0.0",
 		"is-retry-allowed": "^1.1.0",
 		"isurl": "^1.0.0-alpha5",

--- a/readme.md
+++ b/readme.md
@@ -299,16 +299,17 @@ Configure a new `got` instance with default `options`:
 
 ```js
 (async () => {
-	const client = got.create({headers: {'X-Foo': 'bar'}})
-	let {body: {headers}} = await client.get('httpbin.org/headers', {json: true})
-	// ==> headers['X-Foo'] === 'bar'
+	const client = got.create({headers: {'x-foo': 'bar'}});
+	const {headers} = await client.get('httpbin.org/headers', {json: true}).body;
+	//=> headers['x-foo'] === 'bar'
 
-	const jsonClient = client.create({json: true, headers: {'X-Baz': 'qux'}})
-	let {body: {headers: h2}} = await jsonClient.get('httpbin.org/headers')
-	// ==> h2['X-Foo'] === 'bar'
-	// ==> h2['X-Baz'] === 'qux'
+	const jsonClient = client.create({json: true, headers: {'x-baz': 'qux'}});
+	const {headers: headers2} = await jsonClient.get('httpbin.org/headers').body;
+	//=> headers2['x-foo'] === 'bar'
+	//=> headers2['x-baz'] === 'qux'
 })();
 ```
+
 
 ## Errors
 

--- a/readme.md
+++ b/readme.md
@@ -291,6 +291,24 @@ If it's not possible to retrieve the body size (can happen when streaming), `tot
 
 Sets `options.method` to the method name and makes a request.
 
+#### Instances
+
+#### got.create([options])
+
+Configure a new `got` instance with default `options`:
+
+```js
+(async () => {
+	const client = got.create({headers: {'X-Foo': 'bar'}})
+	let {body: {headers}} = await client.get('httpbin.org/headers', {json: true})
+	// ==> headers['X-Foo'] === 'bar'
+
+	const jsonClient = client.create({json: true, headers: {'X-Baz': 'qux'}})
+	let {body: {headers: h2}} = await jsonClient.get('httpbin.org/headers')
+	// ==> h2['X-Foo'] === 'bar'
+	// ==> h2['X-Baz'] === 'qux'
+})();
+```
 
 ## Errors
 

--- a/test/create.js
+++ b/test/create.js
@@ -15,6 +15,10 @@ test.before('setup', async () => {
 	await s.listen(s.port);
 });
 
+test.after('cleanup', async () => {
+	await s.close();
+});
+
 test('preserve global defaults', async t => {
 	const globalHeaders = (await got(s.url, {json: true})).body;
 	const instanceHeaders = (await got.create()(s.url, {json: true})).body;
@@ -60,8 +64,4 @@ test('curry previous instance defaults', async t => {
 	const headers = (await instanceB(s.url, {json: true})).body;
 	t.is(headers['x-foo'], 'foo');
 	t.is(headers['x-bar'], 'bar');
-});
-
-test.after('cleanup', async () => {
-	await s.close();
 });

--- a/test/create.js
+++ b/test/create.js
@@ -1,0 +1,67 @@
+import test from 'ava';
+import got from '..';
+import {createServer} from './helpers/server';
+
+let s;
+
+test.before('setup', async () => {
+	s = await createServer();
+
+	s.on('/', (req, res) => {
+		req.resume();
+		res.end(JSON.stringify(req.headers));
+	});
+
+	await s.listen(s.port);
+});
+
+test('preserve global defaults', async t => {
+	const globalHeaders = (await got(s.url, {json: true})).body;
+	const instanceHeaders = (await got.create()(s.url, {json: true})).body;
+	t.deepEqual(instanceHeaders, globalHeaders);
+});
+
+test('support instance defaults', async t => {
+	const instance = got.create({
+		headers: {
+			'user-agent': 'custom-ua-string'
+		}
+	});
+	const headers = (await instance(s.url, {json: true})).body;
+	t.is(headers['user-agent'], 'custom-ua-string');
+});
+
+test('support invocation overrides', async t => {
+	const instance = got.create({
+		headers: {
+			'user-agent': 'custom-ua-string'
+		}
+	});
+	const headers = (await instance(s.url, {
+		json: true,
+		headers: {
+			'user-agent': 'different-ua-string'
+		}
+	})).body;
+	t.is(headers['user-agent'], 'different-ua-string');
+});
+
+test('curry previous instance defaults', async t => {
+	const instanceA = got.create({
+		headers: {
+			'x-foo': 'foo'
+		}
+	});
+	const instanceB = instanceA.create({
+		headers: {
+			'x-bar': 'bar'
+		}
+	});
+	const headers = (await instanceB(s.url, {json: true})).body;
+	t.is(headers['x-foo'], 'foo');
+	t.is(headers['x-bar'], 'bar');
+});
+
+test.after('cleanup', async () => {
+	await s.close();
+});


### PR DESCRIPTION
Add first-class support for discrete client configuration via new public `got.create([options])` method.

Feature is 100% backwards compatible and internal defaults have been refactored ever so slightly to dogfood the interface.

I did my best to adhere to existing code standards-- linted w/ `xo`, added tests to maintain coverage (statements + lines are slightly up, branches are slightly down), documented the method in `readme.md`, and tailored the commit message style to match the predominant pattern.

My first time contributing here so please let me know if there's anything else I can do to help! If y'all prefer to keep this out of core I'll understand and can publish elsewhere-- no hard feelings either way.

Thanks!