### PR TITLE
Ky-like body response transformations

### DIFF
--- a/advanced-creation.md
+++ b/advanced-creation.md
@@ -112,7 +112,8 @@ const defaults = {
 		form: false,
 		cache: false,
 		useElectronNet: false,
-		responseType: 'text'
+		responseType: 'text',
+		resolveBody: 'false'
 	},
 	mutableDefaults: false
 };

--- a/advanced-creation.md
+++ b/advanced-creation.md
@@ -112,7 +112,7 @@ const defaults = {
 		form: false,
 		cache: false,
 		useElectronNet: false,
-		responseType: 'text
+		responseType: 'text'
 	},
 	mutableDefaults: false
 };

--- a/advanced-creation.md
+++ b/advanced-creation.md
@@ -113,7 +113,7 @@ const defaults = {
 		cache: false,
 		useElectronNet: false,
 		responseType: 'text',
-		resolveBody: 'false'
+		resolveBodyOnly: 'false'
 	},
 	mutableDefaults: false
 };

--- a/advanced-creation.md
+++ b/advanced-creation.md
@@ -54,7 +54,7 @@ const settings = {
 		return next(options);
 	},
 	options: got.mergeOptions(got.defaults.options, {
-		json: true
+		responseType: 'json'
 	})
 };
 
@@ -110,9 +110,9 @@ const defaults = {
 		followRedirect: true,
 		stream: false,
 		form: false,
-		json: false,
 		cache: false,
-		useElectronNet: false
+		useElectronNet: false,
+		responseType: 'text
 	},
 	mutableDefaults: false
 };

--- a/migration-guides.md
+++ b/migration-guides.md
@@ -44,7 +44,6 @@ These Got options are the same as with Request:
 
 - [`url`](https://github.com/sindresorhus/got#url) (+ we accept [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL) instances too!)
 - [`body`](https://github.com/sindresorhus/got#body)
-- [`json`](https://github.com/sindresorhus/got#json)
 - [`followRedirect`](https://github.com/sindresorhus/got#followRedirect)
 - [`encoding`](https://github.com/sindresorhus/got#encoding)
 
@@ -82,6 +81,7 @@ To use streams, just call `got.stream(url, options)` or `got(url, {stream: true,
 - No `agentClass`/`agentOptions`/`pool` option.
 - No `forever` option. You need to use [forever-agent](https://github.com/request/forever-agent).
 - No `proxy` option. You need to [pass a custom agent](readme.md#proxies).
+- No `json` option. Assume it's set to `true` when passing an object.
 - No `removeRefererHeader` option. You can remove the referer header in a [`beforeRequest` hook](https://github.com/sindresorhus/got#hooksbeforeRequest):
 
 ```js
@@ -105,21 +105,17 @@ const gotInstance = got.extend({
 	hooks: {
 		init: [
 			options => {
-				// Save the original option, so we can look at it in the `afterResponse` hook
-				options.originalJson = options.json;
-
-				if (options.json && options.jsonReplacer) {
+				if (options.jsonReplacer) {
 					options.body = JSON.stringify(options.body, options.jsonReplacer);
-					options.json = false; // We've handled that on our own
 				}
 			}
 		],
 		afterResponse: [
 			response => {
 				const options = response.request.gotOptions;
-				if (options.originalJson && options.jsonReviver) {
+				if (options.jsonReviver && options.responseType === 'json') {
+					options.responseType = '';
 					response.body = JSON.parse(response.body, options.jsonReviver);
-					options.json = false; // We've handled that on our own
 				}
 
 				return response;

--- a/readme.md
+++ b/readme.md
@@ -159,7 +159,7 @@ Type: `string` `Buffer` `stream.Readable` [`form-data` instance](https://github.
 
 **Note:** If you provide this option, `got.stream()` will be read-only.
 
-**Note:** if body is an object/array and `Content-Type` header is not set, it will be set to `application/json`.
+**Note:** If body is an object/array, it will be stringified. The `Content-Type` header will be set to `application/json` if it's not defined.
 
 The body that will be sent with a `POST` request.
 
@@ -172,7 +172,7 @@ The `content-length` header will be automatically set if `body` is a `string` / 
 Type: `string`<br>
 Default: `text`
 
-**Note**: when using streams, this option is ignored.
+**Note**: When using streams, this option is ignored.
 
 Parsing method used to retrieve the body from the response. Can be `text`, `json` or `buffer`. The promise has `.json()` and `.buffer()` functions which set this option automatically.
 
@@ -374,11 +374,9 @@ See the [Request migration guide](migration-guides.md#breaking-changes) for an e
 Type: `Function[]`<br>
 Default: `[]`
 
-Called with [normalized](source/normalize-arguments.js) [request options](#options). Got will make no further changes to the request before it is sent. This is especially useful in conjunction with [`got.extend()`](#instances) and [`got.create()`](advanced-creation.md) when you want to create an API client that, for example, uses HMAC-signing.
+Called with [normalized](source/normalize-arguments.js) [request options](#options). Got will make no further changes to the request before it is sent (except the body serialization). This is especially useful in conjunction with [`got.extend()`](#instances) and [`got.create()`](advanced-creation.md) when you want to create an API client that, for example, uses HMAC-signing.
 
 See the [AWS section](#aws) for an example.
-
-**Note:** If you modify the `body` you will need to modify the `content-length` header too, because it has already been computed and assigned.
 
 ###### hooks.beforeRedirect
 
@@ -1010,6 +1008,43 @@ const createTestServer = require('create-test-server');
 
 
 ## Tips
+
+### JSON mode
+
+By default, if you pass an object to the `body` option it will be stringified using `JSON.stringify`. Example:
+
+```js
+const got = require('got');
+
+(async () => {
+	const response = await got('httpbin.org/anything', {
+		body: {
+			hello: 'world'
+		},
+		responseType: 'json'
+	});
+
+	console.log(response.body.data);
+	//=> '{"hello":"world"}'
+})();
+```
+
+To receive a JSON body you can either set `responseType` option to `json` or use `promise.json()`. Example:
+
+```js
+const got = require('got');
+
+(async () => {
+	const {body} = await got('httpbin.org/anything', {
+		body: {
+			hello: 'world'
+		}
+	}).json();
+
+	console.log(body);
+	//=> {...}
+})();
+```
 
 ### User Agent
 

--- a/readme.md
+++ b/readme.md
@@ -1132,7 +1132,7 @@ const h2got = got.extend({request});
 | Advanced timeouts     |        ✔       |        ✖       |          ✖         |        ✖       |          ✖          |
 | Timings               |        ✔       |        ✔       |          ✖         |        ✖       |          ✖          |
 | Errors with metadata  |        ✔       |        ✖       |          ✖         |        ✔       |          ✖          |
-| JSON mode             |        ✔       |        ✔       |          ✖         |        ✔       |          ✔          |
+| JSON mode             |        ✔       |        ✔       |          ✔         |        ✔       |          ✔          |
 | Custom defaults       |        ✔       |        ✔       |          ✖         |        ✔       |          ✖          |
 | Composable            |        ✔       |        ✖       |          ✖         |        ✖       |          ✔          |
 | Hooks                 |        ✔       |        ✖       |          ✖         |        ✔       |          ✖          |

--- a/readme.md
+++ b/readme.md
@@ -169,6 +169,8 @@ The `content-length` header will be automatically set if `body` is a `string` / 
 
 Type: `Object` `Array` `number` `string` `boolean` `null`
 
+**Note:** If you provide this option, `got.stream()` will be read-only.
+
 JSON body. The `Content-Type` header will be set to `application/json` if it's not defined.
 
 ###### responseType

--- a/readme.md
+++ b/readme.md
@@ -157,23 +157,26 @@ Returns a `Stream` instead of a `Promise`. This is equivalent to calling `got.st
 
 Type: `string` `Buffer` `stream.Readable` [`form-data` instance](https://github.com/form-data/form-data)
 
+**Note:** The `body` option cannot be used with the `json` or `form` option.
+
 **Note:** If you provide this option, `got.stream()` will be read-only.
-
-**Note:** If body is an object/array, it will be stringified. The `Content-Type` header will be set to `application/json` if it's not defined.
->>>>>>> Improvements
-
-The body that will be sent with a `POST` request.
 
 If present in `options` and `options.method` is not set, `options.method` will be set to `POST`.
 
 The `content-length` header will be automatically set if `body` is a `string` / `Buffer` / `fs.createReadStream` instance / [`form-data` instance](https://github.com/form-data/form-data), and `content-length` and `transfer-encoding` are not manually set in `options.headers`.
+
+###### json
+
+Type: `Object` `Array` `number` `string` `boolean` `null`
+
+JSON body. The `Content-Type` header will be set to `application/json` if it's not defined.
 
 ###### responseType
 
 Type: `string`<br>
 Default: `text`
 
-**Note**: When using streams, this option is ignored.
+**Note:** When using streams, this option is ignored.
 
 Parsing method used to retrieve the body from the response. Can be `text`, `json` or `buffer`. The promise has `.json()` and `.buffer()` functions which set this option automatically.
 
@@ -183,7 +186,7 @@ Example:
 const {body} = await got(url).json();
 ```
 
-###### resolveBody
+###### resolveBodyOnly
 
 Type: `string`<br>
 Default: `false`
@@ -207,11 +210,11 @@ Default: `'utf8'`
 
 ###### form
 
-Type: `boolean`<br>
-Default: `false`
+Type: `Object`
 
 **Note:** If you provide this option, `got.stream()` will be read-only.
-**Note:** `body` must be a plain object. It will be converted to a query string using [`(new URLSearchParams(object)).toString()`](https://nodejs.org/api/url.html#url_constructor_new_urlsearchparams_obj).
+
+The form body is converted to query string using [`(new URLSearchParams(object)).toString()`](https://nodejs.org/api/url.html#url_constructor_new_urlsearchparams_obj).
 
 If set to `true` and `Content-Type` header is not set, it will be set to `application/x-www-form-urlencoded`.
 
@@ -375,7 +378,7 @@ Called with plain [request options](#options), right before their normalization.
 
 See the [Request migration guide](migration-guides.md#breaking-changes) for an example.
 
-**Note**: This hook must be synchronous!
+**Note:** This hook must be synchronous!
 
 ###### hooks.beforeRequest
 
@@ -478,7 +481,7 @@ Default: `[]`
 
 Called with an `Error` instance. The error is passed to the hook right before it's thrown. This is especially useful when you want to have more detailed errors.
 
-**Note**: Errors thrown while normalizing input options are thrown directly and not part of this hook.
+**Note:** Errors thrown while normalizing input options are thrown directly and not part of this hook.
 
 ```js	
 const got = require('got');	

--- a/readme.md
+++ b/readme.md
@@ -160,6 +160,7 @@ Type: `string` `Buffer` `stream.Readable` [`form-data` instance](https://github.
 **Note:** If you provide this option, `got.stream()` will be read-only.
 
 **Note:** If body is an object/array, it will be stringified. The `Content-Type` header will be set to `application/json` if it's not defined.
+>>>>>>> Improvements
 
 The body that will be sent with a `POST` request.
 

--- a/readme.md
+++ b/readme.md
@@ -182,6 +182,13 @@ Example:
 const {body} = await got(url).json();
 ```
 
+###### resolveBody
+
+Type: `string`<br>
+Default: `false`
+
+When set to `true` the promise will return the [Response body](#body-1) instead of the [Response](#response) object.
+
 ###### cookieJar
 
 Type: [`tough.CookieJar` instance](https://github.com/salesforce/tough-cookie#cookiejar)

--- a/source/as-promise.js
+++ b/source/as-promise.js
@@ -89,13 +89,13 @@ const asPromise = options => {
 						return;
 					}
 
-					resolve(options.resolveBody ? response.body : response);
+					resolve(options.resolveBodyOnly ? response.body : response);
 				}
 
 				return;
 			}
 
-			resolve(options.resolveBody ? response.body : response);
+			resolve(options.resolveBodyOnly ? response.body : response);
 		});
 
 		emitter.once('error', reject);
@@ -114,19 +114,19 @@ const asPromise = options => {
 
 	promise.json = () => {
 		options.responseType = 'json';
-		options.resolveBody = true;
+		options.resolveBodyOnly = true;
 		return promise;
 	};
 
 	promise.buffer = () => {
 		options.responseType = 'buffer';
-		options.resolveBody = true;
+		options.resolveBodyOnly = true;
 		return promise;
 	};
 
 	promise.text = () => {
 		options.responseType = 'text';
-		options.resolveBody = true;
+		options.resolveBodyOnly = true;
 		return promise;
 	};
 

--- a/source/as-promise.js
+++ b/source/as-promise.js
@@ -124,6 +124,12 @@ const asPromise = options => {
 		return promise;
 	};
 
+	promise.text = () => {
+		options.responseType = 'text';
+		options.resolveBody = true;
+		return promise;
+	};
+
 	return promise;
 };
 

--- a/source/as-promise.js
+++ b/source/as-promise.js
@@ -89,13 +89,13 @@ const asPromise = options => {
 						return;
 					}
 
-					resolve(response);
+					resolve(options.resolveBody ? response.body : response);
 				}
 
 				return;
 			}
 
-			resolve(response);
+			resolve(options.resolveBody ? response.body : response);
 		});
 
 		emitter.once('error', reject);
@@ -114,11 +114,13 @@ const asPromise = options => {
 
 	promise.json = () => {
 		options.responseType = 'json';
+		options.resolveBody = true;
 		return promise;
 	};
 
 	promise.buffer = () => {
 		options.responseType = 'buffer';
+		options.resolveBody = true;
 		return promise;
 	};
 

--- a/source/as-promise.js
+++ b/source/as-promise.js
@@ -11,6 +11,16 @@ const {reNormalize} = require('./normalize-arguments');
 const asPromise = options => {
 	const proxy = new EventEmitter();
 
+	const parseBody = response => {
+		if (options.responseType === 'json') {
+			response.body = JSON.parse(response.body);
+		} else if (options.responseType === 'buffer') {
+			response.body = Buffer.from(response.body);
+		} else if (options.responseType !== 'text' && !is.falsy(options.responseType)) {
+			throw new Error(`Failed to parse body of type '${options.responseType}'`);
+		}
+	};
+
 	const promise = new PCancelable((resolve, reject, onCancel) => {
 		const emitter = requestAsEventEmitter(options);
 
@@ -57,9 +67,9 @@ const asPromise = options => {
 
 			const {statusCode} = response;
 
-			if (options.json && response.body) {
+			if (response.body) {
 				try {
-					response.body = JSON.parse(response.body);
+					parseBody(response);
 				} catch (error) {
 					if (statusCode >= 200 && statusCode < 300) {
 						const parseError = new ParseError(error, statusCode, options, data);
@@ -99,6 +109,16 @@ const asPromise = options => {
 
 	promise.on = (name, fn) => {
 		proxy.on(name, fn);
+		return promise;
+	};
+
+	promise.json = () => {
+		options.responseType = 'json';
+		return promise;
+	};
+
+	promise.buffer = () => {
+		options.responseType = 'buffer';
 		return promise;
 	};
 

--- a/source/errors.js
+++ b/source/errors.js
@@ -52,8 +52,9 @@ module.exports.ReadError = class extends GotError {
 
 module.exports.ParseError = class extends GotError {
 	constructor(error, statusCode, options, data) {
-		super(`${error.message} in "${urlLib.format(options)}": \n${data.slice(0, 77)}...`, error, options);
+		super(`${error.message} in "${urlLib.format(options)}"`, error, options);
 		this.name = 'ParseError';
+		this.body = data;
 		this.statusCode = statusCode;
 		this.statusMessage = http.STATUS_CODES[this.statusCode];
 	}

--- a/source/index.js
+++ b/source/index.js
@@ -50,7 +50,8 @@ const defaults = {
 		form: false,
 		json: false,
 		cache: false,
-		useElectronNet: false
+		useElectronNet: false,
+		responseType: 'text'
 	},
 	mutableDefaults: false
 };

--- a/source/index.js
+++ b/source/index.js
@@ -51,7 +51,8 @@ const defaults = {
 		json: false,
 		cache: false,
 		useElectronNet: false,
-		responseType: 'text'
+		responseType: 'text',
+		resolveBody: false
 	},
 	mutableDefaults: false
 };

--- a/source/index.js
+++ b/source/index.js
@@ -47,12 +47,10 @@ const defaults = {
 		throwHttpErrors: true,
 		followRedirect: true,
 		stream: false,
-		form: false,
-		json: false,
 		cache: false,
 		useElectronNet: false,
 		responseType: 'text',
-		resolveBody: false
+		resolveBodyOnly: false
 	},
 	mutableDefaults: false
 };

--- a/source/normalize-arguments.js
+++ b/source/normalize-arguments.js
@@ -57,6 +57,7 @@ const preNormalize = (options, defaults) => {
 
 	const {retry} = options;
 	options.retry = {
+
 		retries: 0,
 		methods: [],
 		statusCodes: [],

--- a/source/normalize-arguments.js
+++ b/source/normalize-arguments.js
@@ -5,7 +5,6 @@ const is = require('@sindresorhus/is');
 const urlParseLax = require('url-parse-lax');
 const lowercaseKeys = require('lowercase-keys');
 const urlToOptions = require('./utils/url-to-options');
-const isFormData = require('./utils/is-form-data');
 const validateSearchParams = require('./utils/validate-search-params');
 const merge = require('./merge');
 const knownHookEvents = require('./known-hook-events');
@@ -186,31 +185,10 @@ const normalize = (url, options, defaults) => {
 		headers['accept-encoding'] = 'gzip, deflate';
 	}
 
-	const {body} = options;
-	if (is.nullOrUndefined(body)) {
-		options.method = options.method ? options.method.toUpperCase() : 'GET';
+	if (options.method) {
+		options.method = options.method.toUpperCase();
 	} else {
-		const isObject = is.object(body) && !is.buffer(body) && !is.nodeStream(body);
-		if (!is.nodeStream(body) && !is.string(body) && !is.buffer(body) && !isObject && !options.form) {
-			throw new TypeError('The `body` option must be a stream.Readable, string, Buffer, Object or Array');
-		}
-
-		if (options.form && !isObject) {
-			throw new TypeError('The `body` option must be an Object when the `form` option is used');
-		}
-
-		if (isFormData(body)) {
-			// Special case for https://github.com/form-data/form-data
-			headers['content-type'] = headers['content-type'] || `multipart/form-data; boundary=${body.getBoundary()}`;
-		} else if (options.form) {
-			headers['content-type'] = headers['content-type'] || 'application/x-www-form-urlencoded';
-			options.body = (new URLSearchParams(body)).toString();
-		} else if (isObject) {
-			headers['content-type'] = headers['content-type'] || 'application/json';
-			options.body = JSON.stringify(body);
-		}
-
-		options.method = options.method ? options.method.toUpperCase() : 'POST';
+		options.method = is.nullOrUndefined(options.body) ? 'GET' : 'POST';
 	}
 
 	if (!is.function(options.retry.retries)) {

--- a/source/normalize-arguments.js
+++ b/source/normalize-arguments.js
@@ -32,10 +32,6 @@ const preNormalize = (options, defaults) => {
 		options.baseUrl += '/';
 	}
 
-	if (options.stream) {
-		options.json = false;
-	}
-
 	if (is.nullOrUndefined(options.hooks)) {
 		options.hooks = {};
 	} else if (!is.object(options.hooks)) {
@@ -62,6 +58,7 @@ const preNormalize = (options, defaults) => {
 
 	const {retry} = options;
 	options.retry = {
+
 		retries: 0,
 		methods: [],
 		statusCodes: [],
@@ -185,10 +182,6 @@ const normalize = (url, options, defaults) => {
 		}
 	}
 
-	if (options.json && is.undefined(headers.accept)) {
-		headers.accept = 'application/json';
-	}
-
 	if (options.decompress && is.undefined(headers['accept-encoding'])) {
 		headers['accept-encoding'] = 'gzip, deflate';
 	}
@@ -198,12 +191,8 @@ const normalize = (url, options, defaults) => {
 		options.method = options.method ? options.method.toUpperCase() : 'GET';
 	} else {
 		const isObject = is.object(body) && !is.buffer(body) && !is.nodeStream(body);
-		if (!is.nodeStream(body) && !is.string(body) && !is.buffer(body) && !(options.form || options.json)) {
-			throw new TypeError('The `body` option must be a stream.Readable, string or Buffer');
-		}
-
-		if (options.json && !(isObject || is.array(body))) {
-			throw new TypeError('The `body` option must be an Object or Array when the `json` option is used');
+		if (!is.nodeStream(body) && !is.string(body) && !is.buffer(body) && !isObject && !options.form) {
+			throw new TypeError('The `body` option must be a stream.Readable, string, Buffer, Object or Array');
 		}
 
 		if (options.form && !isObject) {
@@ -216,7 +205,7 @@ const normalize = (url, options, defaults) => {
 		} else if (options.form) {
 			headers['content-type'] = headers['content-type'] || 'application/x-www-form-urlencoded';
 			options.body = (new URLSearchParams(body)).toString();
-		} else if (options.json) {
+		} else if (isObject) {
 			headers['content-type'] = headers['content-type'] || 'application/json';
 			options.body = JSON.stringify(body);
 		}

--- a/source/normalize-arguments.js
+++ b/source/normalize-arguments.js
@@ -57,7 +57,6 @@ const preNormalize = (options, defaults) => {
 
 	const {retry} = options;
 	options.retry = {
-
 		retries: 0,
 		methods: [],
 		statusCodes: [],

--- a/source/request-as-event-emitter.js
+++ b/source/request-as-event-emitter.js
@@ -1,5 +1,5 @@
 'use strict';
-const {URL} = require('url'); // TODO: Use the `URL` global when targeting Node.js 10
+const {URL, URLSearchParams} = require('url'); // TODO: Use the `URL` global when targeting Node.js 10
 const util = require('util');
 const EventEmitter = require('events');
 const http = require('http');

--- a/source/request-as-event-emitter.js
+++ b/source/request-as-event-emitter.js
@@ -295,6 +295,10 @@ module.exports = (options, input) => {
 				}
 			}
 
+			if (options.responseType === 'json' && is.undefined(options.headers.accept)) {
+				options.headers.accept = 'application/json';
+			}
+
 			for (const hook of options.hooks.beforeRequest) {
 				// eslint-disable-next-line no-await-in-loop
 				await hook(options);

--- a/test/arguments.js
+++ b/test/arguments.js
@@ -131,6 +131,10 @@ test('should ignore empty query object', async t => {
 	t.is((await got(`${s.url}/test`, {query: {}})).requestUrl, `${s.url}/test`);
 });
 
+test('should throw on invalid type of body', async t => {
+	await t.throwsAsync(got(`${s.url}/`, {body: false}), TypeError);
+});
+
 test('WHATWG URL support', async t => {
 	const wURL = new URL(`${s.url}/test`);
 	await t.notThrowsAsync(got(wURL));

--- a/test/arguments.js
+++ b/test/arguments.js
@@ -131,10 +131,6 @@ test('should ignore empty query object', async t => {
 	t.is((await got(`${s.url}/test`, {query: {}})).requestUrl, `${s.url}/test`);
 });
 
-test('should throw when body is set to object', async t => {
-	await t.throwsAsync(got(`${s.url}/`, {body: {}}), TypeError);
-});
-
 test('WHATWG URL support', async t => {
 	const wURL = new URL(`${s.url}/test`);
 	await t.notThrowsAsync(got(wURL));
@@ -142,11 +138,6 @@ test('WHATWG URL support', async t => {
 
 test('should return streams when using stream option', async t => {
 	const data = await pEvent(got(`${s.url}/stream`, {stream: true}), 'data');
-	t.is(data.toString(), 'ok');
-});
-
-test('should ignore JSON option when using stream option', async t => {
-	const data = await pEvent(got(`${s.url}/stream`, {stream: true, json: true}), 'data');
 	t.is(data.toString(), 'ok');
 });
 

--- a/test/create.js
+++ b/test/create.js
@@ -22,8 +22,8 @@ test.after('cleanup', async () => {
 });
 
 test('preserve global defaults', async t => {
-	const globalHeaders = (await got(s.url, {json: true})).body;
-	const instanceHeaders = (await got.extend()(s.url, {json: true})).body;
+	const globalHeaders = (await got(s.url).json()).body;
+	const instanceHeaders = (await got.extend()(s.url).json()).body;
 	t.deepEqual(instanceHeaders, globalHeaders);
 });
 
@@ -33,7 +33,7 @@ test('support instance defaults', async t => {
 			'user-agent': 'custom-ua-string'
 		}
 	});
-	const headers = (await instance(s.url, {json: true})).body;
+	const headers = (await instance(s.url).json()).body;
 	t.is(headers['user-agent'], 'custom-ua-string');
 });
 
@@ -44,7 +44,7 @@ test('support invocation overrides', async t => {
 		}
 	});
 	const headers = (await instance(s.url, {
-		json: true,
+		responseType: 'json',
 		headers: {
 			'user-agent': 'different-ua-string'
 		}
@@ -63,7 +63,7 @@ test('curry previous instance defaults', async t => {
 			'x-bar': 'bar'
 		}
 	});
-	const headers = (await instanceB(s.url, {json: true})).body;
+	const headers = (await instanceB(s.url).json()).body;
 	t.is(headers['x-foo'], 'foo');
 	t.is(headers['x-bar'], 'bar');
 });
@@ -72,9 +72,7 @@ test('custom headers (extend)', async t => {
 	const options = {headers: {unicorn: 'rainbow'}};
 
 	const instance = got.extend(options);
-	const headers = (await instance(`${s.url}/`, {
-		json: true
-	})).body;
+	const headers = (await instance(`${s.url}/`).json()).body;
 	t.is(headers.unicorn, 'rainbow');
 });
 
@@ -108,9 +106,7 @@ test('create', async t => {
 			return next(options);
 		}
 	});
-	const headers = (await instance(s.url, {
-		json: true
-	})).body;
+	const headers = (await instance(s.url).json()).body;
 	t.is(headers.unicorn, 'rainbow');
 	t.is(headers['user-agent'], undefined);
 });
@@ -127,9 +123,7 @@ test('hooks are merged on got.extend()', t => {
 
 test('custom endpoint with custom headers (extend)', async t => {
 	const instance = got.extend({headers: {unicorn: 'rainbow'}, baseUrl: s.url});
-	const headers = (await instance('/', {
-		json: true
-	})).body;
+	const headers = (await instance('/').json()).body;
 	t.is(headers.unicorn, 'rainbow');
 	t.not(headers['user-agent'], undefined);
 });

--- a/test/create.js
+++ b/test/create.js
@@ -22,8 +22,8 @@ test.after('cleanup', async () => {
 });
 
 test('preserve global defaults', async t => {
-	const globalHeaders = (await got(s.url).json()).body;
-	const instanceHeaders = (await got.extend()(s.url).json()).body;
+	const globalHeaders = await got(s.url).json();
+	const instanceHeaders = await got.extend()(s.url).json();
 	t.deepEqual(instanceHeaders, globalHeaders);
 });
 
@@ -33,7 +33,7 @@ test('support instance defaults', async t => {
 			'user-agent': 'custom-ua-string'
 		}
 	});
-	const headers = (await instance(s.url).json()).body;
+	const headers = await instance(s.url).json();
 	t.is(headers['user-agent'], 'custom-ua-string');
 });
 
@@ -43,12 +43,11 @@ test('support invocation overrides', async t => {
 			'user-agent': 'custom-ua-string'
 		}
 	});
-	const headers = (await instance(s.url, {
-		responseType: 'json',
+	const headers = await instance(s.url, {
 		headers: {
 			'user-agent': 'different-ua-string'
 		}
-	})).body;
+	}).json();
 	t.is(headers['user-agent'], 'different-ua-string');
 });
 
@@ -63,7 +62,7 @@ test('curry previous instance defaults', async t => {
 			'x-bar': 'bar'
 		}
 	});
-	const headers = (await instanceB(s.url).json()).body;
+	const headers = await instanceB(s.url).json();
 	t.is(headers['x-foo'], 'foo');
 	t.is(headers['x-bar'], 'bar');
 });
@@ -72,7 +71,7 @@ test('custom headers (extend)', async t => {
 	const options = {headers: {unicorn: 'rainbow'}};
 
 	const instance = got.extend(options);
-	const headers = (await instance(`${s.url}/`).json()).body;
+	const headers = await instance(`${s.url}/`).json();
 	t.is(headers.unicorn, 'rainbow');
 });
 
@@ -106,7 +105,7 @@ test('create', async t => {
 			return next(options);
 		}
 	});
-	const headers = (await instance(s.url).json()).body;
+	const headers = await instance(s.url).json();
 	t.is(headers.unicorn, 'rainbow');
 	t.is(headers['user-agent'], undefined);
 });
@@ -123,7 +122,7 @@ test('hooks are merged on got.extend()', t => {
 
 test('custom endpoint with custom headers (extend)', async t => {
 	const instance = got.extend({headers: {unicorn: 'rainbow'}, baseUrl: s.url});
-	const headers = (await instance('/').json()).body;
+	const headers = await instance('/').json();
 	t.is(headers.unicorn, 'rainbow');
 	t.not(headers['user-agent'], undefined);
 });

--- a/test/error.js
+++ b/test/error.js
@@ -77,7 +77,7 @@ test('no plain object restriction on body', async t => {
 		this.a = 123;
 	}
 
-	const {body} = await got(`${s.url}/body`, {body: new CustomObject()}).json();
+	const body = await got(`${s.url}/body`, {body: new CustomObject()}).json();
 
 	t.deepEqual(body, {a: 123});
 });

--- a/test/error.js
+++ b/test/error.js
@@ -66,18 +66,6 @@ test('dns message', async t => {
 	t.is(error.method, 'GET');
 });
 
-test('options.body error message', async t => {
-	await t.throwsAsync(got(s.url, {body: {}}), {
-		message: 'The `body` option must be a stream.Readable, string or Buffer'
-	});
-});
-
-test('options.body json error message', async t => {
-	await t.throwsAsync(got(s.url, {body: Buffer.from('test'), json: true}), {
-		message: 'The `body` option must be an Object or Array when the `json` option is used'
-	});
-});
-
 test('options.body form error message', async t => {
 	await t.throwsAsync(got(s.url, {body: Buffer.from('test'), form: true}), {
 		message: 'The `body` option must be an Object when the `form` option is used'
@@ -89,7 +77,7 @@ test('no plain object restriction on body', async t => {
 		this.a = 123;
 	}
 
-	const {body} = await got(`${s.url}/body`, {body: new CustomObject(), json: true});
+	const {body} = await got(`${s.url}/body`, {body: new CustomObject()}).json();
 
 	t.deepEqual(body, {a: 123});
 });
@@ -186,7 +174,7 @@ test('catch error in mimicResponse', async t => {
 });
 
 test('errors are thrown directly when options.stream is true', t => {
-	t.throws(() => got(s.url, {stream: true, body: {}}), {
-		message: 'The `body` option must be a stream.Readable, string or Buffer'
+	t.throws(() => got(s.url, {stream: true, body: Buffer.from('blah'), form: true}), {
+		message: 'The `body` option must be an Object when the `form` option is used'
 	});
 });

--- a/test/error.js
+++ b/test/error.js
@@ -67,17 +67,17 @@ test('dns message', async t => {
 });
 
 test('options.body form error message', async t => {
-	await t.throwsAsync(got(s.url, {body: Buffer.from('test'), form: true}), {
-		message: 'The `body` option must be an Object when the `form` option is used'
+	await t.throwsAsync(got(s.url, {body: Buffer.from('test'), form: ''}), {
+		message: 'The `body` option cannot be used with the `json` option or `form` option'
 	});
 });
 
-test('no plain object restriction on body', async t => {
+test('no plain object restriction on json body', async t => {
 	function CustomObject() {
 		this.a = 123;
 	}
 
-	const body = await got(`${s.url}/body`, {body: new CustomObject()}).json();
+	const body = await got(`${s.url}/body`, {json: new CustomObject()}).json();
 
 	t.deepEqual(body, {a: 123});
 });

--- a/test/error.js
+++ b/test/error.js
@@ -174,7 +174,7 @@ test('catch error in mimicResponse', async t => {
 });
 
 test('errors are thrown directly when options.stream is true', t => {
-	t.throws(() => got(s.url, {stream: true, body: Buffer.from('blah'), form: true}), {
-		message: 'The `body` option must be an Object when the `form` option is used'
+	t.throws(() => got(s.url, {stream: true, hooks: false}), {
+		message: 'Parameter `hooks` must be an object, not boolean'
 	});
 });

--- a/test/headers.js
+++ b/test/headers.js
@@ -25,22 +25,21 @@ test.after('cleanup', async () => {
 });
 
 test('user-agent', async t => {
-	const headers = (await got(s.url).json()).body;
+	const headers = await got(s.url).json();
 	t.is(headers['user-agent'], `${pkg.name}/${pkg.version} (https://github.com/sindresorhus/got)`);
 });
 
 test('accept-encoding', async t => {
-	const headers = (await got(s.url).json()).body;
+	const headers = await got(s.url).json();
 	t.is(headers['accept-encoding'], 'gzip, deflate');
 });
 
 test('do not override accept-encoding', async t => {
-	const headers = (await got(s.url, {
-		responseType: 'json',
+	const headers = await got(s.url, {
 		headers: {
 			'accept-encoding': 'gzip'
 		}
-	})).body;
+	}).json();
 	t.is(headers['accept-encoding'], 'gzip');
 });
 
@@ -62,27 +61,26 @@ test('do not remove user headers from `url` object argument', async t => {
 });
 
 test('do not set accept-encoding header when decompress options is false', async t => {
-	const {body: headers} = await got(s.url, {
+	const headers = await got(s.url, {
 		decompress: false
 	}).json();
 	t.false(Reflect.has(headers, 'accept-encoding'));
 });
 
 test('accept header with json option', async t => {
-	let headers = (await got(s.url).json()).body;
+	let headers = await got(s.url).json();
 	t.is(headers.accept, 'application/json');
 
-	headers = (await got(s.url, {
+	headers = await got(s.url, {
 		headers: {
 			accept: ''
-		},
-		responseType: 'json'
-	})).body;
+		}
+	}).json();
 	t.is(headers.accept, '');
 });
 
 test('host', async t => {
-	const headers = (await got(s.url).json()).body;
+	const headers = await got(s.url).json();
 	t.is(headers.host, `localhost:${s.port}`);
 });
 
@@ -196,26 +194,26 @@ test('non-existent headers set to undefined are omitted', async t => {
 });
 
 test('preserve port in host header if non-standard port', async t => {
-	const {body} = await got(s.url).json();
+	const body = await got(s.url).json();
 	t.is(body.host, 'localhost:' + s.port);
 });
 
 test('strip port in host header if explicit standard port (:80) & protocol (HTTP)', async t => {
-	const {body} = await got('http://httpbin.org:80/headers').json();
+	const body = await got('http://httpbin.org:80/headers').json();
 	t.is(body.headers.Host, 'httpbin.org');
 });
 
 test('strip port in host header if explicit standard port (:443) & protocol (HTTPS)', async t => {
-	const {body} = await got('https://httpbin.org:443/headers').json();
+	const body = await got('https://httpbin.org:443/headers').json();
 	t.is(body.headers.Host, 'httpbin.org');
 });
 
 test('strip port in host header if implicit standard port & protocol (HTTP)', async t => {
-	const {body} = await got('http://httpbin.org/headers').json();
+	const body = await got('http://httpbin.org/headers').json();
 	t.is(body.headers.Host, 'httpbin.org');
 });
 
 test('strip port in host header if implicit standard port & protocol (HTTPS)', async t => {
-	const {body} = await got('https://httpbin.org/headers').json();
+	const body = await got('https://httpbin.org/headers').json();
 	t.is(body.headers.Host, 'httpbin.org');
 });

--- a/test/headers.js
+++ b/test/headers.js
@@ -25,18 +25,18 @@ test.after('cleanup', async () => {
 });
 
 test('user-agent', async t => {
-	const headers = (await got(s.url, {json: true})).body;
+	const headers = (await got(s.url).json()).body;
 	t.is(headers['user-agent'], `${pkg.name}/${pkg.version} (https://github.com/sindresorhus/got)`);
 });
 
 test('accept-encoding', async t => {
-	const headers = (await got(s.url, {json: true})).body;
+	const headers = (await got(s.url).json()).body;
 	t.is(headers['accept-encoding'], 'gzip, deflate');
 });
 
 test('do not override accept-encoding', async t => {
 	const headers = (await got(s.url, {
-		json: true,
+		responseType: 'json',
 		headers: {
 			'accept-encoding': 'gzip'
 		}
@@ -48,7 +48,7 @@ test('do not remove user headers from `url` object argument', async t => {
 	const headers = (await got({
 		hostname: s.host,
 		port: s.port,
-		json: true,
+		responseType: 'json',
 		protocol: 'http:',
 		headers: {
 			'X-Request-Id': 'value'
@@ -63,27 +63,26 @@ test('do not remove user headers from `url` object argument', async t => {
 
 test('do not set accept-encoding header when decompress options is false', async t => {
 	const {body: headers} = await got(s.url, {
-		json: true,
 		decompress: false
-	});
+	}).json();
 	t.false(Reflect.has(headers, 'accept-encoding'));
 });
 
 test('accept header with json option', async t => {
-	let headers = (await got(s.url, {json: true})).body;
+	let headers = (await got(s.url).json()).body;
 	t.is(headers.accept, 'application/json');
 
 	headers = (await got(s.url, {
 		headers: {
 			accept: ''
 		},
-		json: true
+		responseType: 'json'
 	})).body;
 	t.is(headers.accept, '');
 });
 
 test('host', async t => {
-	const headers = (await got(s.url, {json: true})).body;
+	const headers = (await got(s.url).json()).body;
 	t.is(headers.host, `localhost:${s.port}`);
 });
 
@@ -92,7 +91,7 @@ test('transform names to lowercase', async t => {
 		headers: {
 			'ACCEPT-ENCODING': 'identity'
 		},
-		json: true
+		responseType: 'json'
 	})).body;
 	t.is(headers['accept-encoding'], 'identity');
 });
@@ -197,26 +196,26 @@ test('non-existent headers set to undefined are omitted', async t => {
 });
 
 test('preserve port in host header if non-standard port', async t => {
-	const {body} = await got(s.url, {json: true});
+	const {body} = await got(s.url).json();
 	t.is(body.host, 'localhost:' + s.port);
 });
 
 test('strip port in host header if explicit standard port (:80) & protocol (HTTP)', async t => {
-	const {body} = await got('http://httpbin.org:80/headers', {json: true});
+	const {body} = await got('http://httpbin.org:80/headers').json();
 	t.is(body.headers.Host, 'httpbin.org');
 });
 
 test('strip port in host header if explicit standard port (:443) & protocol (HTTPS)', async t => {
-	const {body} = await got('https://httpbin.org:443/headers', {json: true});
+	const {body} = await got('https://httpbin.org:443/headers').json();
 	t.is(body.headers.Host, 'httpbin.org');
 });
 
 test('strip port in host header if implicit standard port & protocol (HTTP)', async t => {
-	const {body} = await got('http://httpbin.org/headers', {json: true});
+	const {body} = await got('http://httpbin.org/headers').json();
 	t.is(body.headers.Host, 'httpbin.org');
 });
 
 test('strip port in host header if implicit standard port & protocol (HTTPS)', async t => {
-	const {body} = await got('https://httpbin.org/headers', {json: true});
+	const {body} = await got('https://httpbin.org/headers').json();
 	t.is(body.headers.Host, 'httpbin.org');
 });

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -66,7 +66,7 @@ test.after('cleanup', async () => {
 
 test('async hooks', async t => {
 	const {body} = await got(s.url, {
-		json: true,
+		responseType: 'json',
 		hooks: {
 			beforeRequest: [
 				async options => {
@@ -207,7 +207,7 @@ test('init allows modifications', async t => {
 
 test('beforeRequest is called with options', async t => {
 	await got(s.url, {
-		json: true,
+		responseType: 'json',
 		hooks: {
 			beforeRequest: [
 				options => {
@@ -221,7 +221,7 @@ test('beforeRequest is called with options', async t => {
 
 test('beforeRequest allows modifications', async t => {
 	const {body} = await got(s.url, {
-		json: true,
+		responseType: 'json',
 		hooks: {
 			beforeRequest: [
 				options => {
@@ -235,7 +235,7 @@ test('beforeRequest allows modifications', async t => {
 
 test('beforeRedirect is called with options', async t => {
 	await got(`${s.url}/redirect`, {
-		json: true,
+		responseType: 'json',
 		hooks: {
 			beforeRedirect: [
 				options => {
@@ -249,7 +249,7 @@ test('beforeRedirect is called with options', async t => {
 
 test('beforeRedirect allows modifications', async t => {
 	const {body} = await got(`${s.url}/redirect`, {
-		json: true,
+		responseType: 'json',
 		hooks: {
 			beforeRedirect: [
 				options => {
@@ -263,7 +263,7 @@ test('beforeRedirect allows modifications', async t => {
 
 test('beforeRetry is called with options', async t => {
 	await got(`${s.url}/retry`, {
-		json: true,
+		responseType: 'json',
 		retry: 1,
 		throwHttpErrors: false,
 		hooks: {
@@ -280,7 +280,7 @@ test('beforeRetry is called with options', async t => {
 
 test('beforeRetry allows modifications', async t => {
 	const {body} = await got(`${s.url}/retry`, {
-		json: true,
+		responseType: 'json',
 		hooks: {
 			beforeRetry: [
 				options => {
@@ -294,7 +294,7 @@ test('beforeRetry allows modifications', async t => {
 
 test('afterResponse is called with response', async t => {
 	await got(`${s.url}`, {
-		json: true,
+		responseType: 'json',
 		hooks: {
 			afterResponse: [
 				response => {
@@ -309,7 +309,7 @@ test('afterResponse is called with response', async t => {
 
 test('afterResponse allows modifications', async t => {
 	const {body} = await got(`${s.url}`, {
-		json: true,
+		responseType: 'json',
 		hooks: {
 			afterResponse: [
 				response => {

--- a/test/http.js
+++ b/test/http.js
@@ -69,7 +69,7 @@ test('doesn\'t throw on throwHttpErrors === false', async t => {
 });
 
 test('invalid protocol throws', async t => {
-	const error = await t.throwsAsync(got('c:/nope.com', {json: true}));
+	const error = await t.throwsAsync(got('c:/nope.com').json());
 	t.is(error.constructor, got.UnsupportedProtocolError);
 });
 

--- a/test/json-parse.js
+++ b/test/json-parse.js
@@ -42,41 +42,41 @@ test.after('cleanup', async () => {
 });
 
 test('parses response', async t => {
-	t.deepEqual((await got(s.url, {json: true})).body, {data: 'dog'});
+	t.deepEqual((await got(s.url, {responseType: 'json'})).body, {data: 'dog'});
 });
 
 test('not parses responses without a body', async t => {
-	const {body} = await got(`${s.url}/no-body`, {json: true});
+	const {body} = await got(`${s.url}/no-body`, {responseType: 'json'});
 	t.is(body, '');
 });
 
 test('wraps parsing errors', async t => {
-	const error = await t.throwsAsync(got(`${s.url}/invalid`, {json: true}));
+	const error = await t.throwsAsync(got(`${s.url}/invalid`, {responseType: 'json'}));
 	t.regex(error.message, /Unexpected token/);
 	t.true(error.message.includes(error.hostname), error.message);
 	t.is(error.path, '/invalid');
 });
 
 test('parses non-200 responses', async t => {
-	const error = await t.throwsAsync(got(`${s.url}/non200`, {json: true}));
+	const error = await t.throwsAsync(got(`${s.url}/non200`, {responseType: 'json'}));
 	t.deepEqual(error.response.body, {data: 'dog'});
 });
 
 test('ignores errors on invalid non-200 responses', async t => {
-	const error = await t.throwsAsync(got(`${s.url}/non200-invalid`, {json: true}));
+	const error = await t.throwsAsync(got(`${s.url}/non200-invalid`, {responseType: 'json'}));
 	t.is(error.message, 'Response code 500 (Internal Server Error)');
 	t.is(error.response.body, 'Internal error');
 	t.is(error.path, '/non200-invalid');
 });
 
 test('should have statusCode in error', async t => {
-	const error = await t.throwsAsync(got(`${s.url}/invalid`, {json: true}));
+	const error = await t.throwsAsync(got(`${s.url}/invalid`, {responseType: 'json'}));
 	t.is(error.constructor, got.ParseError);
 	t.is(error.statusCode, 200);
 });
 
 test('should set correct headers', async t => {
-	const {body: headers} = await got(`${s.url}/headers`, {json: true, body: {}});
+	const {body: headers} = await got(`${s.url}/headers`, {responseType: 'json', body: {}});
 	t.is(headers['content-type'], 'application/json');
 	t.is(headers.accept, 'application/json');
 });

--- a/test/merge-instances.js
+++ b/test/merge-instances.js
@@ -24,7 +24,7 @@ test('merging instances', async t => {
 	const instanceB = got.extend({baseUrl: s.url});
 	const merged = got.mergeInstances(instanceA, instanceB);
 
-	const headers = (await merged('/', {json: true})).body;
+	const headers = (await merged('/').json()).body;
 	t.is(headers.unicorn, 'rainbow');
 	t.not(headers['user-agent'], undefined);
 });
@@ -55,7 +55,7 @@ test('merges default handlers & custom handlers', async t => {
 	});
 	const merged = got.mergeInstances(instanceA, instanceB);
 
-	const {body: headers} = await merged(s.url, {json: true});
+	const {body: headers} = await merged(s.url).json();
 	t.is(headers.unicorn, 'rainbow');
 	t.is(headers.cat, 'meow');
 });
@@ -69,7 +69,7 @@ test('merging one group & one instance', async t => {
 	const merged = got.mergeInstances(instanceA, instanceB, instanceC);
 	const doubleMerged = got.mergeInstances(merged, instanceD);
 
-	const headers = (await doubleMerged(s.url, {json: true})).body;
+	const headers = (await doubleMerged(s.url).json()).body;
 	t.is(headers.dog, 'woof');
 	t.is(headers.cat, 'meow');
 	t.is(headers.bird, 'tweet');
@@ -87,7 +87,7 @@ test('merging two groups of merged instances', async t => {
 
 	const merged = got.mergeInstances(groupA, groupB);
 
-	const headers = (await merged(s.url, {json: true})).body;
+	const headers = (await merged(s.url).json()).body;
 	t.is(headers.dog, 'woof');
 	t.is(headers.cat, 'meow');
 	t.is(headers.bird, 'tweet');

--- a/test/merge-instances.js
+++ b/test/merge-instances.js
@@ -24,7 +24,7 @@ test('merging instances', async t => {
 	const instanceB = got.extend({baseUrl: s.url});
 	const merged = got.mergeInstances(instanceA, instanceB);
 
-	const headers = (await merged('/').json()).body;
+	const headers = await merged('/').json();
 	t.is(headers.unicorn, 'rainbow');
 	t.not(headers['user-agent'], undefined);
 });
@@ -55,7 +55,7 @@ test('merges default handlers & custom handlers', async t => {
 	});
 	const merged = got.mergeInstances(instanceA, instanceB);
 
-	const {body: headers} = await merged(s.url).json();
+	const headers = await merged(s.url).json();
 	t.is(headers.unicorn, 'rainbow');
 	t.is(headers.cat, 'meow');
 });
@@ -69,7 +69,7 @@ test('merging one group & one instance', async t => {
 	const merged = got.mergeInstances(instanceA, instanceB, instanceC);
 	const doubleMerged = got.mergeInstances(merged, instanceD);
 
-	const headers = (await doubleMerged(s.url).json()).body;
+	const headers = await doubleMerged(s.url).json();
 	t.is(headers.dog, 'woof');
 	t.is(headers.cat, 'meow');
 	t.is(headers.bird, 'tweet');
@@ -87,7 +87,7 @@ test('merging two groups of merged instances', async t => {
 
 	const merged = got.mergeInstances(groupA, groupB);
 
-	const headers = (await merged(s.url).json()).body;
+	const headers = await merged(s.url).json();
 	t.is(headers.dog, 'woof');
 	t.is(headers.cat, 'meow');
 	t.is(headers.bird, 'tweet');

--- a/test/post.js
+++ b/test/post.js
@@ -67,7 +67,7 @@ test('does NOT support sending arrays as forms', async t => {
 test('sends plain objects as JSON', async t => {
 	const {body} = await got(s.url, {
 		body: {such: 'wow'},
-		json: true
+		responseType: 'json'
 	});
 	t.deepEqual(body, {such: 'wow'});
 });
@@ -75,7 +75,7 @@ test('sends plain objects as JSON', async t => {
 test('sends arrays as JSON', async t => {
 	const {body} = await got(s.url, {
 		body: ['such', 'wow'],
-		json: true
+		responseType: 'json'
 	});
 	t.deepEqual(body, ['such', 'wow']);
 });
@@ -135,13 +135,9 @@ test('content-type header is not overriden when object in options.body', async t
 		body: {
 			such: 'wow'
 		},
-		json: true
+		responseType: 'json'
 	});
 	t.is(headers['content-type'], 'doge');
-});
-
-test('throws when json body is not a plain object or array', async t => {
-	await t.throwsAsync(got(`${s.url}`, {body: '{}', json: true}), TypeError);
 });
 
 test('throws when form body is not a plain object or array', async t => {

--- a/test/post.js
+++ b/test/post.js
@@ -51,22 +51,20 @@ test('sends Streams', async t => {
 
 test('sends plain objects as forms', async t => {
 	const {body} = await got(s.url, {
-		body: {such: 'wow'},
-		form: true
+		form: {such: 'wow'}
 	});
 	t.is(body, 'such=wow');
 });
 
 test('does NOT support sending arrays as forms', async t => {
 	await t.throwsAsync(got(s.url, {
-		body: ['such', 'wow'],
-		form: true
+		form: ['such', 'wow']
 	}), TypeError);
 });
 
 test('sends plain objects as JSON', async t => {
 	const {body} = await got(s.url, {
-		body: {such: 'wow'},
+		json: {such: 'wow'},
 		responseType: 'json'
 	});
 	t.deepEqual(body, {such: 'wow'});
@@ -74,7 +72,7 @@ test('sends plain objects as JSON', async t => {
 
 test('sends arrays as JSON', async t => {
 	const {body} = await got(s.url, {
-		body: ['such', 'wow'],
+		json: ['such', 'wow'],
 		responseType: 'json'
 	});
 	t.deepEqual(body, ['such', 'wow']);
@@ -132,7 +130,7 @@ test('content-type header is not overriden when object in options.body', async t
 		headers: {
 			'content-type': 'doge'
 		},
-		body: {
+		json: {
 			such: 'wow'
 		},
 		responseType: 'json'
@@ -141,5 +139,5 @@ test('content-type header is not overriden when object in options.body', async t
 });
 
 test('throws when form body is not a plain object or array', async t => {
-	await t.throwsAsync(got(`${s.url}`, {body: 'such=wow', form: true}), TypeError);
+	await t.throwsAsync(got(`${s.url}`, {form: 'such=wow'}), TypeError);
 });

--- a/test/progress.js
+++ b/test/progress.js
@@ -1,3 +1,4 @@
+
 import util from 'util';
 import fs from 'fs';
 import SlowStream from 'slow-stream';

--- a/test/promise.js
+++ b/test/promise.js
@@ -20,13 +20,13 @@ test.after('cleanup', async () => {
 });
 
 test('should emit request event as promise', async t => {
-	await got(s.url, {json: true}).on('request', request => {
+	await got(s.url).json().on('request', request => {
 		t.true(request instanceof ClientRequest);
 	});
 });
 
 test('should emit response event as promise', async t => {
-	await got(s.url, {json: true}).on('response', response => {
+	await got(s.url).json().on('response', response => {
 		t.true(response instanceof Transform);
 		t.true(response.readable);
 		t.is(response.statusCode, 200);

--- a/test/response-parse.js
+++ b/test/response-parse.js
@@ -43,7 +43,6 @@ test.after('cleanup', async () => {
 	await s.close();
 });
 
-<<<<<<< HEAD:test/response-parse.js
 test('options.resolveBody works', async t => {
 	t.deepEqual(await got(s.url, {responseType: 'json', resolveBody: true}), {data: 'dog'});
 });

--- a/test/response-parse.js
+++ b/test/response-parse.js
@@ -43,6 +43,7 @@ test.after('cleanup', async () => {
 	await s.close();
 });
 
+<<<<<<< HEAD:test/response-parse.js
 test('options.resolveBody works', async t => {
 	t.deepEqual(await got(s.url, {responseType: 'json', resolveBody: true}), {data: 'dog'});
 });

--- a/test/response-parse.js
+++ b/test/response-parse.js
@@ -43,6 +43,10 @@ test.after('cleanup', async () => {
 	await s.close();
 });
 
+test('options.resolveBody works', async t => {
+	t.deepEqual(await got(s.url, {responseType: 'json', resolveBody: true}), {data: 'dog'});
+});
+
 test('JSON response', async t => {
 	t.deepEqual((await got(s.url, {responseType: 'json'})).body, {data: 'dog'});
 });
@@ -52,11 +56,11 @@ test('Buffer response', async t => {
 });
 
 test('JSON response - promise.json()', async t => {
-	t.deepEqual((await got(s.url).json()).body, {data: 'dog'});
+	t.deepEqual(await got(s.url).json(), {data: 'dog'});
 });
 
 test('Buffer response - promise.buffer()', async t => {
-	t.deepEqual((await got(s.url).buffer()).body, Buffer.from(jsonResponse));
+	t.deepEqual(await got(s.url).buffer(), Buffer.from(jsonResponse));
 });
 
 test('throws an error on invalid response type', async t => {
@@ -64,7 +68,7 @@ test('throws an error on invalid response type', async t => {
 });
 
 test('doesn\'t parse responses without a body', async t => {
-	const {body} = await got(`${s.url}/no-body`, {responseType: 'json'});
+	const body = await got(`${s.url}/no-body`).json();
 	t.is(body, '');
 });
 

--- a/test/response-parse.js
+++ b/test/response-parse.js
@@ -43,8 +43,8 @@ test.after('cleanup', async () => {
 	await s.close();
 });
 
-test('options.resolveBody works', async t => {
-	t.deepEqual(await got(s.url, {responseType: 'json', resolveBody: true}), {data: 'dog'});
+test('options.resolveBodyOnly works', async t => {
+	t.deepEqual(await got(s.url, {responseType: 'json', resolveBodyOnly: true}), {data: 'dog'});
 });
 
 test('JSON response', async t => {
@@ -106,7 +106,7 @@ test('should have statusCode in error', async t => {
 });
 
 test('should set correct headers', async t => {
-	const {body: headers} = await got(`${s.url}/headers`, {responseType: 'json', body: {}});
+	const {body: headers} = await got(`${s.url}/headers`, {responseType: 'json', json: {}});
 	t.is(headers['content-type'], 'application/json');
 	t.is(headers.accept, 'application/json');
 });

--- a/test/response-parse.js
+++ b/test/response-parse.js
@@ -4,11 +4,13 @@ import {createServer} from './helpers/server';
 
 let s;
 
+const jsonResponse = '{"data":"dog"}';
+
 test.before('setup', async () => {
 	s = await createServer();
 
 	s.on('/', (request, response) => {
-		response.end('{"data":"dog"}');
+		response.end(jsonResponse);
 	});
 
 	s.on('/invalid', (request, response) => {
@@ -22,7 +24,7 @@ test.before('setup', async () => {
 
 	s.on('/non200', (request, response) => {
 		response.statusCode = 500;
-		response.end('{"data":"dog"}');
+		response.end(jsonResponse);
 	});
 
 	s.on('/non200-invalid', (request, response) => {
@@ -41,11 +43,27 @@ test.after('cleanup', async () => {
 	await s.close();
 });
 
-test('parses response', async t => {
+test('JSON response', async t => {
 	t.deepEqual((await got(s.url, {responseType: 'json'})).body, {data: 'dog'});
 });
 
-test('not parses responses without a body', async t => {
+test('Buffer response', async t => {
+	t.deepEqual((await got(s.url, {responseType: 'buffer'})).body, Buffer.from(jsonResponse));
+});
+
+test('JSON response - promise.json()', async t => {
+	t.deepEqual((await got(s.url).json()).body, {data: 'dog'});
+});
+
+test('Buffer response - promise.buffer()', async t => {
+	t.deepEqual((await got(s.url).buffer()).body, Buffer.from(jsonResponse));
+});
+
+test('throws an error on invalid response type', async t => {
+	await t.throwsAsync(() => got(s.url, {responseType: 'invalid'}), /^Failed to parse body of type 'invalid'/);
+});
+
+test('doesn\'t parse responses without a body', async t => {
 	const {body} = await got(`${s.url}/no-body`, {responseType: 'json'});
 	t.is(body, '');
 });

--- a/test/response-parse.js
+++ b/test/response-parse.js
@@ -55,12 +55,20 @@ test('Buffer response', async t => {
 	t.deepEqual((await got(s.url, {responseType: 'buffer'})).body, Buffer.from(jsonResponse));
 });
 
+test('Text response', async t => {
+	t.is((await got(s.url, {responseType: 'text'})).body, jsonResponse);
+});
+
 test('JSON response - promise.json()', async t => {
 	t.deepEqual(await got(s.url).json(), {data: 'dog'});
 });
 
 test('Buffer response - promise.buffer()', async t => {
 	t.deepEqual(await got(s.url).buffer(), Buffer.from(jsonResponse));
+});
+
+test('Text response - promise.text()', async t => {
+	t.is(await got(s.url).text(), jsonResponse);
 });
 
 test('throws an error on invalid response type', async t => {

--- a/test/stream.js
+++ b/test/stream.js
@@ -43,6 +43,10 @@ test.after('cleanup', async () => {
 	await s.close();
 });
 
+test('options.responseType is ignored', t => {
+	t.notThrows(() => got.stream(s.url, {responseType: 'json'}));
+});
+
 test('returns readable stream', async t => {
 	const data = await pEvent(got.stream(s.url), 'data');
 	t.is(data.toString(), 'ok');

--- a/test/stream.js
+++ b/test/stream.js
@@ -43,10 +43,6 @@ test.after('cleanup', async () => {
 	await s.close();
 });
 
-test('options.json is ignored', t => {
-	t.notThrows(() => got.stream(s.url, {json: true}));
-});
-
 test('returns readable stream', async t => {
 	const data = await pEvent(got.stream(s.url), 'data');
 	t.is(data.toString(), 'ok');


### PR DESCRIPTION
Fixes #671 

### 🎉 New options

#### `options.responseType`

The option may be set to `json`, `buffer`, `text` or be empty (it defaults to `text`).

#### `options.resolveBody`

If set to `true`, the promise will return the Response body instead of the Response.

There are some shortcuts:

#### promise.json()

Automatically sets `options.responseType` to `json` and `options.resolveBody` to true.
Returns the promise.

#### promise.buffer()

Automatically sets `options.responseType` to `buffer` and `options.resolveBody` to true.
Returns the promise.

#### promise.text()

Automatically sets `options.responseType` to `text` and `options.resolveBody` to true.
Returns the promise.

### ❗️ Removed options

#### `options.json`

The body will be `JSON.parse`d automatically when it's an object/array.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] If it's a new feature, I have included documentation updates.
