### PR TITLE
Fix null search being appended to path when legacy parsing URL

### DIFF
--- a/source/url-to-options.js
+++ b/source/url-to-options.js
@@ -11,7 +11,7 @@ module.exports = url => {
 		href: url.href
 	};
 
-	if (url.port !== '') {
+	if (typeof url.port === 'string' && url.port.length > 0) {
 		options.port = Number(url.port);
 	}
 

--- a/source/url-to-options.js
+++ b/source/url-to-options.js
@@ -19,11 +19,7 @@ module.exports = url => {
 		options.auth = `${url.username}:${url.password}`;
 	}
 
-	if (is.null(url.search)) {
-		options.path = url.pathname;
-	} else {
-		options.path = `${url.pathname}${url.search}`;
-	}
+	options.path = is.null(url.search) ? url.pathname : `${url.pathname}${url.search}`;
 
 	return options;
 };

--- a/source/url-to-options.js
+++ b/source/url-to-options.js
@@ -8,7 +8,6 @@ module.exports = url => {
 		hash: url.hash,
 		search: url.search,
 		pathname: url.pathname,
-		path: `${url.pathname}${url.search}`,
 		href: url.href
 	};
 
@@ -18,6 +17,12 @@ module.exports = url => {
 
 	if (url.username || url.password) {
 		options.auth = `${url.username}:${url.password}`;
+	}
+
+	if (url.search === null) {
+		options.path = url.pathname;
+	} else {
+		options.path = `${url.pathname}${url.search}`;
 	}
 
 	return options;

--- a/source/url-to-options.js
+++ b/source/url-to-options.js
@@ -1,4 +1,5 @@
 'use strict';
+const is = require('@sindresorhus/is');
 
 // From: https://github.com/nodejs/node/blob/8476053c132fd9613aab547aba165190f8064254/lib/internal/url.js#L1318-L1340
 module.exports = url => {
@@ -11,7 +12,7 @@ module.exports = url => {
 		href: url.href
 	};
 
-	if (typeof url.port === 'string' && url.port.length > 0) {
+	if (is.string(url.port) && url.port.length > 0) {
 		options.port = Number(url.port);
 	}
 
@@ -19,7 +20,7 @@ module.exports = url => {
 		options.auth = `${url.username}:${url.password}`;
 	}
 
-	if (url.search === null) {
+	if (is.null(url.search)) {
 		options.path = url.pathname;
 	} else {
 		options.path = `${url.pathname}${url.search}`;

--- a/source/url-to-options.js
+++ b/source/url-to-options.js
@@ -1,7 +1,6 @@
 'use strict';
 const is = require('@sindresorhus/is');
 
-// From: https://github.com/nodejs/node/blob/8476053c132fd9613aab547aba165190f8064254/lib/internal/url.js#L1318-L1340
 module.exports = url => {
 	const options = {
 		protocol: url.protocol,

--- a/test/url-to-options.js
+++ b/test/url-to-options.js
@@ -1,0 +1,76 @@
+import url from 'url';
+import test from 'ava';
+import urlToOptions from '../source/url-to-options';
+
+const exampleURL = 'https://user:password@github.com:443/say?hello=world#bang';
+
+test('converts node legacy URL to options', t => {
+	const parsedURL = url.parse(exampleURL);
+	const options = urlToOptions(parsedURL);
+	const expected = {
+		hash: '#bang',
+		hostname: 'github.com',
+		href: exampleURL,
+		path: '/say?hello=world',
+		pathname: '/say',
+		port: 443,
+		protocol: 'https:',
+		search: '?hello=world'
+	};
+
+	t.deepEqual(options, expected);
+});
+
+test('converts URL to options', t => {
+	// TODO: Use the `URL` global when targeting Node.js 10
+	const parsedURL = new url.URL(exampleURL);
+	const options = urlToOptions(parsedURL);
+	const expected = {
+		auth: 'user:password',
+		hash: '#bang',
+		hostname: 'github.com',
+		href: 'https://user:password@github.com/say?hello=world#bang',
+		path: '/say?hello=world',
+		pathname: '/say',
+		protocol: 'https:',
+		search: '?hello=world'
+	};
+
+	t.deepEqual(options, expected);
+});
+
+test('converts IPv6 URL to options', t => {
+	const IPv6URL = 'https://[2001:cdba::3257:9652]:443/';
+	// TODO: Use the `URL` global when targeting Node.js 10
+	const parsedURL = new url.URL(IPv6URL);
+	const options = urlToOptions(parsedURL);
+	const expected = {
+		hash: '',
+		hostname: '2001:cdba::3257:9652',
+		href: 'https://[2001:cdba::3257:9652]/',
+		path: '/',
+		pathname: '/',
+		protocol: 'https:',
+		search: ''
+	};
+
+	t.deepEqual(options, expected);
+});
+
+test('only adds port to options for URLs with ports', t => {
+	const noPortURL = 'https://github.com/';
+	const parsedURL = new url.URL(noPortURL);
+	const options = urlToOptions(parsedURL);
+	const expected = {
+		hash: '',
+		hostname: 'github.com',
+		href: 'https://github.com/',
+		path: '/',
+		pathname: '/',
+		protocol: 'https:',
+		search: ''
+	};
+
+	t.deepEqual(options, expected);
+	t.false(Reflect.has(options, 'port'));
+});

--- a/test/url-to-options.js
+++ b/test/url-to-options.js
@@ -89,7 +89,26 @@ test('does not concat null search to path', t => {
 		href: 'https://github.com/',
 		path: '/',
 		pathname: '/',
-		port: 0,
+		protocol: 'https:',
+		search: null
+	};
+
+	t.deepEqual(options, expected);
+});
+
+test('does not add null port to options', t => {
+	const exampleURL = 'https://github.com/';
+	const parsedURL = url.parse(exampleURL);
+
+	t.is(parsedURL.port, null);
+
+	const options = urlToOptions(parsedURL);
+	const expected = {
+		hash: null,
+		hostname: 'github.com',
+		href: 'https://github.com/',
+		path: '/',
+		pathname: '/',
 		protocol: 'https:',
 		search: null
 	};

--- a/test/url-to-options.js
+++ b/test/url-to-options.js
@@ -2,9 +2,9 @@ import url from 'url';
 import test from 'ava';
 import urlToOptions from '../source/url-to-options';
 
-const exampleURL = 'https://user:password@github.com:443/say?hello=world#bang';
 
 test('converts node legacy URL to options', t => {
+	const exampleURL = 'https://user:password@github.com:443/say?hello=world#bang';
 	const parsedURL = url.parse(exampleURL);
 	const options = urlToOptions(parsedURL);
 	const expected = {
@@ -22,6 +22,7 @@ test('converts node legacy URL to options', t => {
 });
 
 test('converts URL to options', t => {
+	const exampleURL = 'https://user:password@github.com:443/say?hello=world#bang';
 	// TODO: Use the `URL` global when targeting Node.js 10
 	const parsedURL = new url.URL(exampleURL);
 	const options = urlToOptions(parsedURL);
@@ -73,4 +74,25 @@ test('only adds port to options for URLs with ports', t => {
 
 	t.deepEqual(options, expected);
 	t.false(Reflect.has(options, 'port'));
+});
+
+test('does not concat null search to path', t => {
+	const exampleURL = 'https://github.com/';
+	const parsedURL = url.parse(exampleURL);
+
+	t.is(parsedURL.search, null);
+
+	const options = urlToOptions(parsedURL);
+	const expected = {
+		hash: null,
+		hostname: 'github.com',
+		href: 'https://github.com/',
+		path: '/',
+		pathname: '/',
+		port: 0,
+		protocol: 'https:',
+		search: null
+	};
+
+	t.deepEqual(options, expected);
 });


### PR DESCRIPTION
This still needs to be rebased after #513 is merged. 