### PR TITLE
Include `body` property in `HTTPError`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -541,7 +541,7 @@ Options are deeply merged to a new object. The value of each key is determined a
 
 ## Errors
 
-Each error contains (if available) `statusCode`, `statusMessage`, `host`, `hostname`, `method`, `path`, `protocol` and `url` properties to make debugging easier.
+Each error contains (if available) `body`, `statusCode`, `statusMessage`, `host`, `hostname`, `method`, `path`, `protocol` and `url` properties to make debugging easier.
 
 In Promise mode, the `response` is attached to the error.
 

--- a/source/as-promise.js
+++ b/source/as-promise.js
@@ -74,7 +74,7 @@ module.exports = options => {
 			}
 
 			if (statusCode !== 304 && (statusCode < 200 || statusCode > limitStatusCode)) {
-				const error = new HTTPError(statusCode, response.statusMessage, response.headers, response.body, options);
+				const error = new HTTPError(response, options);
 				Object.defineProperty(error, 'response', {value: response});
 				emitter.emit('retry', error, retried => {
 					if (!retried) {

--- a/source/as-promise.js
+++ b/source/as-promise.js
@@ -74,7 +74,7 @@ module.exports = options => {
 			}
 
 			if (statusCode !== 304 && (statusCode < 200 || statusCode > limitStatusCode)) {
-				const error = new HTTPError(statusCode, response.statusMessage, response.headers, options);
+				const error = new HTTPError(statusCode, response.statusMessage, response.headers, response.body, options);
 				Object.defineProperty(error, 'response', {value: response});
 				emitter.emit('retry', error, retried => {
 					if (!retried) {

--- a/source/as-stream.js
+++ b/source/as-stream.js
@@ -56,7 +56,7 @@ module.exports = options => {
 		});
 
 		if (options.throwHttpErrors && statusCode !== 304 && (statusCode < 200 || statusCode > 299)) {
-			proxy.emit('error', new HTTPError(statusCode, response.statusMessage, response.headers, response.body, options), null, response);
+			proxy.emit('error', new HTTPError(response, options), null, response);
 			return;
 		}
 

--- a/source/as-stream.js
+++ b/source/as-stream.js
@@ -56,7 +56,7 @@ module.exports = options => {
 		});
 
 		if (options.throwHttpErrors && statusCode !== 304 && (statusCode < 200 || statusCode > 299)) {
-			proxy.emit('error', new HTTPError(statusCode, response.statusMessage, response.headers, options), null, response);
+			proxy.emit('error', new HTTPError(statusCode, response.statusMessage, response.headers, response.body, options), null, response);
 			return;
 		}
 

--- a/source/errors.js
+++ b/source/errors.js
@@ -59,9 +59,9 @@ module.exports.ParseError = class extends GotError {
 };
 
 module.exports.HTTPError = class extends GotError {
-	constructor(request, opts) {
-		const {statusCode} = request;
-		let {statusMessage} = request;
+	constructor(response, opts) {
+		const {statusCode} = response;
+		let {statusMessage} = response;
 
 		if (statusMessage) {
 			statusMessage = statusMessage.replace(/\r?\n/g, ' ').trim();
@@ -72,8 +72,8 @@ module.exports.HTTPError = class extends GotError {
 		this.name = 'HTTPError';
 		this.statusCode = statusCode;
 		this.statusMessage = statusMessage;
-		this.headers = request.headers;
-		this.body = request.body;
+		this.headers = response.headers;
+		this.body = response.body;
 	}
 };
 

--- a/source/errors.js
+++ b/source/errors.js
@@ -59,7 +59,7 @@ module.exports.ParseError = class extends GotError {
 };
 
 module.exports.HTTPError = class extends GotError {
-	constructor(statusCode, statusMessage, headers, opts) {
+	constructor(statusCode, statusMessage, headers, body, opts) {
 		if (statusMessage) {
 			statusMessage = statusMessage.replace(/\r?\n/g, ' ').trim();
 		} else {
@@ -70,6 +70,7 @@ module.exports.HTTPError = class extends GotError {
 		this.statusCode = statusCode;
 		this.statusMessage = statusMessage;
 		this.headers = headers;
+		this.body = body;
 	}
 };
 

--- a/source/errors.js
+++ b/source/errors.js
@@ -59,7 +59,10 @@ module.exports.ParseError = class extends GotError {
 };
 
 module.exports.HTTPError = class extends GotError {
-	constructor(statusCode, statusMessage, headers, body, opts) {
+	constructor(request, opts) {
+		const {statusCode} = request;
+		let {statusMessage} = request;
+
 		if (statusMessage) {
 			statusMessage = statusMessage.replace(/\r?\n/g, ' ').trim();
 		} else {
@@ -69,8 +72,8 @@ module.exports.HTTPError = class extends GotError {
 		this.name = 'HTTPError';
 		this.statusCode = statusCode;
 		this.statusMessage = statusMessage;
-		this.headers = headers;
-		this.body = body;
+		this.headers = request.headers;
+		this.body = request.body;
 	}
 };
 

--- a/test/error.js
+++ b/test/error.js
@@ -107,6 +107,12 @@ test('custom status message', async t => {
 	t.is(error.statusMessage, 'Something Exploded');
 });
 
+test('custom body', async t => {
+	const error = await t.throwsAsync(got(s.url));
+	t.is(error.statusCode, 404);
+	t.is(error.body, 'not');
+});
+
 test('no status message is overriden by the default one', async t => {
 	const error = await t.throwsAsync(got(`${s.url}/no-status-message`));
 	t.is(error.statusCode, 400);


### PR DESCRIPTION
#### Description

The ability to look at the body of the error response inside the `retries` function .

#### Why?

Some services use the response body to provide an extended description of why the error occurred (for example, reason of [409 code](https://developer.mozilla.org/docs/Web/HTTP/Status/409)).

We would like to use this field for logging.