### PR TITLE
Add tests for `url-to-options.js`

### DIFF
--- a/test/url-to-options.js
+++ b/test/url-to-options.js
@@ -1,0 +1,76 @@
+import url from 'url';
+import test from 'ava';
+import urlToOptions from '../source/url-to-options';
+
+const exampleURL = 'https://user:password@github.com:443/say?hello=world#bang';
+
+test('converts node legacy URL to options', t => {
+	const parsedURL = url.parse(exampleURL);
+	const options = urlToOptions(parsedURL);
+	const expected = {
+		hash: '#bang',
+		hostname: 'github.com',
+		href: exampleURL,
+		path: '/say?hello=world',
+		pathname: '/say',
+		port: 443,
+		protocol: 'https:',
+		search: '?hello=world'
+	};
+
+	t.deepEqual(options, expected);
+});
+
+test('converts URL to options', t => {
+	// TODO: Use the `URL` global when targeting Node.js 10
+	const parsedURL = new url.URL(exampleURL);
+	const options = urlToOptions(parsedURL);
+	const expected = {
+		auth: 'user:password',
+		hash: '#bang',
+		hostname: 'github.com',
+		href: 'https://user:password@github.com/say?hello=world#bang',
+		path: '/say?hello=world',
+		pathname: '/say',
+		protocol: 'https:',
+		search: '?hello=world'
+	};
+
+	t.deepEqual(options, expected);
+});
+
+test('converts IPv6 URL to options', t => {
+	const IPv6URL = 'https://[2001:cdba::3257:9652]:443/';
+	// TODO: Use the `URL` global when targeting Node.js 10
+	const parsedURL = new url.URL(IPv6URL);
+	const options = urlToOptions(parsedURL);
+	const expected = {
+		hash: '',
+		hostname: '2001:cdba::3257:9652',
+		href: 'https://[2001:cdba::3257:9652]/',
+		path: '/',
+		pathname: '/',
+		protocol: 'https:',
+		search: ''
+	};
+
+	t.deepEqual(options, expected);
+});
+
+test('only adds port to options for URLs with ports', t => {
+	const noPortURL = 'https://github.com/';
+	const parsedURL = new url.URL(noPortURL);
+	const options = urlToOptions(parsedURL);
+	const expected = {
+		hash: '',
+		hostname: 'github.com',
+		href: 'https://github.com/',
+		path: '/',
+		pathname: '/',
+		protocol: 'https:',
+		search: ''
+	};
+
+	t.deepEqual(options, expected);
+	t.false(Reflect.has(options, 'port'));
+});


### PR DESCRIPTION
One moment you're looking at how beautiful got has grown. The next you're submitting a PR to increase test coverage.

Not sure we want to take on these tests. The code it tests is copied from Node and more code means more maintenance. That said, I feel if you copy it, it's yours. Good to make sure it keeps working going forward I think.

If you disagree, feel free to close it. This was more for me than the users, though I do hope our users can get something out of it too 😁 .