### PR TITLE
Link to current docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,7 @@ A nicer interface to the built-in [`http`](http://nodejs.org/api/http.html) modu
 
 Created because [`request`](https://github.com/request/request) is bloated *(several megabytes!)*.
 
+*Looking for the [current npm got release docs](https://github.com/sindresorhus/got/blob/v8.3.2/readme.md)?*
 
 ## Highlights
 


### PR DESCRIPTION
I hadn't used got in a while. Saw the docs, many fancy updates looking great, but when it came time to use them, there were not implemented (in got 8.3.2). A tip at the top of the docs liking to current version might be helpful.