### PR TITLE
Fix throwing errors when using got.stream()

### DIFF
--- a/source/create.js
+++ b/source/create.js
@@ -20,7 +20,11 @@ const create = defaults => {
 			options = mergeOptions(defaults.options, options);
 			return defaults.handler(normalizeArguments(url, options, defaults), next);
 		} catch (error) {
-			return Promise.reject(error);
+			if (options.stream) {
+				throw error;
+			} else {
+				return Promise.reject(error);
+			}
 		}
 	}
 

--- a/test/error.js
+++ b/test/error.js
@@ -133,3 +133,9 @@ test.serial('catch error in mimicResponse', async t => {
 
 	await t.throws(proxiedGot(s.url), {message: 'Error in mimic-response'});
 });
+
+test('errors are thrown directly when options.stream is true', t => {
+	t.throws(() => got(s.url, {stream: true, body: {}}), {
+		message: 'The `body` option must be a stream.Readable, string or Buffer'
+	});
+});


### PR DESCRIPTION
If normalizing arguments throws and using `got.stream()`, it'd return a rejecting promise. This PR fixes that.