### PR TITLE
Update node-fetch in the readme comparison table

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1032,7 +1032,7 @@ const h2got = got.extend({request});
 | Electron support      |       ✔      |       ✖      |       ✖      |       ✖      |
 | Promise API           |       ✔      |       ✔      |       ✔      |       ✔      |
 | Stream API            |       ✔      |       ✔      | Node.js only |       ✖      |
-| Request cancelation   |       ✔      |       ✖      |       ✖      |       ✔      |
+| Request cancelation   |       ✔      |       ✖      |       ✔      |       ✔      |
 | RFC compliant caching |       ✔      |       ✖      |       ✖      |       ✖      |
 | Cookies (out-of-box)  |       ✔      |       ✔      |       ✖      |       ✖      |
 | Follows redirects     |       ✔      |       ✔      |       ✔      |       ✔      |


### PR DESCRIPTION
node-fetch now has standard compliant `AbortSignal` support, thus proper request cancelation support.