### PR TITLE
Remove error thrown for URLs with auth component

### DIFF
--- a/source/normalize-arguments.js
+++ b/source/normalize-arguments.js
@@ -116,11 +116,7 @@ const normalize = (url, options, defaults) => {
 			url = urlToOptions(new URL(url, options.baseUrl));
 		} else {
 			url = url.replace(/^unix:/, 'http://$&');
-
 			url = urlParseLax(url);
-			if (url.auth) {
-				throw new Error('Basic authentication must be done with the `auth` option');
-			}
 		}
 	} else if (is(url) === 'URL') {
 		url = urlToOptions(url);

--- a/test/arguments.js
+++ b/test/arguments.js
@@ -130,27 +130,6 @@ test('should ignore empty query object', async t => {
 	t.is((await got(`${s.url}/test`, {query: {}})).requestUrl, `${s.url}/test`);
 });
 
-test('should throw with auth in url string', async t => {
-	await t.throwsAsync(
-		got('https://test:45d3ps453@account.myservice.com/api/token'),
-		{
-			message: 'Basic authentication must be done with the `auth` option'
-		}
-	);
-});
-
-test('does not throw with auth in url object', async t => {
-	await t.notThrowsAsync(
-		got({
-			auth: 'foo:bar',
-			hostname: s.host,
-			port: s.port,
-			protocol: 'http:',
-			path: '/test'
-		})
-	);
-});
-
 test('should throw when body is set to object', async t => {
 	await t.throwsAsync(got(`${s.url}/`, {body: {}}), TypeError);
 });


### PR DESCRIPTION
Removes an error thrown when the URL contains auth instead of using got's auth option.
Removes the tests that verified the throwing behavior.

Not sure how you feel about removing the tests. I like removing them to keep the codebase as low maintenance as possible.

Fixes #106 