### PR TITLE
Make it possible to unset the default `user-agent` header

### DIFF
--- a/index.js
+++ b/index.js
@@ -528,16 +528,17 @@ function normalizeArguments(url, opts) {
 	};
 
 	const headers = lowercaseKeys(opts.headers);
+	if (!headers.hasOwnProperty('user-agent')) { // eslint-disable-line no-prototype-builtins
+		headers['user-agent'] = `${pkg.name}/${pkg.version} (https://github.com/sindresorhus/got)`;
+	}
+
 	for (const [key, value] of Object.entries(headers)) {
 		if (is.nullOrUndefined(value)) {
 			delete headers[key];
 		}
 	}
 
-	opts.headers = {
-		'user-agent': `${pkg.name}/${pkg.version} (https://github.com/sindresorhus/got)`,
-		...headers
-	};
+	opts.headers = headers;
 
 	if (opts.decompress && is.undefined(opts.headers['accept-encoding'])) {
 		opts.headers['accept-encoding'] = 'gzip, deflate';

--- a/index.js
+++ b/index.js
@@ -528,7 +528,7 @@ function normalizeArguments(url, opts) {
 	};
 
 	const headers = lowercaseKeys(opts.headers);
-	if (!headers.hasOwnProperty('user-agent')) { // eslint-disable-line no-prototype-builtins
+	if (!Object.keys(headers).includes('user-agent')) {
 		headers['user-agent'] = `${pkg.name}/${pkg.version} (https://github.com/sindresorhus/got)`;
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -105,6 +105,13 @@ Type: `Object`
 
 Any of the [`https.request`](https://nodejs.org/api/https.html#https_https_request_options_callback) options.
 
+###### headers
+
+Type: `Object`<br>
+Default: `{}`
+
+Add headers by specyfing this property. Existing headers will be overwritten.
+
 ###### stream
 
 Type: `boolean`<br>
@@ -616,7 +623,7 @@ const createTestServer = require('create-test-server');
 
 ### User Agent
 
-It's a good idea to set the `'user-agent'` header so the provider can more easily see how their resource is used. By default, it's the URL to this repo.
+It's a good idea to set the `'user-agent'` header so the provider can more easily see how their resource is used. By default, it's the URL to this repo. You can omit this header by setting it to `null` or `undefined`.
 
 ```js
 const got = require('got');
@@ -625,6 +632,12 @@ const pkg = require('./package.json');
 got('sindresorhus.com', {
 	headers: {
 		'user-agent': `my-module/${pkg.version} (https://github.com/username/my-module)`
+	}
+});
+
+got('sindresorhus.com', {
+	headers: {
+		'user-agent': null
 	}
 });
 ```

--- a/readme.md
+++ b/readme.md
@@ -110,7 +110,9 @@ Any of the [`https.request`](https://nodejs.org/api/https.html#https_https_reque
 Type: `Object`<br>
 Default: `{}`
 
-Add headers by specyfing this property. Existing headers will be overwritten.
+Specify this property to set HTTP headers. If already existing header is specified, the old one will be overwritten.
+
+Headers set to `null` or `undefined` are omitted.
 
 ###### stream
 

--- a/readme.md
+++ b/readme.md
@@ -110,9 +110,9 @@ Any of the [`https.request`](https://nodejs.org/api/https.html#https_https_reque
 Type: `Object`<br>
 Default: `{}`
 
-Specify this property to set HTTP headers. If already existing header is specified, the old one will be overwritten.
+Request headers.
 
-Headers set to `null` or `undefined` are omitted.
+Existing headers will be overwritten. Headers set to `null` or `undefined` will be omitted.
 
 ###### stream
 

--- a/test/headers.js
+++ b/test/headers.js
@@ -128,21 +128,21 @@ test('stream as options.body sets content-length', async t => {
 test('remove null value headers', async t => {
 	const {body} = await got(s.url, {
 		headers: {
-			unicorns: null
+			'user-agent': null
 		}
 	});
 	const headers = JSON.parse(body);
-	t.false(Reflect.has(headers, 'unicorns'));
+	t.false(Reflect.has(headers, 'user-agent'));
 });
 
 test('remove undefined value headers', async t => {
 	const {body} = await got(s.url, {
 		headers: {
-			unicorns: undefined
+			'user-agent': undefined
 		}
 	});
 	const headers = JSON.parse(body);
-	t.false(Reflect.has(headers, 'unicorns'));
+	t.false(Reflect.has(headers, 'user-agent'));
 });
 
 test.after('cleanup', async () => {


### PR DESCRIPTION
Fixes #485. To disable `user-agent` header set it to `null` or `undefined`.