### PR TITLE
Use events to wire upload tracking instead of racing with setImmediate

### DIFF
--- a/source/request-as-event-emitter.js
+++ b/source/request-as-event-emitter.js
@@ -91,13 +91,11 @@ module.exports = (options = {}) => {
 				return;
 			}
 
-			setImmediate(() => {
-				try {
-					getResponse(response, options, emitter, redirects);
-				} catch (error) {
-					emitter.emit('error', error);
-				}
-			});
+			try {
+				getResponse(response, options, emitter, redirects);
+			} catch (error) {
+				emitter.emit('error', error);
+			}
 		});
 
 		cacheReq.on('error', error => {
@@ -110,7 +108,7 @@ module.exports = (options = {}) => {
 
 		cacheReq.once('request', req => {
 			let aborted = false;
-			req.once('abort', _ => {
+			req.once('abort', () => {
 				aborted = true;
 			});
 
@@ -133,9 +131,7 @@ module.exports = (options = {}) => {
 				timedOut(req, options.gotTimeout);
 			}
 
-			setImmediate(() => {
-				emitter.emit('request', req);
-			});
+			emitter.emit('request', req);
 		});
 	};
 


### PR DESCRIPTION
I could not determine why `setImmediate` was being used to defer some of the statements in the event emitter wiring, other than the socket connection check, which can be safely done by subscribing to the right events.