### PR TITLE
Add ability to pass a custom request function

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -266,6 +266,13 @@ Default: `false`
 
 [Cache adapter instance](#cache-adapters) for storing cached data.
 
+###### request
+
+Type: `Function`<br>
+Default: `http.request` `https.request`
+
+Custom request function. By default it's `http.request` or `https.request` (depending on the protocol).
+
 ###### useElectronNet
 
 Type: `boolean`<br>

--- a/readme.md
+++ b/readme.md
@@ -814,12 +814,27 @@ const custom = got.extend({
 
 *Need to merge some instances into a single one? Check out [`got.mergeInstances()`](advanced-creation.md#merging-instances).*
 
+### Experimental HTTP2 support
+
+Got provides an experimental support for HTTP2 using the [`http2-wrapper`](https://github.com/szmarczak/http2-wrapper) module:
+
+```js
+const got = require('got');
+const {request} = require('http2-wrapper');
+
+const h2got = got.extend({request});
+
+(async () => {
+	const {body} = await h2got('https://nghttp2.org/httpbin/headers');
+	console.log(body);
+})();
+```
 
 ## Comparison
 
 |                       |  `got`  | `request` | `node-fetch` | `axios` |
 |-----------------------|:-------:|:---------:|:------------:|:-------:|
-| HTTP/2 support        |    ✖    |     ✖    |       ✖      |    ✖   |
+| HTTP/2 support        |    ❔    |     ✖    |       ✖      |    ✖   |
 | Browser support       |    ✖    |     ✖    |       ✔*     |    ✔   |
 | Electron support      |    ✔    |     ✖    |       ✖      |    ✖   |
 | Promise API           |    ✔    |     ✔    |       ✔      |    ✔   |
@@ -844,7 +859,8 @@ const custom = got.extend({
 | Dependents            | ![][gdp] | ![][rdp] |   ![][ndp]   | ![][adp] |
 | Install size          | ![][gis] | ![][ris] |   ![][nis]   | ![][ais] |
 
-\* It's almost API compatible with the browser `fetch` API.
+\* It's almost API compatible with the browser `fetch` API.<br>
+❔ Experimental support.
 
 <!-- ISSUES OPEN -->
 [gio]: https://img.shields.io/github/issues/sindresorhus/got.svg

--- a/readme.md
+++ b/readme.md
@@ -271,7 +271,7 @@ Default: `false`
 Type: `Function`<br>
 Default: `http.request` `https.request` *(depending on the protocol)*
 
-Custom request function.
+Custom request function. The main purpose of this ability is to [support HTTP2 using a wrapper](#experimental-http2-support).
 
 ###### useElectronNet
 

--- a/readme.md
+++ b/readme.md
@@ -271,7 +271,7 @@ Default: `false`
 Type: `Function`<br>
 Default: `http.request` `https.request` *(depending on the protocol)*
 
-Custom request function. The main purpose of this ability is to [support HTTP2 using a wrapper](#experimental-http2-support).
+Custom request function. The main purpose of this is to [support HTTP2 using a wrapper](#experimental-http2-support).
 
 ###### useElectronNet
 

--- a/readme.md
+++ b/readme.md
@@ -269,9 +269,9 @@ Default: `false`
 ###### request
 
 Type: `Function`<br>
-Default: `http.request` `https.request`
+Default: `http.request` `https.request` *(depending on the protocol)*
 
-Custom request function. By default it's `http.request` or `https.request` (depending on the protocol).
+Custom request function.
 
 ###### useElectronNet
 

--- a/source/request-as-event-emitter.js
+++ b/source/request-as-event-emitter.js
@@ -33,7 +33,7 @@ module.exports = options => {
 		}
 
 		let fn;
-		if (options.fn) {
+		if (options._requestFunction) {
 			fn = options.fn; // eslint-disable-line prefer-destructuring
 		} else {
 			fn = options.protocol === 'https:' ? https : http;

--- a/source/request-as-event-emitter.js
+++ b/source/request-as-event-emitter.js
@@ -33,8 +33,8 @@ module.exports = options => {
 		}
 
 		let fn;
-		if (options._requestFunction) {
-			fn = options.fn; // eslint-disable-line prefer-destructuring
+		if (is.function(options.request)) {
+			fn = {request: options.request};
 		} else {
 			fn = options.protocol === 'https:' ? https : http;
 		}

--- a/source/request-as-event-emitter.js
+++ b/source/request-as-event-emitter.js
@@ -32,7 +32,12 @@ module.exports = options => {
 			return;
 		}
 
-		let fn = options.protocol === 'https:' ? https : http;
+		let fn;
+		if (options.fn) {
+			fn = options.fn; // eslint-disable-line prefer-destructuring
+		} else {
+			fn = options.protocol === 'https:' ? https : http;
+		}
 
 		if (agents) {
 			const protocolName = options.protocol === 'https:' ? 'https' : 'http';

--- a/test/create.js
+++ b/test/create.js
@@ -177,7 +177,7 @@ test('ability to pass a custom request lib', async t => {
 		}
 	};
 
-	const instance = got.extend({fn: lib});
+	const instance = got.extend({_requestFunction: lib});
 	await instance(s.url);
 
 	t.true(called);

--- a/test/create.js
+++ b/test/create.js
@@ -166,3 +166,19 @@ test('defaults are cloned on instance creation', t => {
 	t.not(options.foo, instance.defaults.options.foo);
 	t.not(options.hooks.beforeRequest, instance.defaults.options.hooks.beforeRequest);
 });
+
+test('ability to pass a custom request lib', async t => {
+	let called = false;
+
+	const lib = {
+		request: (...args) => {
+			called = true;
+			return http.request(...args);
+		}
+	};
+
+	const instance = got.extend({fn: lib});
+	await instance(s.url);
+
+	t.true(called);
+});

--- a/test/create.js
+++ b/test/create.js
@@ -170,14 +170,12 @@ test('defaults are cloned on instance creation', t => {
 test('ability to pass a custom request library', async t => {
 	let called = false;
 
-	const library = {
-		request: (...args) => {
-			called = true;
-			return http.request(...args);
-		}
+	const request = (...args) => {
+		called = true;
+		return http.request(...args);
 	};
 
-	const instance = got.extend({_requestFunction: library});
+	const instance = got.extend({request});
 	await instance(s.url);
 
 	t.true(called);

--- a/test/create.js
+++ b/test/create.js
@@ -167,7 +167,7 @@ test('defaults are cloned on instance creation', t => {
 	t.not(options.hooks.beforeRequest, instance.defaults.options.hooks.beforeRequest);
 });
 
-test('ability to pass a custom request library', async t => {
+test('ability to pass a custom request method', async t => {
 	let called = false;
 
 	const request = (...args) => {

--- a/test/create.js
+++ b/test/create.js
@@ -167,17 +167,17 @@ test('defaults are cloned on instance creation', t => {
 	t.not(options.hooks.beforeRequest, instance.defaults.options.hooks.beforeRequest);
 });
 
-test('ability to pass a custom request lib', async t => {
+test('ability to pass a custom request library', async t => {
 	let called = false;
 
-	const lib = {
+	const library = {
 		request: (...args) => {
 			called = true;
 			return http.request(...args);
 		}
 	};
 
-	const instance = got.extend({_requestFunction: lib});
+	const instance = got.extend({_requestFunction: library});
 	await instance(s.url);
 
 	t.true(called);


### PR DESCRIPTION
This would allow an experimental support of http2 using [`http2-wrapper`](https://github.com/szmarczak/http2-wrapper):

```js
const got = require('got');
const wrapper = require('http2-wrapper');

const h2got = got.extend({fn: wrapper});

(async () => {
	const {body} = await h2got('https://nghttp2.org/httpbin/headers');
	console.log(body);
})();
```