### PR TITLE
Ignore empty query objects

### DIFF
--- a/source/normalize-arguments.js
+++ b/source/normalize-arguments.js
@@ -68,14 +68,15 @@ module.exports = (url, options, defaults) => {
 	}
 
 	const {query} = options;
-	if (query) {
+	if (!is.empty(query)) {
 		if (!is.string(query)) {
 			options.query = (new URLSearchParamsGlobal(query)).toString();
 		}
 
 		options.path = `${options.path.split('?')[0]}?${options.query}`;
-		delete options.query;
 	}
+
+	delete options.query;
 
 	if (options.json && is.undefined(options.headers.accept)) {
 		options.headers.accept = 'application/json';

--- a/test/arguments.js
+++ b/test/arguments.js
@@ -99,6 +99,10 @@ test('overrides querystring from opts', async t => {
 	t.is(response.body, '/?test=wow');
 });
 
+test('should ignore empty query object', async t => {
+	t.is((await got(`${s.url}/test`, {query: {}})).requestUrl, `${s.url}/test`);
+});
+
 test('should throw with auth in url string', async t => {
 	const error = await t.throwsAsync(got('https://test:45d3ps453@account.myservice.com/api/token'));
 	t.regex(error.message, /Basic authentication must be done with the `auth` option/);


### PR DESCRIPTION
- Checks query value with `is.empty()`
- Moves `delete` out to so it is always cleaned up from options
---
Closes #567 