### PR TITLE
Add support for Brotli encoding

### DIFF
--- a/advanced-creation.md
+++ b/advanced-creation.md
@@ -253,7 +253,7 @@ const merged = got.mergeInstances(controlRedirects, limitDownloadUpload, httpbin
 	await merged('/');
 	/* HTTP Request =>
 	 * GET / HTTP/1.1
-	 * accept-encoding: gzip, deflate
+	 * accept-encoding: gzip, deflate, br
 	 * sign: F9E66E179B6747AE54108F82F8ADE8B3C25D76FD30AFDE6C395822C530196169
 	 * Host: httpbin.org
 	 * Connection: close

--- a/package.json
+++ b/package.json
@@ -34,17 +34,18 @@
 		"fetch",
 		"net",
 		"network",
-		"electron"
+		"electron",
+		"brotli"
 	],
 	"dependencies": {
 		"@sindresorhus/is": "^0.14.0",
 		"@szmarczak/http-timer": "^1.1.2",
 		"cacheable-request": "^6.0.0",
-		"decompress-response": "^3.3.0",
+		"decompress-response": "^4.0.0",
 		"duplexer3": "^0.1.4",
 		"get-stream": "^4.1.0",
 		"lowercase-keys": "^1.0.1",
-		"mimic-response": "^1.0.1",
+		"mimic-response": "^2.0.0",
 		"p-cancelable": "^1.0.0",
 		"to-readable-stream": "^1.0.0"
 	},

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ Got is for Node.js. For browsers, we recommend [Ky](https://github.com/sindresor
 - [Follows redirects](#followredirect)
 - [Retries on failure](#retry)
 - [Progress events](#onuploadprogress-progress)
-- [Handles gzip/deflate](#decompress)
+- [Handles gzip/deflate/brotli](#decompress)
 - [Timeout handling](#timeout)
 - [Errors with metadata](#errors)
 - [JSON mode](#json-mode)
@@ -317,7 +317,9 @@ Note that if a `303` is sent by the server in response to any request type (`POS
 Type: `boolean`<br>
 Default: `true`
 
-Decompress the response automatically. This will set the `accept-encoding` header to `gzip, deflate` unless you set it yourself.
+Decompress the response automatically. This will set the `accept-encoding` header to `gzip, deflate, br` on Node.js 11.7.0+ or `gzip, deflate` for older Node.js versions, unless you set it yourself.
+
+Brotli (`br`) support requires Node.js 11.7.0 or later.
 
 If this is disabled, a compressed response is returned as a `Buffer`. This may be useful if you want to handle decompression yourself or stream the raw compressed data.
 

--- a/source/normalize-arguments.js
+++ b/source/normalize-arguments.js
@@ -5,6 +5,7 @@ const is = require('@sindresorhus/is');
 const lowercaseKeys = require('lowercase-keys');
 const urlToOptions = require('./utils/url-to-options').default;
 const validateSearchParams = require('./utils/validate-search-params');
+const supportsBrotli = require('./utils/supports-brotli').default;
 const merge = require('./merge');
 const knownHookEvents = require('./known-hook-events').default;
 
@@ -193,7 +194,7 @@ const normalize = (url, options, defaults) => {
 	}
 
 	if (options.decompress && is.undefined(headers['accept-encoding'])) {
-		headers['accept-encoding'] = 'gzip, deflate';
+		headers['accept-encoding'] = supportsBrotli ? 'gzip, deflate, br' : 'gzip, deflate';
 	}
 
 	if (options.method) {

--- a/source/utils/supports-brotli.ts
+++ b/source/utils/supports-brotli.ts
@@ -1,0 +1,3 @@
+import zlib from 'zlib';
+
+export default typeof (zlib as any).createBrotliDecompress === 'function';

--- a/test/headers.js
+++ b/test/headers.js
@@ -4,6 +4,7 @@ import path from 'path';
 import test from 'ava';
 import FormData from 'form-data';
 import got from '../dist';
+import supportsBrotli from '../dist/utils/supports-brotli';
 import pkg from '../package';
 import {createServer} from './helpers/server';
 
@@ -31,7 +32,7 @@ test('user-agent', async t => {
 
 test('accept-encoding', async t => {
 	const headers = await got(s.url).json();
-	t.is(headers['accept-encoding'], 'gzip, deflate');
+	t.is(headers['accept-encoding'], supportsBrotli ? 'gzip, deflate, br' : 'gzip, deflate');
 });
 
 test('do not override accept-encoding', async t => {
@@ -56,7 +57,7 @@ test('do not remove user headers from `url` object argument', async t => {
 
 	t.is(headers.accept, 'application/json');
 	t.is(headers['user-agent'], `${pkg.name}/${pkg.version} (https://github.com/sindresorhus/got)`);
-	t.is(headers['accept-encoding'], 'gzip, deflate');
+	t.is(headers['accept-encoding'], supportsBrotli ? 'gzip, deflate, br' : 'gzip, deflate');
 	t.is(headers['x-request-id'], 'value');
 });
 


### PR DESCRIPTION
When using Node.js 11.7.0 or later.


// @kevva @silverwind