### PR TITLE
Fix: formatted query should be assigned to `options.search`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 	],
 	"dependencies": {
 		"@sindresorhus/is": "^0.9.0",
-		"cacheable-request": "^2.1.1",
+		"cacheable-request": "^4.0.1",
 		"decompress-response": "^3.3.0",
 		"duplexer3": "^0.1.4",
 		"extend": "^3.0.1",

--- a/test/arguments.js
+++ b/test/arguments.js
@@ -60,7 +60,21 @@ test('requestUrl with url.parse object as first argument', async t => {
 });
 
 test('overrides querystring from opts', async t => {
-	t.is((await got(`${s.url}/?test=doge`, {query: {test: 'wow'}})).body, '/?test=wow');
+	const response = await got(
+		`${s.url}/?drop=this`,
+		{
+			query: {test: 'wow'},
+			cache: {
+				get(key) {
+					t.is(key, `cacheable-request:GET:${s.url}/?test=wow`);
+				},
+				set(key) {
+					t.is(key, `cacheable-request:GET:${s.url}/?test=wow`);
+				}
+			}
+		}
+	);
+	t.is(response.body, '/?test=wow');
 });
 
 test('should throw with auth in url string', async t => {


### PR DESCRIPTION
cacheable-request uses url.format to construct the cache key.
url.format uses `pathname` and `search` when formatting the path.

fixes: #487 