### PR TITLE
Set `content-length` header to zero when doing a PUT request with no body

### DIFF
--- a/source/request-as-event-emitter.js
+++ b/source/request-as-event-emitter.js
@@ -162,12 +162,10 @@ module.exports = options => {
 		try {
 			uploadBodySize = await getBodySize(options);
 
-			if (
-				uploadBodySize > 0 &&
-				is.undefined(options.headers['content-length']) &&
-				is.undefined(options.headers['transfer-encoding'])
-			) {
-				options.headers['content-length'] = uploadBodySize;
+			if (is.undefined(options.headers['content-length']) && is.undefined(options.headers['transfer-encoding'])) {
+				if (uploadBodySize > 0 || options.method === 'PUT') {
+					options.headers['content-length'] = uploadBodySize;
+				}
 			}
 
 			for (const hook of options.hooks.beforeRequest) {

--- a/test/headers.js
+++ b/test/headers.js
@@ -80,12 +80,20 @@ test('transform names to lowercase', async t => {
 	t.is(headers['user-agent'], 'test');
 });
 
-test('zero content-length', async t => {
+test('setting content-length to 0', async t => {
 	const {body} = await got(s.url, {
 		headers: {
 			'content-length': 0
 		},
 		body: 'sup'
+	});
+	const headers = JSON.parse(body);
+	t.is(headers['content-length'], '0');
+});
+
+test('sets content-length to 0 when requesting PUT with empty body', async t => {
+	const {body} = await got(s.url, {
+		method: 'PUT'
 	});
 	const headers = JSON.parse(body);
 	t.is(headers['content-length'], '0');


### PR DESCRIPTION
Fixes #582