### PR TITLE
Add `beforeError` hook

### DIFF
--- a/advanced-creation.md
+++ b/advanced-creation.md
@@ -98,11 +98,11 @@ const defaults = {
 			'user-agent': `${pkg.name}/${pkg.version} (https://github.com/sindresorhus/got)`
 		},
 		hooks: {
+			beforeError: [],
 			beforeRequest: [],
 			beforeRedirect: [],
 			beforeRetry: [],
-			afterResponse: [],
-			onError: []
+			afterResponse: []
 		},
 		decompress: true,
 		throwHttpErrors: true,

--- a/advanced-creation.md
+++ b/advanced-creation.md
@@ -101,7 +101,8 @@ const defaults = {
 			beforeRequest: [],
 			beforeRedirect: [],
 			beforeRetry: [],
-			afterResponse: []
+			afterResponse: [],
+			onError: []
 		},
 		decompress: true,
 		throwHttpErrors: true,

--- a/readme.md
+++ b/readme.md
@@ -463,7 +463,9 @@ const instance = got.extend({
 Type: `Function[]`<br>
 Default: `[]`
 
-Called with an `Error` instance. The error is passed to the hook right before it's thrown. This is especially useful when you want to have more detailed errors. Example:
+Called with an `Error` instance. The error is passed to the hook right before it's thrown. This is especially useful when you want to have more detailed errors.
+
+**Note**: errors thrown while normalizing options are thrown directly.
 
 ```js	
 const got = require('got');	

--- a/readme.md
+++ b/readme.md
@@ -465,7 +465,7 @@ Default: `[]`
 
 Called with an `Error` instance. The error is passed to the hook right before it's thrown. This is especially useful when you want to have more detailed errors.
 
-**Note**: errors thrown while normalizing options are thrown directly.
+**Note**: Errors thrown while normalizing input options are thrown directly and not part of this hook.
 
 ```js	
 const got = require('got');	

--- a/readme.md
+++ b/readme.md
@@ -452,7 +452,26 @@ const instance = got.extend({
 Type: `Function[]`<br>
 Default: `[]`
 
-Called with an `Error` instance. The error is passed to the hook right before it's thrown. This is especially useful when you want to have more detailed errors.
+Called with an `Error` instance. The error is passed to the hook right before it's thrown. This is especially useful when you want to have more detailed errors. Example:
+
+```js	
+const got = require('got');	
+got('api.github.com/someEndpoint', {	
+	hooks: {	
+		onError: [	
+			error => {	
+				const {response} = error;	
+ 				if (response && response.body) {	
+					error.name = 'GitHubError';	
+					error.message = `${response.body.message} (${error.statusCode})`;	
+				}
+
+ 				return error;	
+			}	
+		]	
+	}	
+});	
+```
 
 #### Response
 

--- a/readme.md
+++ b/readme.md
@@ -456,7 +456,8 @@ Called with an `Error` instance. The error is passed to the hook right before it
 
 ```js	
 const got = require('got');	
-got('api.github.com/someEndpoint', {	
+
+got('api.github.com/some-endpoint', {	
 	hooks: {	
 		onError: [	
 			error => {	

--- a/readme.md
+++ b/readme.md
@@ -447,6 +447,38 @@ const instance = got.extend({
 });
 ```
 
+###### hooks.onError
+
+Type: `Function[]`<br>
+Default: `[]`
+
+Called with an `Error` instance. The error is passed to the hook right before it's thrown. This is especially useful when you want to have more detailed errors. Example:
+
+```js
+const got = require('got');
+
+got('api.github.com/someEndpoint', {
+	hooks: {
+		onError: [
+			error => {
+				const {response} = error;
+
+				if (response && response.body) {
+					error.name = 'GitHubError';
+					error.message = `${response.body.message} (${error.statusCode})`;
+				}
+
+				if (response) {
+					error.rateLimit = getRateLimit(response);
+				}
+
+				return error;
+			}
+		]
+	}
+});
+```
+
 #### Response
 
 The response object will typically be a [Node.js HTTP response stream](https://nodejs.org/api/http.html#http_class_http_incomingmessage), however, if returned from the cache it will be a [response-like object](https://github.com/lukechilds/responselike) which behaves in the same way.

--- a/readme.md
+++ b/readme.md
@@ -452,32 +452,7 @@ const instance = got.extend({
 Type: `Function[]`<br>
 Default: `[]`
 
-Called with an `Error` instance. The error is passed to the hook right before it's thrown. This is especially useful when you want to have more detailed errors. Example:
-
-```js
-const got = require('got');
-
-got('api.github.com/someEndpoint', {
-	hooks: {
-		onError: [
-			error => {
-				const {response} = error;
-
-				if (response && response.body) {
-					error.name = 'GitHubError';
-					error.message = `${response.body.message} (${error.statusCode})`;
-				}
-
-				if (response) {
-					error.rateLimit = getRateLimit(response);
-				}
-
-				return error;
-			}
-		]
-	}
-});
-```
+Called with an `Error` instance. The error is passed to the hook right before it's thrown. This is especially useful when you want to have more detailed errors.
 
 #### Response
 

--- a/readme.md
+++ b/readme.md
@@ -447,7 +447,7 @@ const instance = got.extend({
 });
 ```
 
-###### hooks.onError
+###### hooks.beforeError
 
 Type: `Function[]`<br>
 Default: `[]`

--- a/source/known-hook-events.js
+++ b/source/known-hook-events.js
@@ -4,5 +4,6 @@ module.exports = [
 	'beforeRequest',
 	'beforeRedirect',
 	'beforeRetry',
-	'afterResponse'
+	'afterResponse',
+	'onError'
 ];

--- a/source/known-hook-events.js
+++ b/source/known-hook-events.js
@@ -1,9 +1,9 @@
 'use strict';
 
 module.exports = [
+	'beforeError',
 	'beforeRequest',
 	'beforeRedirect',
 	'beforeRetry',
-	'afterResponse',
-	'onError'
+	'afterResponse'
 ];

--- a/source/request-as-event-emitter.js
+++ b/source/request-as-event-emitter.js
@@ -33,6 +33,19 @@ module.exports = (options, input) => {
 	const getCookieString = options.cookieJar ? util.promisify(options.cookieJar.getCookieString.bind(options.cookieJar)) : null;
 	const agents = is.object(options.agent) ? options.agent : null;
 
+	const emitError = async error => {
+		try {
+			for (const hook of options.hooks.onError) {
+				// eslint-disable-next-line no-await-in-loop
+				error = await hook(error);
+			}
+
+			emitter.emit('error', error);
+		} catch (error2) {
+			emitter.emit('error', error2);
+		}
+	};
+
 	const get = async options => {
 		const currentUrl = redirectString || requestUrl;
 
@@ -141,7 +154,7 @@ module.exports = (options, input) => {
 
 				getResponse(response, options, emitter);
 			} catch (error) {
-				emitter.emit('error', error);
+				emitError(error);
 			}
 		};
 
@@ -166,7 +179,7 @@ module.exports = (options, input) => {
 				}
 
 				if (emitter.retry(error) === false) {
-					emitter.emit('error', error);
+					emitError(error);
 				}
 			});
 
@@ -198,7 +211,7 @@ module.exports = (options, input) => {
 					request.end(uploadComplete);
 				}
 			} catch (error) {
-				emitter.emit('error', new RequestError(error, options));
+				emitError(new RequestError(error, options));
 			}
 		};
 
@@ -208,9 +221,9 @@ module.exports = (options, input) => {
 
 			cacheRequest.once('error', error => {
 				if (error instanceof CacheableRequest.RequestError) {
-					emitter.emit('error', new RequestError(error, options));
+					emitError(new RequestError(error, options));
 				} else {
-					emitter.emit('error', new CacheError(error, options));
+					emitError(new CacheError(error, options));
 				}
 			});
 
@@ -220,7 +233,7 @@ module.exports = (options, input) => {
 			try {
 				handleRequest(fn.request(options, handleResponse));
 			} catch (error) {
-				emitter.emit('error', new RequestError(error, options));
+				emitError(new RequestError(error, options));
 			}
 		}
 	};
@@ -231,7 +244,7 @@ module.exports = (options, input) => {
 		try {
 			backoff = options.retry.retries(++retryCount, error);
 		} catch (error2) {
-			emitter.emit('error', error2);
+			emitError(error2);
 			return;
 		}
 
@@ -245,7 +258,7 @@ module.exports = (options, input) => {
 
 					await get(options);
 				} catch (error) {
-					emitter.emit('error', error);
+					emitError(error);
 				}
 			};
 
@@ -291,7 +304,7 @@ module.exports = (options, input) => {
 
 			await get(options);
 		} catch (error) {
-			emitter.emit('error', error);
+			emitError(error);
 		}
 	});
 

--- a/source/request-as-event-emitter.js
+++ b/source/request-as-event-emitter.js
@@ -35,7 +35,7 @@ module.exports = (options, input) => {
 
 	const emitError = async error => {
 		try {
-			for (const hook of options.hooks.onError) {
+			for (const hook of options.hooks.beforeError) {
 				// eslint-disable-next-line no-await-in-loop
 				error = await hook(error);
 			}

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -362,7 +362,7 @@ test('onError allows modifications', async t => {
 			throw error;
 		},
 		hooks: {
-			onError: [error2 => {
+			onError: [() => {
 				return new Error(errorString2);
 			}]
 		}

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -129,11 +129,11 @@ test('catches afterResponse errors', async t => {
 	}), errorString);
 });
 
-test('catches onError errors', async t => {
+test('catches beforeError errors', async t => {
 	await t.throwsAsync(() => got(s.url, {
 		request: () => {},
 		hooks: {
-			onError: [() => Promise.reject(error)]
+			beforeError: [() => Promise.reject(error)]
 		}
 	}), errorString);
 });
@@ -340,13 +340,13 @@ test.serial('doesn\'t throw on afterResponse retry HTTP failure if throwHttpErro
 	t.is(statusCode, 500);
 });
 
-test('onError is called with an error', async t => {
+test('beforeError is called with an error', async t => {
 	await t.throwsAsync(() => got(s.url, {
 		request: () => {
 			throw error;
 		},
 		hooks: {
-			onError: [error2 => {
+			beforeError: [error2 => {
 				t.true(error2 instanceof Error);
 				return error2;
 			}]
@@ -354,7 +354,7 @@ test('onError is called with an error', async t => {
 	}), errorString);
 });
 
-test('onError allows modifications', async t => {
+test('beforeError allows modifications', async t => {
 	const errorString2 = 'foobar';
 
 	await t.throwsAsync(() => got(s.url, {
@@ -362,7 +362,7 @@ test('onError allows modifications', async t => {
 			throw error;
 		},
 		hooks: {
-			onError: [() => {
+			beforeError: [() => {
 				return new Error(errorString2);
 			}]
 		}

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -129,6 +129,15 @@ test('catches afterResponse errors', async t => {
 	}), errorString);
 });
 
+test('catches onError errors', async t => {
+	await t.throwsAsync(() => got(s.url, {
+		request: null,
+		hooks: {
+			onError: [() => Promise.reject(error)]
+		}
+	}), errorString);
+});
+
 test('beforeRequest', async t => {
 	await got(s.url, {
 		json: true,
@@ -329,4 +338,33 @@ test.serial('doesn\'t throw on afterResponse retry HTTP failure if throwHttpErro
 		}
 	});
 	t.is(statusCode, 500);
+});
+
+test('onError is called with an error', async t => {
+	await t.throwsAsync(() => got(s.url, {
+		request: () => {
+			throw error;
+		},
+		hooks: {
+			onError: [error2 => {
+				t.true(error2 instanceof Error);
+				return error2;
+			}]
+		}
+	}), errorString);
+});
+
+test('onError allows modifications', async t => {
+	const errorString2 = 'foobar';
+
+	await t.throwsAsync(() => got(s.url, {
+		request: () => {
+			throw error;
+		},
+		hooks: {
+			onError: [error2 => {
+				return new Error(errorString2);
+			}]
+		}
+	}), errorString2);
 });

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -131,7 +131,7 @@ test('catches afterResponse errors', async t => {
 
 test('catches onError errors', async t => {
 	await t.throwsAsync(() => got(s.url, {
-		request: null,
+		request: () => {},
 		hooks: {
 			onError: [() => Promise.reject(error)]
 		}


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/gh-got/blob/master/index.js

Instead using handler we could do:

```js
hooks: {
	beforeRequest: [
		options => {
			if (options.token) {
				options.headers.authorization = options.headers.authorization || `token ${options.token}`;
			}
		}
	],
	afterResponse: [
		response => {
			response.rateLimit = getRateLimit(response);
			return response;
		}
	],
	onError: [
		error => {
			const {response} = error;

			if (response && response.body) {
				error.name = 'GitHubError';
				error.message = `${response.body.message} (${error.statusCode})`;
			}

			if (response) {
				error.rateLimit = getRateLimit(response);
			}

			return error;
		}
	]
}
```

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] If it's a new feature, I have included documentation updates.
