### PR TITLE
Add `init` hook

### DIFF
--- a/advanced-creation.md
+++ b/advanced-creation.md
@@ -98,6 +98,7 @@ const defaults = {
 			'user-agent': `${pkg.name}/${pkg.version} (https://github.com/sindresorhus/got)`
 		},
 		hooks: {
+			init: [],
 			beforeRequest: [],
 			beforeRedirect: [],
 			beforeRetry: [],

--- a/migration-guides.md
+++ b/migration-guides.md
@@ -103,23 +103,11 @@ gotInstance(url, options);
 ```js
 const gotInstance = got.extend({
 	hooks: {
-		beforeRequest: [
+		init: [
 			options => {
 				if (options.json && options.jsonReplacer) {
-					// #1 solution (faster)
-					const newBody = {};
-					for (const [key, value] of Object.entries(options.body)) {
-						let newValue = value;
-						do {
-							newValue = options.jsonReplacer(key, newValue);
-						} while (typeof newValue === 'object');
-
-						newBody[key] = newValue;
-					}
-					options.body = newBody;
-
-					// #2 solution (slower)
-					options.body = JSON.parse(JSON.stringify(options.body, options.jsonReplacer));
+					options.body = JSON.stringify(options.body, options.jsonReplacer);
+					options.json = false; // We've handled that on our own
 				}
 			}
 		],
@@ -127,7 +115,8 @@ const gotInstance = got.extend({
 			response => {
 				const options = response.request.gotOptions;
 				if (options.json && options.jsonReviver) {
-					response.body = JSON.stringify(JSON.parse(response.body, options.jsonReviver));
+					response.body = JSON.parse(response.body, options.jsonReviver);
+					options.json = false; // We've handled that on our own
 				}
 
 				return response;

--- a/migration-guides.md
+++ b/migration-guides.md
@@ -105,6 +105,9 @@ const gotInstance = got.extend({
 	hooks: {
 		init: [
 			options => {
+				// Save the original option, so we can look at it in the `afterResponse` hook
+				options._json = options.json;
+
 				if (options.json && options.jsonReplacer) {
 					options.body = JSON.stringify(options.body, options.jsonReplacer);
 					options.json = false; // We've handled that on our own
@@ -114,7 +117,7 @@ const gotInstance = got.extend({
 		afterResponse: [
 			response => {
 				const options = response.request.gotOptions;
-				if (options.json && options.jsonReviver) {
+				if (options._json && options.jsonReviver) {
 					response.body = JSON.parse(response.body, options.jsonReviver);
 					options.json = false; // We've handled that on our own
 				}

--- a/migration-guides.md
+++ b/migration-guides.md
@@ -106,7 +106,7 @@ const gotInstance = got.extend({
 		init: [
 			options => {
 				// Save the original option, so we can look at it in the `afterResponse` hook
-				options._json = options.json;
+				options.originalJson = options.json;
 
 				if (options.json && options.jsonReplacer) {
 					options.body = JSON.stringify(options.body, options.jsonReplacer);
@@ -117,7 +117,7 @@ const gotInstance = got.extend({
 		afterResponse: [
 			response => {
 				const options = response.request.gotOptions;
-				if (options._json && options.jsonReviver) {
+				if (options.originalJson && options.jsonReviver) {
 					response.body = JSON.parse(response.body, options.jsonReviver);
 					options.json = false; // We've handled that on our own
 				}

--- a/readme.md
+++ b/readme.md
@@ -360,6 +360,8 @@ Called with plain [request options](#options), right before their normalization.
 
 See the [Request migration guide](migration-guides.md#breaking-changes) for an example.
 
+**Note**: this hook must be synchronous!
+
 ###### hooks.beforeRequest
 
 Type: `Function[]`<br>

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ Got is for Node.js. For browsers, we recommend [Ky](https://github.com/sindresor
 - [Errors with metadata](#errors)
 - [JSON mode](#json)
 - [WHATWG URL support](#url)
-- [Hooks](https://github.com/sindresorhus/got#hooks)
+- [Hooks](#hooks)
 - [Instances with custom defaults](#instances)
 - [Composable](advanced-creation.md#merging-instances)
 - [Electron support](#useelectronnet)
@@ -350,6 +350,15 @@ got('sindresorhus.com', {
 Type: `Object<string, Function[]>`
 
 Hooks allow modifications during the request lifecycle. Hook functions may be async and are run serially.
+
+###### hooks.init
+
+Type: `Function[]`<br>
+Default: `[]`
+
+Called with plain [request options](#options), right before their normalization. This is especially useful in conjunction with [`got.extend()`](#instances) and [`got.create()`](advanced-creation.md) when the input needs custom handling.
+
+See the [Request migration guide](migration-guides.md#breaking-changes) for an example.
 
 ###### hooks.beforeRequest
 

--- a/readme.md
+++ b/readme.md
@@ -360,7 +360,7 @@ Called with plain [request options](#options), right before their normalization.
 
 See the [Request migration guide](migration-guides.md#breaking-changes) for an example.
 
-**Note**: this hook must be synchronous!
+**Note**: This hook must be synchronous!
 
 ###### hooks.beforeRequest
 

--- a/source/known-hook-events.js
+++ b/source/known-hook-events.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = [
+	'init',
 	'beforeRequest',
 	'beforeRedirect',
 	'beforeRetry',

--- a/source/normalize-arguments.js
+++ b/source/normalize-arguments.js
@@ -135,7 +135,7 @@ const normalize = (url, options, defaults) => {
 	for (const hook of options.hooks.init) {
 		const called = hook(options);
 
-		if (called instanceof Promise) {
+		if (is.promise(called)) {
 			throw new TypeError('The `init` hook must be a synchronous function');
 		}
 	}

--- a/source/normalize-arguments.js
+++ b/source/normalize-arguments.js
@@ -114,11 +114,6 @@ const normalize = (url, options, defaults) => {
 		throw new TypeError(`Parameter \`url\` must be a string or object, not ${is(url)}`);
 	}
 
-	for (const hook of options.hooks.init) {
-		// eslint-disable-next-line no-await-in-loop
-		await hook(options);
-	}
-
 	if (is.string(url)) {
 		if (options.baseUrl) {
 			if (url.toString().startsWith('/')) {
@@ -136,6 +131,10 @@ const normalize = (url, options, defaults) => {
 
 	// Override both null/undefined with default protocol
 	options = merge({path: ''}, url, {protocol: url.protocol || 'https:'}, options);
+
+	for (const hook of options.hooks.init) {
+		hook(options);
+	}
 
 	const {baseUrl} = options;
 	Object.defineProperty(options, 'baseUrl', {

--- a/source/normalize-arguments.js
+++ b/source/normalize-arguments.js
@@ -133,7 +133,11 @@ const normalize = (url, options, defaults) => {
 	options = merge({path: ''}, url, {protocol: url.protocol || 'https:'}, options);
 
 	for (const hook of options.hooks.init) {
-		hook(options);
+		const called = hook(options);
+
+		if (called instanceof Promise) {
+			throw new TypeError('The `init` hook must be a synchronous function');
+		}
 	}
 
 	const {baseUrl} = options;


### PR DESCRIPTION
Introduces a new hook: `init`. It gets called right before option normalization - very useful when you need to handle some things on your own.
For example, this fixes the [`jsonReplacer` example in `migration-guides.md`](https://github.com/sindresorhus/got/pull/683/files#diff-a54dbc53336e27b44b3bfab2b8c9b48f).

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] If it's a new feature, I have included documentation updates.
