### PR TITLE
Add Got options onto responses and errors

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -451,6 +451,12 @@ const instance = got.extend({
 
 The response object will typically be a [Node.js HTTP response stream](https://nodejs.org/api/http.html#http_class_http_incomingmessage), however, if returned from the cache it will be a [response-like object](https://github.com/lukechilds/responselike) which behaves in the same way.
 
+##### req
+
+Type: `Object`
+
+- `gotOptions` - The options that were set on this request.
+
 ##### body
 
 Type: `string` `Object` *(depending on `options.json`)*
@@ -661,7 +667,7 @@ The default Got options.
 
 ## Errors
 
-Each error contains (if available) `body`, `statusCode`, `statusMessage`, `host`, `hostname`, `method`, `path`, `protocol` and `url` properties to make debugging easier.
+Each error contains (if available) `body`, `statusCode`, `statusMessage`, `host`, `hostname`, `method`, `path`, `protocol`, `url`, and `gotOptions` properties to make debugging easier.
 
 In Promise mode, the `response` is attached to the error.
 

--- a/readme.md
+++ b/readme.md
@@ -451,7 +451,7 @@ const instance = got.extend({
 
 The response object will typically be a [Node.js HTTP response stream](https://nodejs.org/api/http.html#http_class_http_incomingmessage), however, if returned from the cache it will be a [response-like object](https://github.com/lukechilds/responselike) which behaves in the same way.
 
-##### req
+##### request
 
 Type: `Object`
 

--- a/readme.md
+++ b/readme.md
@@ -455,7 +455,7 @@ The response object will typically be a [Node.js HTTP response stream](https://n
 
 Type: `Object`
 
-This is not a [http.ClientRequest](https://nodejs.org/api/http.html#http_class_http_clientrequest).
+**Note:** This is not a [http.ClientRequest](https://nodejs.org/api/http.html#http_class_http_clientrequest).
 
 - `gotOptions` - The options that were set on this request.
 

--- a/readme.md
+++ b/readme.md
@@ -455,6 +455,8 @@ The response object will typically be a [Node.js HTTP response stream](https://n
 
 Type: `Object`
 
+This is not a [http.ClientRequest](https://nodejs.org/api/http.html#http_class_http_clientrequest).
+
 - `gotOptions` - The options that were set on this request.
 
 ##### body

--- a/source/errors.js
+++ b/source/errors.js
@@ -21,7 +21,8 @@ class GotError extends Error {
 			path: options.path,
 			socketPath: options.socketPath,
 			protocol: options.protocol,
-			url: options.href
+			url: options.href,
+			gotOptions: options
 		});
 	}
 }

--- a/source/request-as-event-emitter.js
+++ b/source/request-as-event-emitter.js
@@ -92,7 +92,9 @@ module.exports = (options, input) => {
 				response.retryCount = retryCount;
 				response.timings = timings;
 				response.redirectUrls = redirects;
-				response.request = {gotOptions: options}
+				response.request = {
+					gotOptions: options
+				};
 
 				const rawCookies = response.headers['set-cookie'];
 				if (options.cookieJar && rawCookies) {

--- a/source/request-as-event-emitter.js
+++ b/source/request-as-event-emitter.js
@@ -93,6 +93,12 @@ module.exports = (options, input) => {
 				response.timings = timings;
 				response.redirectUrls = redirects;
 
+				if (response.req) {
+					response.req.gotOptions = options;
+			  } else {
+					response.req = {gotOptions: options};
+			  }
+
 				const rawCookies = response.headers['set-cookie'];
 				if (options.cookieJar && rawCookies) {
 					await Promise.all(rawCookies.map(rawCookie => setCookie(rawCookie, response.url)));

--- a/source/request-as-event-emitter.js
+++ b/source/request-as-event-emitter.js
@@ -92,12 +92,7 @@ module.exports = (options, input) => {
 				response.retryCount = retryCount;
 				response.timings = timings;
 				response.redirectUrls = redirects;
-
-				if (response.req) {
-					response.req.gotOptions = options;
-			  } else {
-					response.req = {gotOptions: options};
-			  }
+				response.request = {gotOptions: options}
 
 				const rawCookies = response.headers['set-cookie'];
 				if (options.cookieJar && rawCookies) {

--- a/test/cache.js
+++ b/test/cache.js
@@ -110,6 +110,17 @@ test('Redirects are cached and re-used internally', async t => {
 	t.is(firstResponse.body, secondResponse.body);
 });
 
+test('Cached response should have got options', async t => {
+	const endpoint = '/cache';
+	const cache = new Map();
+	const options = {url: s.url + endpoint, auth: 'foo:bar', cache}
+
+	await got(options);
+	const secondResponse = await got(options);
+
+	t.is(secondResponse.req.gotOptions.auth, options.auth);
+});
+
 test('Cache error throws got.CacheError', async t => {
 	const endpoint = '/no-store';
 	const cache = {};

--- a/test/cache.js
+++ b/test/cache.js
@@ -118,7 +118,7 @@ test('Cached response should have got options', async t => {
 	await got(options);
 	const secondResponse = await got(options);
 
-	t.is(secondResponse.req.gotOptions.auth, options.auth);
+	t.is(secondResponse.request.gotOptions.auth, options.auth);
 });
 
 test('Cache error throws got.CacheError', async t => {

--- a/test/cache.js
+++ b/test/cache.js
@@ -113,7 +113,11 @@ test('Redirects are cached and re-used internally', async t => {
 test('Cached response should have got options', async t => {
 	const endpoint = '/cache';
 	const cache = new Map();
-	const options = {url: s.url + endpoint, auth: 'foo:bar', cache}
+	const options = {
+		url: s.url + endpoint,
+		auth: 'foo:bar',
+		cache
+	};
 
 	await got(options);
 	const secondResponse = await got(options);

--- a/test/error.js
+++ b/test/error.js
@@ -112,8 +112,12 @@ test('custom body', async t => {
 	t.is(error.body, 'not');
 });
 
-test('contains got options', async t => {
-	const options = {url: s.url, auth: 'foo:bar'}
+test('contains Got options', async t => {
+	const options = {
+		url: s.url,
+		auth: 'foo:bar'
+	};
+
 	const error = await t.throwsAsync(got(options));
 	t.is(error.gotOptions.auth, options.auth);
 });

--- a/test/error.js
+++ b/test/error.js
@@ -112,6 +112,12 @@ test('custom body', async t => {
 	t.is(error.body, 'not');
 });
 
+test('contains got options', async t => {
+	const options = {url: s.url, auth: 'foo:bar'}
+	const error = await t.throwsAsync(got(options));
+	t.is(error.gotOptions.auth, options.auth);
+});
+
 test('no status message is overriden by the default one', async t => {
 	const error = await t.throwsAsync(got(`${s.url}/no-status-message`));
 	t.is(error.statusCode, 400);

--- a/test/http.js
+++ b/test/http.js
@@ -93,9 +93,10 @@ test('response contains url', async t => {
 });
 
 test('response contains got options', async t => {
-	 const options = {url: s.url, auth: 'foo:bar'}
+	 const options = {
+		 url: s.url,
+		 auth: 'foo:bar'
+	 };
+
 	 t.is((await got(options)).request.gotOptions.auth, options.auth);
 });
-
-
-

--- a/test/http.js
+++ b/test/http.js
@@ -93,10 +93,10 @@ test('response contains url', async t => {
 });
 
 test('response contains got options', async t => {
-	 const options = {
-		 url: s.url,
-		 auth: 'foo:bar'
-	 };
+	const options = {
+		url: s.url,
+		auth: 'foo:bar'
+	};
 
-	 t.is((await got(options)).request.gotOptions.auth, options.auth);
+	t.is((await got(options)).request.gotOptions.auth, options.auth);
 });

--- a/test/http.js
+++ b/test/http.js
@@ -94,7 +94,7 @@ test('response contains url', async t => {
 
 test('response contains got options', async t => {
 	 const options = {url: s.url, auth: 'foo:bar'}
-	 t.is((await got(options)).req.gotOptions.auth, options.auth);
+	 t.is((await got(options)).request.gotOptions.auth, options.auth);
 });
 
 

--- a/test/http.js
+++ b/test/http.js
@@ -91,3 +91,11 @@ test('requestUrl response when sending url as param', async t => {
 test('response contains url', async t => {
 	t.is((await got(s.url)).url, `${s.url}/`);
 });
+
+test('response contains got options', async t => {
+	 const options = {url: s.url, auth: 'foo:bar'}
+	 t.is((await got(options)).req.gotOptions.auth, options.auth);
+});
+
+
+


### PR DESCRIPTION
It would be helpful to have the options set on `response.req` to identify how the request was made.
For ex, in the `afterResponse` hook, in an event of a failed request, we would like to log the request options.
```javascript
afterResponse: [
      res => {
        if (res.statusCode !== 200) {
          logger.error(
            { res, options: res.req.options, message: res.body },
            'api error'
          );
        }
        return res;
      },
    ],