### PR TITLE
Gracefully handle invalid `Location` redirect URLs

### DIFF
--- a/source/request-as-event-emitter.js
+++ b/source/request-as-event-emitter.js
@@ -122,6 +122,7 @@ module.exports = options => {
 				const bufferString = Buffer.from(response.headers.location, 'binary').toString();
 
 				try {
+					// Handles invalid URLs. See https://github.com/sindresorhus/got/issues/604
 					redirectUrl = (new URL(bufferString, urlLib.format(options))).toString();
 					decodeURI(redirectUrl);
 				} catch (error) {

--- a/source/request-as-event-emitter.js
+++ b/source/request-as-event-emitter.js
@@ -120,9 +120,9 @@ module.exports = options => {
 				}
 
 				const bufferString = Buffer.from(response.headers.location, 'binary').toString();
-				redirectUrl = (new URL(bufferString, urlLib.format(options))).toString();
 
 				try {
+					redirectUrl = (new URL(bufferString, urlLib.format(options))).toString();
 					decodeURI(redirectUrl);
 				} catch (error) {
 					emitter.emit('error', error);

--- a/test/redirects.js
+++ b/test/redirects.js
@@ -110,6 +110,13 @@ test.before('setup', async () => {
 		response.end();
 	});
 
+	http.on('/invalidRedirect', (request, response) => {
+		response.writeHead(302, {
+			location: 'http://'
+		});
+		response.end();
+	});
+
 	await http.listen(http.port);
 	await https.listen(https.port);
 });
@@ -205,4 +212,9 @@ test('redirect response contains UTF-8 with URI encoding', async t => {
 test('throws on malformed redirect URI', async t => {
 	const error = await t.throwsAsync(got(`${http.url}/malformedRedirect`));
 	t.is(error.name, 'URIError');
+});
+
+test('throws on invalid redirect URL', async t => {
+	const error = await t.throwsAsync(got(`${http.url}/invalidRedirect`));
+	t.is(error.code, 'ERR_INVALID_URL');
 });


### PR DESCRIPTION
- Move `new URL` into existing `try...catch` block to gracefully handle failures
- Add test for `ERR_INVALID_URL`

h/t to @alextes for his initial research. 

---
Closes #604 