### PR TITLE
Customize timeouts and generally improve the whole thing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -188,7 +188,13 @@ Type: `number` `Object`
 
 Milliseconds to wait for the server to end the response before aborting request with `ETIMEDOUT` error (a.k.a. `request` property). By default there's no timeout.
 
-This also accepts an object with separate `connect`, `socket`, and `request` fields for connection, socket, and entire request timeouts.
+This also accepts an object with separate `lookup`, `connect`, `socket`, `response` and `request` fields to specify granular timeouts for each phase of the request.
+
+- `lookup` starts when a socket is assigned and ends when the hostname has been resolved. Does not apply when using a unix domain socket.
+- `connect` starts when `lookup` completes (or when the socket is assigned if lookup does not apply to the request) and ends when the socket is connected.
+- `socket` starts when the socket is connected. See [request.setTimeout](https://nodejs.org/api/http.html#http_request_settimeout_timeout_callback).
+- `response` starts when the socket is connected and ends when the response headers are received.
+- `request` starts when the request is initiated and ends when the response's end event fires.
 
 ###### retry
 

--- a/readme.md
+++ b/readme.md
@@ -190,7 +190,7 @@ Milliseconds to wait for the server to end the response before aborting request 
 
 This also accepts an object with separate `lookup`, `connect`, `socket`, `response` and `request` fields to specify granular timeouts for each phase of the request.
 
-- `lookup` starts when a socket is assigned and ends when the hostname has been resolved. Does not apply when using a unix domain socket.
+- `lookup` starts when a socket is assigned and ends when the hostname has been resolved. Does not apply when using a Unix domain socket.
 - `connect` starts when `lookup` completes (or when the socket is assigned if lookup does not apply to the request) and ends when the socket is connected.
 - `socket` starts when the socket is connected. See [request.setTimeout](https://nodejs.org/api/http.html#http_request_settimeout_timeout_callback).
 - `response` starts when the request has been written to the socket and ends when the response headers are received.

--- a/readme.md
+++ b/readme.md
@@ -193,7 +193,7 @@ This also accepts an object with separate `lookup`, `connect`, `socket`, `respon
 - `lookup` starts when a socket is assigned and ends when the hostname has been resolved. Does not apply when using a unix domain socket.
 - `connect` starts when `lookup` completes (or when the socket is assigned if lookup does not apply to the request) and ends when the socket is connected.
 - `socket` starts when the socket is connected. See [request.setTimeout](https://nodejs.org/api/http.html#http_request_settimeout_timeout_callback).
-- `response` starts when the socket is connected and ends when the response headers are received.
+- `response` starts when the request has been written to the socket and ends when the response headers are received.
 - `request` starts when the request is initiated and ends when the response's end event fires.
 
 ###### retry

--- a/readme.md
+++ b/readme.md
@@ -194,6 +194,7 @@ This also accepts an object with separate `lookup`, `connect`, `socket`, `respon
 - `connect` starts when `lookup` completes (or when the socket is assigned if lookup does not apply to the request) and ends when the socket is connected.
 - `socket` starts when the socket is connected. See [request.setTimeout](https://nodejs.org/api/http.html#http_request_settimeout_timeout_callback).
 - `response` starts when the request has been written to the socket and ends when the response headers are received.
+- `send` starts when the socket is connected and ends with the request has been written to the socket.
 - `request` starts when the request is initiated and ends when the response's end event fires.
 
 ###### retry

--- a/source/as-promise.js
+++ b/source/as-promise.js
@@ -24,17 +24,22 @@ module.exports = options => {
 
 			proxy.emit('request', req);
 
+			const uploadComplete = () => {
+				req.emit('upload-complete');
+			};
+
 			onCancel(() => {
 				req.abort();
 			});
 
 			if (is.nodeStream(options.body)) {
+				options.body.once('end', uploadComplete);
 				options.body.pipe(req);
 				options.body = undefined;
 				return;
 			}
 
-			req.end(options.body);
+			req.end(options.body, uploadComplete);
 		});
 
 		emitter.on('response', async response => {

--- a/source/as-stream.js
+++ b/source/as-stream.js
@@ -28,23 +28,28 @@ module.exports = options => {
 
 	emitter.on('request', req => {
 		proxy.emit('request', req);
+		const uploadComplete = () => {
+			req.emit('upload-complete');
+		};
 
 		if (is.nodeStream(options.body)) {
+			options.body.once('end', uploadComplete);
 			options.body.pipe(req);
 			return;
 		}
 
 		if (options.body) {
-			req.end(options.body);
+			req.end(options.body, uploadComplete);
 			return;
 		}
 
 		if (options.method === 'POST' || options.method === 'PUT' || options.method === 'PATCH') {
+			input.once('end', uploadComplete);
 			input.pipe(req);
 			return;
 		}
 
-		req.end();
+		req.end(uploadComplete);
 	});
 
 	emitter.on('response', response => {

--- a/source/errors.js
+++ b/source/errors.js
@@ -19,6 +19,7 @@ class GotError extends Error {
 			hostname: opts.hostname,
 			method: opts.method,
 			path: opts.path,
+			socketPath: opts.socketPath,
 			protocol: opts.protocol,
 			url: opts.href
 		});
@@ -86,6 +87,14 @@ module.exports.UnsupportedProtocolError = class extends GotError {
 	constructor(opts) {
 		super(`Unsupported protocol "${opts.protocol}"`, {}, opts);
 		this.name = 'UnsupportedProtocolError';
+	}
+};
+
+module.exports.TimeoutError = class extends GotError {
+	constructor(threshold, event, opts) {
+		super(`Timeout awaiting '${event}' for ${threshold}ms`, {code: 'ETIMEDOUT'}, opts);
+		this.name = 'TimeoutError';
+		this.event = event;
 	}
 };
 

--- a/source/timed-out.js
+++ b/source/timed-out.js
@@ -97,6 +97,26 @@ module.exports = function (req, options) {
 			}
 		});
 	}
+	if (delays.send !== undefined) {
+		req.once('socket', socket => {
+			const timeRequest = () => {
+				const cancelTimeout = addTimeout(
+					delays.send,
+					timeoutHandler,
+					'send'
+				);
+				cancelers.push(cancelTimeout);
+				return cancelTimeout;
+			};
+			if (socket.connecting) {
+				socket.once('connect', () => {
+					req.once('upload-complete', timeRequest());
+				});
+			} else {
+				req.once('upload-complete', timeRequest());
+			}
+		});
+	}
 	if (delays.response !== undefined) {
 		req.once('upload-complete', () => {
 			const cancelTimeout = addTimeout(

--- a/source/timed-out.js
+++ b/source/timed-out.js
@@ -1,79 +1,120 @@
 'use strict';
+const net = require('net');
+const {TimeoutError} = require('./errors');
 
-// Forked from https://github.com/floatdrop/timed-out
+const reentry = Symbol('reentry');
 
-module.exports = function (req, delays) {
-	if (req.timeoutTimer) {
-		return req;
-	}
-
-	const host = req._headers ? (' to ' + req._headers.host) : '';
-
-	function throwESOCKETTIMEDOUT() {
-		req.abort();
-		const e = new Error('Socket timed out on request' + host);
-		e.code = 'ESOCKETTIMEDOUT';
-		req.emit('error', e);
-	}
-
-	function throwETIMEDOUT() {
-		req.abort();
-		const e = new Error('Connection timed out on request' + host);
-		e.code = 'ETIMEDOUT';
-		req.emit('error', e);
-	}
-
-	if (delays.connect !== undefined) {
-		req.timeoutTimer = setTimeout(throwETIMEDOUT, delays.connect);
-	}
-
-	if (delays.request !== undefined) {
-		req.requestTimeoutTimer = setTimeout(() => {
-			clear();
-
-			if (req.connection.connecting) {
-				throwETIMEDOUT();
-			} else {
-				throwESOCKETTIMEDOUT();
+function addTimeout(delay, callback, ...args) {
+	// Event loop order is timers, poll, immediates.
+	// The timed event may emit during the current tick poll phase, so
+	// defer calling the handler until the poll phase completes.
+	let immediate;
+	const timeout = setTimeout(
+		() => {
+			immediate = setImmediate(callback, delay, ...args);
+			if (immediate.unref) {
+				// Added in node v9.7.0
+				immediate.unref();
 			}
-		}, delays.request);
+		},
+		delay
+	);
+	timeout.unref();
+	return () => {
+		clearTimeout(timeout);
+		clearImmediate(immediate);
+	};
+}
+
+module.exports = function (req, options) {
+	if (req[reentry]) {
+		return;
 	}
+	req[reentry] = true;
+	const {gotTimeout: delays, host, hostname} = options;
+	const timeoutHandler = (delay, event) => {
+		req.abort();
+		req.emit('error', new TimeoutError(delay, event, options));
+	};
+	const cancelers = [];
+	const cancelTimeouts = () => {
+		cancelers.forEach(cancelTimeout => cancelTimeout());
+	};
 
-	// Clear the connection timeout timer once a socket is assigned to the
-	// request and is connected.
-	req.on('socket', socket => {
-		// Socket may come from Agent pool and may be already connected.
-		if (!socket.connecting) {
-			connect();
-			return;
-		}
-
-		socket.once('connect', connect);
+	req.on('error', cancelTimeouts);
+	req.once('response', response => {
+		response.once('end', cancelTimeouts);
 	});
 
-	function clear() {
-		if (req.timeoutTimer) {
-			clearTimeout(req.timeoutTimer);
-			req.timeoutTimer = null;
-		}
+	if (delays.request !== undefined) {
+		const cancelTimeout = addTimeout(
+			delays.request,
+			timeoutHandler,
+			'request'
+		);
+		cancelers.push(cancelTimeout);
 	}
-
-	function connect() {
-		clear();
-
-		if (delays.socket !== undefined) {
-			// Abort the request if there is no activity on the socket for more
-			// than `delays.socket` milliseconds.
-			req.setTimeout(delays.socket, throwESOCKETTIMEDOUT);
-		}
-
-		req.on('response', res => {
-			res.on('end', () => {
-				// The request is finished, cancel request timeout.
-				clearTimeout(req.requestTimeoutTimer);
-			});
+	if (delays.socket !== undefined) {
+		req.setTimeout(
+			delays.socket,
+			() => {
+				timeoutHandler(delays.socket, 'socket');
+			}
+		);
+	}
+	if (delays.lookup !== undefined && !req.socketPath && !net.isIP(hostname || host)) {
+		req.once('socket', socket => {
+			if (socket.connecting) {
+				const cancelTimeout = addTimeout(
+					delays.lookup,
+					timeoutHandler,
+					'lookup'
+				);
+				cancelers.push(cancelTimeout);
+				socket.once('lookup', cancelTimeout);
+			}
 		});
 	}
-
-	return req.on('error', clear);
+	if (delays.connect !== undefined) {
+		req.once('socket', socket => {
+			if (socket.connecting) {
+				const timeConnect = () => {
+					const cancelTimeout = addTimeout(
+						delays.connect,
+						timeoutHandler,
+						'connect'
+					);
+					cancelers.push(cancelTimeout);
+					return cancelTimeout;
+				};
+				if (req.socketPath || net.isIP(hostname || host)) {
+					socket.once('connect', timeConnect());
+				} else {
+					socket.once('lookup', () => {
+						socket.once('connect', timeConnect());
+					});
+				}
+			}
+		});
+	}
+	if (delays.response !== undefined) {
+		req.once('socket', socket => {
+			const timeResponse = () => {
+				const cancelTimeout = addTimeout(
+					delays.response,
+					timeoutHandler,
+					'response'
+				);
+				cancelers.push(cancelTimeout);
+				return cancelTimeout;
+			};
+			if (socket.connecting) {
+				socket.once('connect', () => {
+					req.once('response', timeResponse());
+				});
+			} else {
+				req.once('response', timeResponse());
+			}
+		});
+	}
 };

--- a/source/timed-out.js
+++ b/source/timed-out.js
@@ -98,23 +98,14 @@ module.exports = function (req, options) {
 		});
 	}
 	if (delays.response !== undefined) {
-		req.once('socket', socket => {
-			const timeResponse = () => {
-				const cancelTimeout = addTimeout(
-					delays.response,
-					timeoutHandler,
-					'response'
-				);
-				cancelers.push(cancelTimeout);
-				return cancelTimeout;
-			};
-			if (socket.connecting) {
-				socket.once('connect', () => {
-					req.once('response', timeResponse());
-				});
-			} else {
-				req.once('response', timeResponse());
-			}
+		req.once('upload-complete', () => {
+			const cancelTimeout = addTimeout(
+				delays.response,
+				timeoutHandler,
+				'response'
+			);
+			cancelers.push(cancelTimeout);
+			return cancelTimeout;
 		});
 	}
 };

--- a/source/timed-out.js
+++ b/source/timed-out.js
@@ -125,7 +125,7 @@ module.exports = function (req, options) {
 				'response'
 			);
 			cancelers.push(cancelTimeout);
-			return cancelTimeout;
+			req.once('response', cancelTimeout);
 		});
 	}
 };

--- a/test/retry.js
+++ b/test/retry.js
@@ -10,7 +10,7 @@ let fifth = 0;
 let lastTried413access = Date.now();
 
 const retryAfterOn413 = 2;
-const socketTimeout = 100;
+const socketTimeout = 200;
 
 test.before('setup', async () => {
 	s = await createServer();

--- a/test/retry.js
+++ b/test/retry.js
@@ -10,7 +10,6 @@ let fifth = 0;
 let lastTried413access = Date.now();
 
 const retryAfterOn413 = 2;
-const connectTimeout = 500;
 const socketTimeout = 100;
 
 test.before('setup', async () => {
@@ -69,12 +68,12 @@ test.before('setup', async () => {
 });
 
 test('works on timeout error', async t => {
-	t.is((await got(`${s.url}/knock-twice`, {timeout: {connect: connectTimeout, socket: socketTimeout}})).body, 'who`s there?');
+	t.is((await got(`${s.url}/knock-twice`, {timeout: {socket: socketTimeout}})).body, 'who`s there?');
 });
 
 test('can be disabled with option', async t => {
 	const err = await t.throws(got(`${s.url}/try-me`, {
-		timeout: {connect: connectTimeout, socket: socketTimeout},
+		timeout: {socket: socketTimeout},
 		retry: 0
 	}));
 	t.truthy(err);
@@ -83,7 +82,7 @@ test('can be disabled with option', async t => {
 
 test('function gets iter count', async t => {
 	await got(`${s.url}/fifth`, {
-		timeout: {connect: connectTimeout, socket: socketTimeout},
+		timeout: {socket: socketTimeout},
 		retry: {
 			retries: iteration => iteration < 10
 		}
@@ -93,7 +92,7 @@ test('function gets iter count', async t => {
 
 test('falsy value prevents retries', async t => {
 	const err = await t.throws(got(`${s.url}/long`, {
-		timeout: {connect: connectTimeout, socket: socketTimeout},
+		timeout: {socket: socketTimeout},
 		retry: {
 			retries: () => 0
 		}
@@ -103,7 +102,7 @@ test('falsy value prevents retries', async t => {
 
 test('falsy value prevents retries #2', async t => {
 	const err = await t.throws(got(`${s.url}/long`, {
-		timeout: {connect: connectTimeout, socket: socketTimeout},
+		timeout: {socket: socketTimeout},
 		retry: {
 			retries: (iter, err) => {
 				t.truthy(err);

--- a/test/timeout.js
+++ b/test/timeout.js
@@ -78,6 +78,19 @@ test('socket timeout', async t => {
 	);
 });
 
+test('send timeout', async t => {
+	await t.throws(
+		got(s.url, {
+			timeout: {send: 1},
+			retry: 0
+		}),
+		{
+			...errorMatcher,
+			message: `Timeout awaiting 'send' for 1ms`
+		}
+	);
+});
+
 test('response timeout', async t => {
 	await t.throws(
 		got(s.url, {

--- a/test/timeout.js
+++ b/test/timeout.js
@@ -139,7 +139,7 @@ test('connect timeout', async t => {
 test('connect timeout (ip address)', async t => {
 	await t.throws(
 		got({
-			hostname: s.address().address,
+			hostname: '127.0.0.1',
 			port: s.port,
 			createConnection: options => {
 				const socket = new net.Socket(options);
@@ -176,7 +176,7 @@ test('lookup timeout', async t => {
 
 test('lookup timeout no error (ip address)', async t => {
 	await got({
-		hostname: s.address().address,
+		hostname: '127.0.0.1',
 		port: s.port
 	}, {
 		timeout: {lookup: 100},


### PR DESCRIPTION
- Refactor timed-out to optimistically defer errors until after the poll
  phase of the current event loop tick.
- Timeouts begin and end when their respective phase of the lifecycle
  begins and ends.
- Timeouts result in a `got.TimeoutError`

This includes the controversial  change discussed in #525: removal of `setImmediate` around response handling and the addition of `setImmediate` in the timeout handling. Those change are not strictly required and can be reverted if necessary and everything in this PR will still work.