### PR TITLE
Improve `headers` test reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 yarn.lock
 coverage
 .nyc_output
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ node_modules
 yarn.lock
 coverage
 .nyc_output
-.vscode

--- a/test/headers.js
+++ b/test/headers.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import util from 'util';
 import path from 'path';
 import test from 'ava';
 import FormData from 'form-data';
@@ -118,11 +119,13 @@ test('form-data sets content-length', async t => {
 });
 
 test('stream as options.body sets content-length', async t => {
+	const fixture = path.join(__dirname, 'fixtures/stream-content-length');
+	const {size} = await util.promisify(fs.stat)(fixture);
 	const {body} = await got(s.url, {
-		body: fs.createReadStream(path.join(__dirname, 'fixtures/stream-content-length'))
+		body: fs.createReadStream(fixture)
 	});
 	const headers = JSON.parse(body);
-	t.is(headers['content-length'], '9');
+	t.is(headers['content-length'], String(size));
 });
 
 test('remove null value headers', async t => {

--- a/test/headers.js
+++ b/test/headers.js
@@ -125,7 +125,7 @@ test('stream as options.body sets content-length', async t => {
 		body: fs.createReadStream(fixture)
 	});
 	const headers = JSON.parse(body);
-	t.is(headers['content-length'], String(size));
+	t.is(Number(headers['content-length']), size);
 });
 
 test('remove null value headers', async t => {


### PR DESCRIPTION
The fixture is 10 bytes on my machine. This updates the test to pull the size from disk, and compare that size to the header's value. This should make the test cross-platform compatible. 

![image](https://user-images.githubusercontent.com/4730164/42414302-632ca09a-8200-11e8-9f37-d9b1d2a1eacb.png)

This was the last failing test for me on Windows 10. All ✔️ now!
