### PR TITLE
Add `request` and `response` events to the Promise API

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -285,7 +285,7 @@ Progress events for uploading (sending request) and downloading (receiving respo
 
 If it's not possible to retrieve the body size (can happen when streaming), `total` will be `null`.
 
-**Note**: Progress events can also be used with promises.
+**Note**: Progress events, redirect events and request/response events can also be used with promises.
 
 ```js
 (async () => {

--- a/readme.md
+++ b/readme.md
@@ -245,6 +245,8 @@ If this is disabled, requests that encounter an error status code will be resolv
 
 #### Streams
 
+**Note**: Progress events, redirect events and request/response events can also be used with promises.
+
 #### got.stream(url, [options])
 
 Sets `options.stream` to `true`.
@@ -284,8 +286,6 @@ Progress events for uploading (sending request) and downloading (receiving respo
 ```
 
 If it's not possible to retrieve the body size (can happen when streaming), `total` will be `null`.
-
-**Note**: Progress events, redirect events and request/response events can also be used with promises.
 
 ```js
 (async () => {

--- a/source/as-promise.js
+++ b/source/as-promise.js
@@ -22,6 +22,8 @@ module.exports = options => {
 				req.abort();
 			}
 
+			proxy.emit('request', req);
+
 			onCancel(() => {
 				req.abort();
 			});
@@ -36,6 +38,8 @@ module.exports = options => {
 		});
 
 		emitter.on('response', async response => {
+			proxy.emit('response', response);
+
 			const stream = is.null(options.encoding) ? getStream.buffer(response) : getStream(response, options);
 
 			let data;

--- a/test/promise.js
+++ b/test/promise.js
@@ -1,0 +1,30 @@
+import test from 'ava';
+import {createServer} from './helpers/server';
+import got from '..';
+
+let s;
+
+test.before('setup', async () => {
+	s = await createServer();
+	s.on('/', (req, res) => {
+		res.statusCode = 200;
+		res.end();
+	});
+	await s.listen(s.port);
+});
+
+test('should emit request event as promise', async t => {
+	await got(s.url, {json: true}).on('request', () => {
+		t.pass();
+	});
+});
+
+test('should emit response event as promise', async t => {
+	await got(s.url, {json: true}).on('response', () => {
+		t.pass();
+	});
+});
+
+test.after('cleanup', async () => {
+	await s.close();
+});


### PR DESCRIPTION
Moved from #391.