### PR TITLE
docs: DRY the timeout object section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -186,7 +186,7 @@ Query string object that will be added to the request URL. This will override th
 
 Type: `number` `Object`
 
-Milliseconds to wait for the server to end the response before aborting request with `ETIMEDOUT` error (a.k.a. `request` property). By default there's no timeout.
+Milliseconds to wait for the server to end the response before aborting request with [`got.TimeoutError`](#gottimeouterror) error (a.k.a. `request` property). By default there's no timeout.
 
 This also accepts an `object` with the following fields to constrain the duration of each phase of the request lifecycle:
 
@@ -455,6 +455,9 @@ When given an unsupported protocol.
 
 When the request is aborted with `.cancel()`.
 
+#### got.TimeoutError
+
+When the request is aborted due to a [timeout](#timeout)
 
 ## Aborting the request
 

--- a/readme.md
+++ b/readme.md
@@ -188,7 +188,7 @@ Type: `number` `Object`
 
 Milliseconds to wait for the server to end the response before aborting request with `ETIMEDOUT` error (a.k.a. `request` property). By default there's no timeout.
 
-This also accepts an object with separate `lookup`, `connect`, `socket`, `response` and `request` fields to specify granular timeouts for each phase of the request.
+This also accepts an `object` with the following fields to constrain the duration of each phase of the request lifecycle:
 
 - `lookup` starts when a socket is assigned and ends when the hostname has been resolved. Does not apply when using a Unix domain socket.
 - `connect` starts when `lookup` completes (or when the socket is assigned if lookup does not apply to the request) and ends when the socket is connected.
@@ -412,7 +412,7 @@ Extends parent options. Avoid using [object spread](https://developer.mozilla.or
 ```js
 const a = {headers: {cat: 'meow'}};
 const b = {headers: {dog: 'woof'}};
- 
+
 {...a, ...b}            // => {headers: {dog: 'woof'}}
 got.assignOptions(a, b) // => {headers: {cat: 'meow', dog: 'woof'}}
 ```


### PR DESCRIPTION
I noticed that `send` was not in the first list, then realized we probably don't need to enumerate the object keys twice.