### PR TITLE
Simpler instance creation

### DIFF
--- a/advanced-creation.md
+++ b/advanced-creation.md
@@ -79,6 +79,36 @@ const unicorn = got.create(settings);
 const unicorn = got.extend({headers: {unicorn: 'rainbow'}});
 ```
 
+**Note:** handlers can be asynchronous. The recommended approach is:
+
+```js
+const handler = (options, next) => {
+	if (!options.stream) {
+		// It's a Promise
+
+		return (async () => {
+			try {
+				const result = await next(options);
+
+				result.modifiedByHandler = true;
+
+				return result;
+			} catch (error) {
+				// Every error will be replaced by this one.
+				// Before you will receive any error here,
+				// it will be passed to `beforeError` hooks first.
+
+				// Note: this one won't be passed to `beforeError` hook. It's final.
+				throw new Error('Your very own error.');
+			}
+		})();
+	}
+
+	// It's a Stream
+	return next(options);
+};
+```
+
 ### Merging instances
 
 Got supports composing multiple instances together. This is very powerful. You can create a client that limits download speed and then compose it with an instance that signs a request. It's like plugins without any of the plugin mess. You just create instances and then compose them together.

--- a/documentation/advanced-creation.md
+++ b/documentation/advanced-creation.md
@@ -135,7 +135,7 @@ const controlRedirects = got.extend({
 	handlers: [
 		(options, next) => {
 			const promiseOrStream = next(options);
-			return promiseOrStream.on('redirect', resp => {
+			return promiseOrStream.on('redirect', response => {
 				const host = new URL(resp.url).host;
 				if (options.allowedHosts && !options.allowedHosts.includes(host)) {
 					promiseOrStream.cancel(`Redirection to ${host} is not allowed`);

--- a/documentation/advanced-creation.md
+++ b/documentation/advanced-creation.md
@@ -12,7 +12,7 @@ Configures a new `got` instance with the provided settings. You can access the r
 
 ##### [options](readme.md#options)
 
-To inherit from parent, set it to `got.defaults.options` or use [`got.mergeOptions(defaults.options, options)`](../readme.md#gotmergeoptionsparentoptions-newoptions).<br>
+To inherit from the parent, set it to `got.defaults.options` or use [`got.mergeOptions(defaults.options, options)`](../readme.md#gotmergeoptionsparentoptions-newoptions).<br>
 **Note:** Avoid using [object spread](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_object_literals) as it doesn't work recursively.
 
 **Note #2:** [`got.mergeOptions()`](../readme.md#gotmergeoptionsparentoptions-newoptions) does not merge hooks. Use [`got.extend()`](../readme.md#gotextendinstances) instead.

--- a/documentation/advanced-creation.md
+++ b/documentation/advanced-creation.md
@@ -49,8 +49,7 @@ const settings = {
 	handlers: [
 		(options, next) => {
 			if (options.stream) {
-				// It's a Stream
-				// We can perform stream-specific actions on it
+				// It's a Stream, so we can perform stream-specific actions on it
 				return next(options)
 					.on('request', request => setTimeout(() => request.abort(), 50));
 			}

--- a/documentation/advanced-creation.md
+++ b/documentation/advanced-creation.md
@@ -103,7 +103,7 @@ const handler = (options, next) => {
 
 				return result;
 			} catch (error) {
-				// Every error will be replaced by this one.
+				// Every error will be replaced by the one thrown here.
 				// Before you will receive any error here,
 				// it will be passed to `beforeError` hooks first.
 

--- a/documentation/advanced-creation.md
+++ b/documentation/advanced-creation.md
@@ -51,7 +51,11 @@ const settings = {
 			if (options.stream) {
 				// It's a Stream, so we can perform stream-specific actions on it
 				return next(options)
-					.on('request', request => setTimeout(() => request.abort(), 50));
+					.on('request', request => {
+						setTimeout(() => {
+							request.abort();
+						}, 50);
+					});
 			}
 
 			// It's a Promise

--- a/documentation/advanced-creation.md
+++ b/documentation/advanced-creation.md
@@ -151,7 +151,7 @@ It can be useful when your machine has limited amount of memory.
 
 ```js
 const limitDownloadUpload = got.extend({
-    handlers: [
+	handlers: [
 		(options, next) => {
 			let promiseOrStream = next(options);
 			if (typeof options.downloadLimit === 'number') {

--- a/documentation/advanced-creation.md
+++ b/documentation/advanced-creation.md
@@ -148,7 +148,7 @@ const controlRedirects = got.extend({
 
 #### Limiting download & upload
 
-It's very useful in case your machine's got a little amount of RAM.
+It can be useful when your machine has limited amount of memory.
 
 ```js
 const limitDownloadUpload = got.extend({

--- a/documentation/advanced-creation.md
+++ b/documentation/advanced-creation.md
@@ -199,6 +199,7 @@ const httpbin = got.extend({
 
 ```js
 const crypto = require('crypto');
+
 const getMessageSignature = (data, secret) => crypto.createHmac('sha256', secret).update(data).digest('hex').toUpperCase();
 const signRequest = got.extend({
 	hooks: {

--- a/documentation/advanced-creation.md
+++ b/documentation/advanced-creation.md
@@ -22,7 +22,7 @@ To inherit from the parent, set it to `got.defaults.options` or use [`got.mergeO
 Type: `boolean`<br>
 Default: `false`
 
-States if the defaults are mutable. It's very useful when you need to [update headers over time](readme.md#hooksafterresponse), e.g. update the access token when it expires.
+States if the defaults are mutable. It can be useful when you need to [update headers over time](readme.md#hooksafterresponse), for example, update an access token when it expires.
 
 ##### handlers
 

--- a/documentation/advanced-creation.md
+++ b/documentation/advanced-creation.md
@@ -97,7 +97,7 @@ const handler = (options, next) => {
 
 		return (async () => {
 			try {
-				const result = await next(options);
+				const promiseOrStream = await next(options);
 
 				result.modifiedByHandler = true;
 

--- a/documentation/advanced-creation.md
+++ b/documentation/advanced-creation.md
@@ -88,7 +88,7 @@ const unicorn = got.create(settings);
 const unicorn = got.extend({headers: {unicorn: 'rainbow'}});
 ```
 
-**Note:** handlers can be asynchronous. The recommended approach is:
+**Note:** Handlers can be asynchronous. The recommended approach is:
 
 ```js
 const handler = (options, next) => {

--- a/documentation/advanced-creation.md
+++ b/documentation/advanced-creation.md
@@ -31,7 +31,7 @@ Default: `[]`
 
 An array of functions. These are very special, because they're called first.
 
-To inherit from parent, set it as `got.defaults.handlers`.<br>
+To inherit from the parent, set it as `got.defaults.handlers`.<br>
 To use the default handler, just omit specifying this.
 
 Each handler takes two arguments:

--- a/documentation/advanced-creation.md
+++ b/documentation/advanced-creation.md
@@ -6,31 +6,35 @@
 
 Example: [gh-got](https://github.com/sindresorhus/gh-got/blob/master/index.js)
 
-Configure a new `got` instance with the provided settings. You can access the resolved options with the `.defaults` property on the instance.
+Configures a new `got` instance with the provided settings. You can access the resolved options with the `.defaults` property on the instance.
 
-**Note:** In contrast to `got.extend()`, this method has no defaults.
+**Note:** In contrast to [`got.extend()`](../readme.md#gotextendinstances), this method has no defaults.
 
 ##### [options](readme.md#options)
 
-To inherit from parent, set it as `got.defaults.options` or use [`got.mergeOptions(defaults.options, options)`](readme.md#gotmergeoptionsparentoptions-newoptions).<br>
-**Note**: Avoid using [object spread](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_object_literals) as it doesn't work recursively.
+To inherit from parent, set it to `got.defaults.options` or use [`got.mergeOptions(defaults.options, options)`](../readme.md#gotmergeoptionsparentoptions-newoptions).<br>
+**Note:** Avoid using [object spread](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_object_literals) as it doesn't work recursively.
+
+**Note #2:** [`got.mergeOptions()`](../readme.md#gotmergeoptionsparentoptions-newoptions) does not merge hooks. Use [`got.extend()`](../readme.md#gotextendinstances) instead.
 
 ##### mutableDefaults
 
 Type: `boolean`<br>
 Default: `false`
 
-States if the defaults are mutable. It's very useful when you need to [update headers over time](readme.md#hooksafterresponse).
+States if the defaults are mutable. It's very useful when you need to [update headers over time](readme.md#hooksafterresponse), e.g. update the access token when it expires.
 
-##### handler
+##### handlers
 
-Type: `Function`<br>
-Default: `undefined`
+Type: `Function[]`<br>
+Default: `[]`
 
-A function making additional changes to the request.
+An array of functions. These are very special, because they're called first.
 
-To inherit from parent, set it as `got.defaults.handler`.<br>
+To inherit from parent, set it as `got.defaults.handlers`.<br>
 To use the default handler, just omit specifying this.
+
+Each handler takes two arguments:
 
 ###### [options](readme.md#options)
 
@@ -42,17 +46,19 @@ Returns a `Promise` or a `Stream` depending on [`options.stream`](readme.md#stre
 
 ```js
 const settings = {
-	handler: (options, next) => {
-		if (options.stream) {
-			// It's a Stream
-			// We can perform stream-specific actions on it
-			return next(options)
-				.on('request', request => setTimeout(() => request.abort(), 50));
-		}
+	handlers: [
+		(options, next) => {
+			if (options.stream) {
+				// It's a Stream
+				// We can perform stream-specific actions on it
+				return next(options)
+					.on('request', request => setTimeout(() => request.abort(), 50));
+			}
 
-		// It's a Promise
-		return next(options);
-	},
+			// It's a Promise
+			return next(options);
+		}
+	],
 	options: got.mergeOptions(got.defaults.options, {
 		responseType: 'json'
 	})
@@ -113,7 +119,7 @@ const handler = (options, next) => {
 
 Got supports composing multiple instances together. This is very powerful. You can create a client that limits download speed and then compose it with an instance that signs a request. It's like plugins without any of the plugin mess. You just create instances and then compose them together.
 
-Just use `instanceA.extend(instanceB, instanceC, ...)`, that's all.
+To mix them use `instanceA.extend(instanceB, instanceC, ...)`, that's all.
 
 ## Examples
 

--- a/documentation/examples/gh-got.js
+++ b/documentation/examples/gh-got.js
@@ -1,0 +1,61 @@
+'use strict';
+const package = require('../../package');
+const got = require('got');
+
+const getRateLimit = ({headers}) => ({
+	limit: parseInt(headers['x-ratelimit-limit'], 10),
+	remaining: parseInt(headers['x-ratelimit-remaining'], 10),
+	reset: new Date(parseInt(headers['x-ratelimit-reset'], 10) * 1000)
+});
+
+const instance = got.extend({
+	baseUrl: 'https://api.github.com',
+	headers: {
+		accept: 'application/vnd.github.v3+json',
+		'user-agent': `${package.name}/${package.version}`
+	},
+	responseType: 'json',
+	token: process.env.GITHUB_TOKEN,
+	handlers: [
+		(options, next) => {
+			// Authorization
+			if (options.token && !options.headers.authorization) {
+				options.headers.authorization = `token ${options.token}`;
+			}
+
+			// Don't touch streams
+			if (options.stream) {
+				return next(options);
+			}
+
+			// Magic begins.
+			return (async () => {
+				try {
+					const response = await next(options);
+
+					// Rate limit for the Response object
+					response.rateLimit = getRateLimit(response.headers);
+
+					return response;
+				} catch (error) {
+					const {response} = error;
+
+					// Nicer errors
+					if (response && response.body) {
+						error.name = 'GitHubError';
+						error.message = `${response.body.message} (${error.statusCode} status code)`;
+					}
+
+					// Rate limit for errors
+					if (response) {
+						error.rateLimit = getRateLimit(response.headers);
+					}
+
+					throw error;
+				}
+			})();
+		}
+	]
+});
+
+module.exports = instance;

--- a/documentation/examples/gh-got.js
+++ b/documentation/examples/gh-got.js
@@ -28,7 +28,7 @@ const instance = got.extend({
 				return next(options);
 			}
 
-			// Magic begins.
+			// Magic begins
 			return (async () => {
 				try {
 					const response = await next(options);

--- a/documentation/examples/gh-got.js
+++ b/documentation/examples/gh-got.js
@@ -1,6 +1,6 @@
 'use strict';
+const got = require('../..');
 const package = require('../../package');
-const got = require('got');
 
 const getRateLimit = ({headers}) => ({
 	limit: parseInt(headers['x-ratelimit-limit'], 10),

--- a/documentation/lets-make-a-plugin.md
+++ b/documentation/lets-make-a-plugin.md
@@ -8,7 +8,7 @@ When it comes to advanced usage, custom instances are really helpful.
 For example, take a look at [`gh-got`](https://github.com/sindresorhus/gh-got).
 It looks pretty complicated, but... it's really not.
 
-Before we start, we need to find the GitHub API docs: https://developer.github.com/v3/
+Before we start, we need to find the [GitHub API docs](https://developer.github.com/v3/).
 
 Let's write down the most important information:
 1. The root endpoint is `https://api.github.com/`.

--- a/documentation/lets-make-a-plugin.md
+++ b/documentation/lets-make-a-plugin.md
@@ -12,7 +12,7 @@ Before we start, we need to find the [GitHub API docs](https://developer.github.
 
 Let's write down the most important information:
 1. The root endpoint is `https://api.github.com/`.
-2. We will use the V3 API vesion.<br>
+2. We will use version 3 of the API.<br>
    The `Accept` header needs to be set to `application/vnd.github.v3+json`.
 3. The body is in a JSON format.
 4. We will use OAuth2 for authorization.

--- a/documentation/lets-make-a-plugin.md
+++ b/documentation/lets-make-a-plugin.md
@@ -34,7 +34,7 @@ When we have all the necessary info, we can start mixing :cake:
 
 ### The root endpoint
 
-Not much to do here, just extend an instance and provide `baseUrl` option:
+Not much to do here, just extend an instance and provide the `baseUrl` option:
 
 ```js
 'use strict';

--- a/documentation/lets-make-a-plugin.md
+++ b/documentation/lets-make-a-plugin.md
@@ -76,7 +76,7 @@ const instance = got.extend({
 
 ### Authorization
 
-It's popular to set some environment variables, say `GITHUB_TOKEN`. You can modify the tokens in all your apps easily, right? Cool. What about... we want to provide a unique token for each app. Then we will need to create a new option - it will default to the environment variable, but you can easily override it.
+It's common to set some environment variables, for example, `GITHUB_TOKEN`. You can modify the tokens in all your apps easily, right? Cool. What about... we want to provide a unique token for each app. Then we will need to create a new option - it will default to the environment variable, but you can easily override it.
 
 Let's use handlers instead of hooks, our code will be more readable later.
 

--- a/documentation/lets-make-a-plugin.md
+++ b/documentation/lets-make-a-plugin.md
@@ -236,7 +236,7 @@ const instance = got.extend({
 
 ## Woah. Is that it?
 
-Yup. View the full source code [here](examples/gh-got.js). Here's an example how to use it:
+Yup. View the full source code [here](examples/gh-got.js). Here's an example of how to use it:
 
 ```js
 const ghGot = require('gh-got');

--- a/documentation/lets-make-a-plugin.md
+++ b/documentation/lets-make-a-plugin.md
@@ -37,7 +37,6 @@ When we have all the necessary info, we can start mixing :cake:
 Not much to do here, just extend an instance and provide the `baseUrl` option:
 
 ```js
-'use strict';
 const got = require('got');
 
 const instance = got.extend({
@@ -52,6 +51,8 @@ module.exports = instance;
 GitHub needs to know which version we are using. We'll use the `Accept` header for that:
 
 ```js
+const got = require('got');
+
 const instance = got.extend({
 	baseUrl: 'https://api.github.com',
 	headers: {
@@ -65,6 +66,8 @@ const instance = got.extend({
 We'll use [`options.responseType`](../readme.md#responsetype):
 
 ```js
+const got = require('got');
+
 const instance = got.extend({
 	baseUrl: 'https://api.github.com',
 	headers: {
@@ -72,15 +75,21 @@ const instance = got.extend({
 	},
 	responseType: 'json'
 });
+
+module.exports = instance;
 ```
 
 ### Authorization
 
 It's common to set some environment variables, for example, `GITHUB_TOKEN`. You can modify the tokens in all your apps easily, right? Cool. What about... we want to provide a unique token for each app. Then we will need to create a new option - it will default to the environment variable, but you can easily override it.
 
-Let's use handlers instead of hooks, our code will be more readable later.
+Let's use handlers instead of hooks. This will make our code more readable: having `beforeRequest`, `beforeError` and `afterResponse` hooks for just a few lines of code would complicate things unnecessarily.
+
+**Tip:** it's a good practice to use hooks when your plugin gets complicated. Try not to overload the handler function, but don't abuse hooks either.
 
 ```js
+const got = require('got');
+
 const instance = got.extend({
 	baseUrl: 'https://api.github.com',
 	headers: {
@@ -99,11 +108,13 @@ const instance = got.extend({
 		}
 	]
 });
+
+module.exports = instance;
 ```
 
 ### Errors
 
-We should name our errors, just to know there is a problem with your request, so you don't have to figure it out on your own. Superb errors, here we come!
+We should name our errors, just to know if the error is from the API response. Superb errors, here we come!
 
 ```js
 ...
@@ -162,7 +173,7 @@ getRateLimit({
 // => {
 // 	limit: 60,
 // 	remaining: 55,
-// 	reset: 1562852139000
+// 	reset: 2019-07-11T13:35:39.000Z
 // }
 ```
 
@@ -188,7 +199,7 @@ const getRateLimit = ({headers}) => ({
 				return next(options);
 			}
 
-			// Magic begins.
+			// Magic begins
 			return (async () => {
 				try {
 					const response = await next(options);

--- a/documentation/lets-make-a-plugin.md
+++ b/documentation/lets-make-a-plugin.md
@@ -6,7 +6,7 @@ Okay, so you already have learned some basics. That's great!
 
 When it comes to advanced usage, custom instances are really helpful.
 For example, take a look at [`gh-got`](https://github.com/sindresorhus/gh-got).
-It looks pretty complicated, but... it ain't.
+It looks pretty complicated, but... it's really not.
 
 Before we start, we need to find the GitHub API docs: https://developer.github.com/v3/
 

--- a/documentation/lets-make-a-plugin.md
+++ b/documentation/lets-make-a-plugin.md
@@ -1,0 +1,253 @@
+# Let's make a plugin!
+
+> Another example on how to use Got like a boss :electric_plug:
+
+Okay, so you already have learned some basics. That's great!
+
+When it comes to advanced usage, custom instances are really helpful.
+For example, take a look at [`gh-got`](https://github.com/sindresorhus/gh-got).
+It looks pretty complicated, but... it ain't.
+
+Before we start, we need to find the GitHub API docs: https://developer.github.com/v3/
+
+Let's write down the most important information:
+1. The root endpoint is `https://api.github.com/`.
+2. We will use the V3 API vesion.<br>
+   The `Accept` header needs to be set to `application/vnd.github.v3+json`.
+3. The body is in a JSON format.
+4. We will use OAuth2 for authorization.
+5. We may receive `400 Bad Request` or `422 Unprocessable Entity`.<br>
+   The body contains detailed information about the error.
+6. *Pagination?* Not yet. This is going to be a native feature of Got. We'll update this page accordingly when the feature is available.
+7. Rate limiting. These headers are interesting:
+
+- `X-RateLimit-Limit`
+- `X-RateLimit-Remaining`
+- `X-RateLimit-Reset`
+- `X-GitHub-Request-Id`
+
+Also `X-GitHub-Request-Id` may be useful.
+
+8. User-Agent is required.
+
+When we have all the necessary info, we can start mixing :cake:
+
+### The root endpoint
+
+Not much to do here, just extend an instance and provide `baseUrl` option:
+
+```js
+'use strict';
+const got = require('got');
+
+const instance = got.extend({
+	baseUrl: 'https://api.github.com'
+});
+
+module.exports = instance;
+```
+
+### v3 API
+
+GitHub needs to know which version we are using. We'll use the `Accept` header for that:
+
+```js
+const instance = got.extend({
+	baseUrl: 'https://api.github.com',
+	headers: {
+		accept: 'application/vnd.github.v3+json'
+	}
+});
+```
+
+### JSON body
+
+We'll use [`options.responseType`](../readme.md#responsetype):
+
+```js
+const instance = got.extend({
+	baseUrl: 'https://api.github.com',
+	headers: {
+		accept: 'application/vnd.github.v3+json'
+	},
+	responseType: 'json'
+});
+```
+
+### Authorization
+
+It's popular to set some environment variables, say `GITHUB_TOKEN`. You can modify the tokens in all your apps easily, right? Cool. What about... we want to provide a unique token for each app. Then we will need to create a new option - it will default to the environment variable, but you can easily override it.
+
+Let's use handlers instead of hooks, our code will be more readable later.
+
+```js
+const instance = got.extend({
+	baseUrl: 'https://api.github.com',
+	headers: {
+		accept: 'application/vnd.github.v3+json'
+	},
+	responseType: 'json',
+	token: process.env.GITHUB_TOKEN,
+	handlers: [
+		(options, next) => {
+			// Authorization
+			if (options.token && !options.headers.authorization) {
+				options.headers.authorization = `token ${options.token}`;
+			}
+
+			return next(options);
+		}
+	]
+});
+```
+
+### Errors
+
+We should name our errors, just to know there is a problem with your request, so you don't have to figure it out on your own. Superb errors, here we come!
+
+```js
+...
+	handlers: [
+		(options, next) => {
+			// Authorization
+			if (options.token && !options.headers.authorization) {
+				options.headers.authorization = `token ${options.token}`;
+			}
+
+			// Don't touch streams
+			if (options.stream) {
+				return next(options);
+			}
+
+			// Magic begins.
+			return (async () => {
+				try {
+					const response = await next(options);
+
+					return response;
+				} catch (error) {
+					const {response} = error;
+
+					// Nicer errors
+					if (response && response.body) {
+						error.name = 'GitHubError';
+						error.message = `${response.body.message} (${error.statusCode} status code)`;
+					}
+
+					throw error;
+				}
+			})();
+		}
+	]
+...
+```
+
+### Rate limiting
+
+Umm... `response.headers['x-ratelimit-remaining']` doesn't look good. What about `response.rateLimit.limit` instead?<br>
+Yeah, definitely. Since `response.headers` is an object, we can easily parse these:
+
+```js
+const getRateLimit = ({headers}) => ({
+	limit: parseInt(headers['x-ratelimit-limit'], 10),
+	remaining: parseInt(headers['x-ratelimit-remaining'], 10),
+	reset: new Date(parseInt(headers['x-ratelimit-reset'], 10) * 1000)
+});
+
+getRateLimit({
+	'x-ratelimit-limit': '60',
+	'x-ratelimit-remaining': '55',
+	'x-ratelimit-reset': '1562852139'
+});
+// => {
+// 	limit: 60,
+// 	remaining: 55,
+// 	reset: 1562852139000
+// }
+```
+
+Let's integrate it:
+
+```js
+const getRateLimit = ({headers}) => ({
+	limit: parseInt(headers['x-ratelimit-limit'], 10),
+	remaining: parseInt(headers['x-ratelimit-remaining'], 10),
+	reset: new Date(parseInt(headers['x-ratelimit-reset'], 10) * 1000)
+});
+
+...
+	handlers: [
+		(options, next) => {
+			// Authorization
+			if (options.token && !options.headers.authorization) {
+				options.headers.authorization = `token ${options.token}`;
+			}
+
+			// Don't touch streams
+			if (options.stream) {
+				return next(options);
+			}
+
+			// Magic begins.
+			return (async () => {
+				try {
+					const response = await next(options);
+
+					// Rate limit for the Response object
+					response.rateLimit = getRateLimit(response.headers);
+
+					return response;
+				} catch (error) {
+					const {response} = error;
+
+					// Nicer errors
+					if (response && response.body) {
+						error.name = 'GitHubError';
+						error.message = `${response.body.message} (${error.statusCode} status code)`;
+					}
+
+					// Rate limit for errors
+					if (response) {
+						error.rateLimit = getRateLimit(response.headers);
+					}
+
+					throw error;
+				}
+			})();
+		}
+	]
+...
+```
+
+### The frosting on the cake: `User-Agent` header.
+
+```js
+const package = require('./package');
+
+const instance = got.extend({
+	...
+	headers: {
+		accept: 'application/vnd.github.v3+json',
+		'user-agent': `${package.name}/${package.version}`
+	}
+	...
+});
+```
+
+## Woah. Is that it?
+
+Yup. View the full source code [here](examples/gh-got.js). Here's an example how to use it:
+
+```js
+const ghGot = require('gh-got');
+
+(async () => {
+	const response = await ghGot('users/sindresorhus');
+	const creationDate = new Date(response.created_at);
+
+	console.log(`Sindre's GitHub profile was created on ${creationDate.toGMTString()}`);
+	// => Sindre's GitHub profile was created on Sun, 20 Dec 2009 22:57:02 GMT
+})();
+```
+
+Did you know you can mix many instances into a bigger, more powerful one? Check out the [Advanced Creation](advanced-creation.md) guide.

--- a/documentation/lets-make-a-plugin.md
+++ b/documentation/lets-make-a-plugin.md
@@ -130,7 +130,7 @@ We should name our errors, just to know if the error is from the API response. S
 				return next(options);
 			}
 
-			// Magic begins.
+			// Magic begins
 			return (async () => {
 				try {
 					const response = await next(options);

--- a/documentation/migration-guides.md
+++ b/documentation/migration-guides.md
@@ -12,9 +12,9 @@ Let's take the very first example from Request's readme:
 const request = require('request');
 
 request('https://google.com', (error, response, body) => {
-	console.log('error:', error); // Print the error if one occurred
-	console.log('statusCode:', response && response.statusCode); // Print the response status code if a response was received
-	console.log('body:', body); // Print the HTML for the Google homepage
+	console.log('error:', error);
+	console.log('statusCode:', response && response.statusCode);
+	console.log('body:', body);
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -122,6 +122,9 @@
 			"@typescript-eslint/explicit-function-return-type": "off",
 			"@typescript-eslint/no-unnecessary-type-assertion": "off",
 			"@typescript-eslint/await-thenable": "off"
-		}
+		},
+		"ignores": [
+			"documentation/examples/*"
+		]
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -786,7 +786,27 @@ client.get('/demo');
 
 Merges many instances into a single one:
 - options are merged using [`got.mergeOptions()`](readme.md#gotmergeoptionsparentoptions-newoptions) (+ hooks are merged too),
-- handlers are stored in an array.
+- handlers are stored in an array (you can access them through `instance.defaults.handlers`).
+
+#### got.extend(...options, ...instances, ...)
+
+It's possible to combine options and instances.<br>
+It gives the same effect as `got.extend(...options).extend(...instances)`:
+
+```js
+const a = {headers: {cat: 'meow'}};
+const b = got.create({
+	options: {
+		headers: {
+			cow: 'moo'
+		}
+	}
+});
+
+// The same as `got.extend(a).extend(b)`.
+// Note `a` is options and `b` is an instance.
+got.extend(a, b); // => {headers: {cat: 'meow', cow: 'moo'}}
+```
 
 #### got.mergeOptions(parentOptions, newOptions)
 

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ Got is for Node.js. For browsers, we recommend [Ky](https://github.com/sindresor
 - [Hooks](#hooks)
 - [Instances with custom defaults](#instances)
 - [Composable](documentation/advanced-creation.md#merging-instances)
-- [Plugins](documentation/lest-make-a-plugin.md)
+- [Plugins](documentation/lets-make-a-plugin.md)
 - [Electron support](#useelectronnet)
 - [Used by ~2000 packages and ~500K repos](https://github.com/sindresorhus/got/network/dependents)
 - Actively maintained

--- a/readme.md
+++ b/readme.md
@@ -823,7 +823,8 @@ const b = got.create({
 
 // The same as `got.extend(a).extend(b)`.
 // Note `a` is options and `b` is an instance.
-got.extend(a, b); // => {headers: {cat: 'meow', cow: 'moo'}}
+got.extend(a, b);
+//=> {headers: {cat: 'meow', cow: 'moo'}}
 ```
 
 #### got.mergeOptions(parentOptions, newOptions)

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ Got is for Node.js. For browsers, we recommend [Ky](https://github.com/sindresor
 - [Hooks](#hooks)
 - [Instances with custom defaults](#instances)
 - [Composable](documentation/advanced-creation.md#merging-instances)
-- [Plugins](documentatino/lest-make-a-plugin.md)
+- [Plugins](documentation/lest-make-a-plugin.md)
 - [Electron support](#useelectronnet)
 - [Used by ~2000 packages and ~500K repos](https://github.com/sindresorhus/got/network/dependents)
 - Actively maintained

--- a/readme.md
+++ b/readme.md
@@ -735,7 +735,7 @@ Sets `options.method` to the method name and makes a request.
 
 ### Instances
 
-#### got.extend([options])
+#### got.extend(...options)
 
 Configure a new `got` instance with default `options`. The `options` are merged with the parent instance's `defaults.options` using [`got.mergeOptions`](#gotmergeoptionsparentoptions-newoptions). You can access the resolved options with the `.defaults` property on the instance.
 
@@ -782,6 +782,12 @@ client.get('/demo');
 
 **Tip:** Need more control over the behavior of Got? Check out the [`got.create()`](advanced-creation.md).
 
+#### got.extend(...instances)
+
+Merges many instances into a single one:
+- options are merged using [`got.mergeOptions()`](readme.md#gotmergeoptionsparentoptions-newoptions) (+ hooks are merged too),
+- handlers are stored in an array.
+
 #### got.mergeOptions(parentOptions, newOptions)
 
 Extends parent options. Avoid using [object spread](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_object_literals) as it doesn't work recursively:
@@ -809,7 +815,7 @@ Options are deeply merged to a new object. The value of each key is determined a
 
 Type: `object`
 
-The default Got options.
+The default Got options used in that instance.
 
 ## Errors
 
@@ -1200,8 +1206,6 @@ const custom = got.extend({
 	const list = await custom('/v1/users/list');
 })();
 ```
-
-**Tip:** Need to merge some instances into a single one? Check out [`got.mergeInstances()`](advanced-creation.md#merging-instances).
 
 ### Experimental HTTP2 support
 

--- a/readme.md
+++ b/readme.md
@@ -782,6 +782,23 @@ client.get('/demo');
 
 **Tip:** Need more control over the behavior of Got? Check out the [`got.create()`](advanced-creation.md).
 
+Additionally, `got.extend()` accepts two properties from the `defaults` object: `mutableDefaults` and `handlers`. Example:
+
+```js
+// You can now modify `mutableGot.defaults.options`.
+const mutableGot = got.extend({mutableDefaults: true});
+
+const mergedHandlers = got.extend({
+	handlers: [
+		(options, next) => {
+			delete options.headers.referer;
+
+			return next(options);
+		}
+	]
+});
+```
+
 #### got.extend(...instances)
 
 Merges many instances into a single one:

--- a/readme.md
+++ b/readme.md
@@ -58,12 +58,13 @@ Got is for Node.js. For browsers, we recommend [Ky](https://github.com/sindresor
 - [WHATWG URL support](#url)
 - [Hooks](#hooks)
 - [Instances with custom defaults](#instances)
-- [Composable](advanced-creation.md#merging-instances)
+- [Composable](documentation/advanced-creation.md#merging-instances)
+- [Plugins](documentatino/lest-make-a-plugin.md)
 - [Electron support](#useelectronnet)
 - [Used by ~2000 packages and ~500K repos](https://github.com/sindresorhus/got/network/dependents)
 - Actively maintained
 
-[Moving from Request?](migration-guides.md)
+[Moving from Request?](documentation/migration-guides.md)
 
 [See how Got compares to other HTTP libraries](#comparison)
 
@@ -458,9 +459,9 @@ Hooks allow modifications during the request lifecycle. Hook functions may be as
 Type: `Function[]`<br>
 Default: `[]`
 
-Called with plain [request options](#options), right before their normalization. This is especially useful in conjunction with [`got.extend()`](#instances) and [`got.create()`](advanced-creation.md) when the input needs custom handling.
+Called with plain [request options](#options), right before their normalization. This is especially useful in conjunction with [`got.extend()`](#instances) and [`got.create()`](documentation/advanced-creation.md) when the input needs custom handling.
 
-See the [Request migration guide](migration-guides.md#breaking-changes) for an example.
+See the [Request migration guide](documentation/migration-guides.md#breaking-changes) for an example.
 
 **Note:** This hook must be synchronous!
 
@@ -469,7 +470,7 @@ See the [Request migration guide](migration-guides.md#breaking-changes) for an e
 Type: `Function[]`<br>
 Default: `[]`
 
-Called with [normalized](source/normalize-arguments.ts) [request options](#options). Got will make no further changes to the request before it is sent (except the body serialization). This is especially useful in conjunction with [`got.extend()`](#instances) and [`got.create()`](advanced-creation.md) when you want to create an API client that, for example, uses HMAC-signing.
+Called with [normalized](source/normalize-arguments.ts) [request options](#options). Got will make no further changes to the request before it is sent (except the body serialization). This is especially useful in conjunction with [`got.extend()`](#instances) and [`got.create()`](documentation/advanced-creation.md) when you want to create an API client that, for example, uses HMAC-signing.
 
 See the [AWS section](#aws) for an example.
 
@@ -780,7 +781,7 @@ client.get('/demo');
 })();
 ```
 
-**Tip:** Need more control over the behavior of Got? Check out the [`got.create()`](advanced-creation.md).
+**Tip:** Need more control over the behavior of Got? Check out the [`got.create()`](documentation/advanced-creation.md).
 
 Additionally, `got.extend()` accepts two properties from the `defaults` object: `mutableDefaults` and `handlers`. Example:
 
@@ -802,7 +803,7 @@ const mergedHandlers = got.extend({
 #### got.extend(...instances)
 
 Merges many instances into a single one:
-- options are merged using [`got.mergeOptions()`](readme.md#gotmergeoptionsparentoptions-newoptions) (+ hooks are merged too),
+- options are merged using [`got.mergeOptions()`](#gotmergeoptionsparentoptions-newoptions) (+ hooks are merged too),
 - handlers are stored in an array (you can access them through `instance.defaults.handlers`).
 
 #### got.extend(...options, ...instances, ...)
@@ -1224,7 +1225,7 @@ Bear in mind; if you send an `if-modified-since` header and receive a `304 Not M
 
 Use `got.extend()` to make it nicer to work with REST APIs. Especially if you use the `prefixUrl` option.
 
-**Note:** Not to be confused with [`got.create()`](advanced-creation.md), which has no defaults.
+**Note:** Not to be confused with [`got.create()`](documentation/advanced-creation.md), which has no defaults.
 
 ```js
 const got = require('got');

--- a/source/as-promise.ts
+++ b/source/as-promise.ts
@@ -11,7 +11,7 @@ import requestAsEventEmitter from './request-as-event-emitter';
 
 type ResponseReturn = Response | Buffer | string | any;
 
-export const kProxied = Symbol('proxied');
+export const isProxiedSymbol = Symbol('proxied');
 
 export default function asPromise(options: NormalizedOptions): CancelableRequest<Response> {
 	const proxy = new EventEmitter();
@@ -134,7 +134,7 @@ export default function asPromise(options: NormalizedOptions): CancelableRequest
 		}));
 	}) as CancelableRequest<ResponseReturn>;
 
-	promise[kProxied] = true;
+	promise[isProxiedSymbol] = true;
 
 	promise.on = (name, fn) => {
 		proxy.on(name, fn);

--- a/source/as-promise.ts
+++ b/source/as-promise.ts
@@ -9,7 +9,9 @@ import {ParseError, ReadError, HTTPError} from './errors';
 import {reNormalizeArguments} from './normalize-arguments';
 import requestAsEventEmitter from './request-as-event-emitter';
 
-type ResponeReturn = Response | Buffer | string | any;
+type ResponseReturn = Response | Buffer | string | any;
+
+export const kProxied = Symbol('proxied');
 
 export default function asPromise(options: NormalizedOptions): CancelableRequest<Response> {
 	const proxy = new EventEmitter();
@@ -130,7 +132,9 @@ export default function asPromise(options: NormalizedOptions): CancelableRequest
 		].forEach(event => emitter.on(event, (...args: unknown[]) => {
 			proxy.emit(event, ...args);
 		}));
-	}) as CancelableRequest<ResponeReturn>;
+	}) as CancelableRequest<ResponseReturn>;
+
+	promise[kProxied] = true;
 
 	promise.on = (name, fn) => {
 		proxy.on(name, fn);

--- a/source/create.ts
+++ b/source/create.ts
@@ -41,7 +41,7 @@ export interface Got extends Record<HTTPAlias, ReturnResponse> {
 	(url: URLArgument | Options & { stream: true; url: URLArgument }, options?: Options & { stream: true }): ProxyStream;
 	(url: URLOrOptions, options?: Options): CancelableRequest<Response> | ProxyStream;
 	create(defaults: Defaults): Got;
-	extend(...instancesOrOptions: Array<Got | Options & {mutableDefaults?: boolean, handlers?: HandlerFunction[]}>): Got;
+	extend(...instancesOrOptions: Array<Got | Options & {mutableDefaults?: boolean; handlers?: HandlerFunction[]}>): Got;
 	mergeOptions<T extends Options>(...sources: T[]): T & { hooks: Partial<Hooks> };
 }
 

--- a/source/create.ts
+++ b/source/create.ts
@@ -12,7 +12,7 @@ import {
 } from './utils/types';
 import deepFreeze from './utils/deep-freeze';
 import merge, {mergeOptions} from './merge';
-import asPromise, {kProxied} from './as-promise';
+import asPromise, {isProxiedSymbol} from './as-promise';
 import asStream, {ProxyStream} from './as-stream';
 import {preNormalizeArguments, normalizeArguments} from './normalize-arguments';
 import {Hooks} from './known-hook-events';
@@ -97,7 +97,7 @@ const create = (defaults: Partial<Defaults>): Got => {
 			});
 
 			// Proxy the properties from the next handler to this one
-			if (!isStream && !Reflect.has(result, kProxied)) {
+			if (!isStream && !Reflect.has(result, isProxiedSymbol)) {
 				for (const key of Object.keys(nextPromise)) {
 					Object.defineProperty(result, key, {
 						get: () => {
@@ -110,7 +110,7 @@ const create = (defaults: Partial<Defaults>): Got => {
 				}
 
 				(result as CancelableRequest<Response>).cancel = nextPromise.cancel;
-				result[kProxied] = true;
+				result[isProxiedSymbol] = true;
 			}
 
 			return result;

--- a/source/create.ts
+++ b/source/create.ts
@@ -44,6 +44,7 @@ export interface Got extends Record<HTTPAlias, ReturnResponse> {
 	(url: URLOrOptions, options?: Options): CancelableRequest<Response> | ProxyStream;
 	create(defaults: Defaults): Got;
 	extend(...instancesOrOptions: Array<Got | ExtendedOptions>): Got;
+	mergeInstances(parent: Got, ...instances: Got[]): Got;
 	mergeOptions<T extends Options>(...sources: T[]): T & { hooks: Partial<Hooks> };
 }
 
@@ -61,6 +62,9 @@ const aliases: readonly HTTPAlias[] = [
 ];
 
 const defaultHandler: HandlerFunction = (options, next) => next(options);
+
+// `got.mergeInstances()` is deprecated
+let hasShownDeprecation = false;
 
 const create = (defaults: Partial<Defaults>): Got => {
 	defaults = merge<Defaults, Partial<Defaults>>({}, defaults);
@@ -154,6 +158,15 @@ const create = (defaults: Partial<Defaults>): Got => {
 			handlers,
 			mutableDefaults
 		});
+	};
+
+	got.mergeInstances = (parent, ...instances) => {
+		if (!hasShownDeprecation) {
+			console.warn('`got.mergeInstances()` is deprecated. We support it solely for compatibility - it will be removed in Got 11. Use `instance.extend(...instances)` instead.');
+			hasShownDeprecation = true;
+		}
+
+		return parent.extend(...instances);
 	};
 
 	// @ts-ignore The missing methods because the for-loop handles it for us

--- a/source/create.ts
+++ b/source/create.ts
@@ -7,7 +7,8 @@ import {
 	CancelableRequest,
 	URLOrOptions,
 	URLArgument,
-	HandlerFunction
+	HandlerFunction,
+	ExtendedOptions
 } from './utils/types';
 import deepFreeze from './utils/deep-freeze';
 import merge, {mergeOptions} from './merge';
@@ -42,7 +43,7 @@ export interface Got extends Record<HTTPAlias, ReturnResponse> {
 	(url: URLArgument | Options & { stream: true; url: URLArgument }, options?: Options & { stream: true }): ProxyStream;
 	(url: URLOrOptions, options?: Options): CancelableRequest<Response> | ProxyStream;
 	create(defaults: Defaults): Got;
-	extend(...instancesOrOptions: Array<Got | Options & {mutableDefaults?: boolean; handlers?: HandlerFunction[]}>): Got;
+	extend(...instancesOrOptions: Array<Got | ExtendedOptions>): Got;
 	mergeOptions<T extends Options>(...sources: T[]): T & { hooks: Partial<Hooks> };
 }
 
@@ -139,10 +140,10 @@ const create = (defaults: Partial<Defaults>): Got => {
 				options.push(value as Options);
 
 				if (Reflect.has(value, 'handlers')) {
-					handlers.push(...(value as Options & {handlers?: HandlerFunction[]}).handlers);
+					handlers.push(...(value as ExtendedOptions).handlers);
 				}
 
-				mutableDefaults = (value as Options & {mutableDefaults?: boolean}).mutableDefaults;
+				mutableDefaults = (value as ExtendedOptions).mutableDefaults;
 			}
 		}
 

--- a/source/merge.ts
+++ b/source/merge.ts
@@ -1,8 +1,6 @@
 import is from '@sindresorhus/is';
-import {Options, Method, Defaults, NormalizedOptions, CancelableRequest, Response} from './utils/types';
+import {Options} from './utils/types';
 import knownHookEvents, {Hooks, HookEvent, HookType} from './known-hook-events';
-import {Got} from './create';
-import {ProxyStream} from './as-stream';
 
 const URLGlobal: typeof URL = typeof URL === 'undefined' ? require('url').URL : URL;
 const URLSearchParamsGlobal: typeof URLSearchParams = typeof URLSearchParams === 'undefined' ? require('url').URLSearchParams : URLSearchParams;
@@ -85,20 +83,4 @@ export function mergeOptions<T extends Options>(...sources: T[]): T & {hooks: Pa
 	mergedOptions.hooks = hooks as Hooks;
 
 	return mergedOptions;
-}
-
-export function mergeInstances(instances: Got[], methods?: Method[]): Defaults {
-	const handlers = instances.map(instance => instance.defaults.handler);
-	const size = instances.length - 1;
-
-	return {
-		methods,
-		options: mergeOptions(...instances.map(instance => instance.defaults.options || {})),
-		handler: <T extends ProxyStream | CancelableRequest<Response>>(options: NormalizedOptions, next: (options: NormalizedOptions) => T) => {
-			let iteration = 0;
-			const iterate = (newOptions: NormalizedOptions): T => handlers[++iteration]!(newOptions, iteration === size ? next : iterate);
-
-			return iterate(options);
-		}
-	};
 }

--- a/source/utils/types.ts
+++ b/source/utils/types.ts
@@ -130,7 +130,6 @@ export interface Options extends Omit<https.RequestOptions, 'agent' | 'timeout' 
 	gotTimeout?: number | Delays;
 	cache?: string | StorageAdapter | false;
 	headers?: Headers;
-	mutableDefaults?: boolean;
 	responseType?: ResponseType;
 	resolveBodyOnly?: boolean;
 	followRedirect?: boolean;
@@ -155,6 +154,11 @@ export interface NormalizedOptions extends Omit<Required<Options>, 'timeout' | '
 	path: string;
 	hostname: string;
 	host: string;
+}
+
+export interface ExtendedOptions extends Options {
+	handlers?: HandlerFunction[];
+	mutableDefaults?: boolean;
 }
 
 export interface Defaults {

--- a/source/utils/types.ts
+++ b/source/utils/types.ts
@@ -158,9 +158,8 @@ export interface NormalizedOptions extends Omit<Required<Options>, 'timeout' | '
 }
 
 export interface Defaults {
-	methods?: Method[];
 	options?: Options;
-	handler?: HandlerFunction;
+	handlers?: HandlerFunction[];
 	mutableDefaults?: boolean;
 }
 

--- a/source/utils/types.ts
+++ b/source/utils/types.ts
@@ -69,7 +69,7 @@ export interface Response extends http.IncomingMessage {
 
 export type RetryFunction = (retry: number, error: Error | GotError | ParseError | HTTPError | MaxRedirectsError) => number;
 
-export type HandlerFunction = <T extends ProxyStream | CancelableRequest<Response>>(options: Options, next: (options: Options) => T) => T;
+export type HandlerFunction = <T extends ProxyStream | CancelableRequest<Response>>(options: NormalizedOptions, next: (options: NormalizedOptions) => T) => T;
 
 export interface RetryOption {
 	retries?: RetryFunction | number;

--- a/test/arguments.ts
+++ b/test/arguments.ts
@@ -54,17 +54,18 @@ test('methods are normalized', withServer, async (t, server, got) => {
 	server.post('/test', echoUrl);
 
 	const instance = got.create({
-		methods: got.defaults.methods,
 		options: got.defaults.options,
-		handler: (options, next) => {
-			if (options.method === options.method.toUpperCase()) {
-				t.pass();
-			} else {
-				t.fail();
-			}
+		handlers: [
+			(options, next) => {
+				if (options.method === options.method.toUpperCase()) {
+					t.pass();
+				} else {
+					t.fail();
+				}
 
-			return next(options);
-		}
+				return next(options);
+			}
+		]
 	});
 
 	await instance('test', {method: 'post'});

--- a/test/arguments.ts
+++ b/test/arguments.ts
@@ -232,7 +232,6 @@ test('backslash in the end of `prefixUrl` option is optional', withServer, async
 
 test('throws when trying to modify `prefixUrl` after options got normalized', async t => {
 	const instanceA = got.create({
-		methods: [],
 		options: {prefixUrl: 'https://example.com'},
 		handler: (options, next) => {
 			options.prefixUrl = 'https://google.com';

--- a/test/arguments.ts
+++ b/test/arguments.ts
@@ -236,6 +236,7 @@ test('throws when trying to modify `prefixUrl` after options got normalized', as
 		options: {prefixUrl: 'https://example.com'},
 		handlers: [
 			(options, next) => {
+				// @ts-ignore Even though we know it's read only, we need to test it.
 				options.prefixUrl = 'https://google.com';
 				return next(options);
 			}

--- a/test/arguments.ts
+++ b/test/arguments.ts
@@ -233,10 +233,12 @@ test('backslash in the end of `prefixUrl` option is optional', withServer, async
 test('throws when trying to modify `prefixUrl` after options got normalized', async t => {
 	const instanceA = got.create({
 		options: {prefixUrl: 'https://example.com'},
-		handler: (options, next) => {
-			options.prefixUrl = 'https://google.com';
-			return next(options);
-		}
+		handlers: [
+			(options, next) => {
+				options.prefixUrl = 'https://google.com';
+				return next(options);
+			}
+		]
 	});
 
 	await t.throwsAsync(instanceA(''), 'Failed to set prefixUrl. Options are normalized already.');

--- a/test/create.ts
+++ b/test/create.ts
@@ -266,15 +266,15 @@ test('extend with custom handlers', withServer, async (t, server, got) => {
 });
 
 test('extend with instances', t => {
-	const a = got.extend({baseUrl: new URL('https://example.com/')});
+	const a = got.extend({prefixUrl: new URL('https://example.com/')});
 	const b = got.extend(a);
-	t.is(b.defaults.options.baseUrl.toString(), 'https://example.com/');
+	t.is(b.defaults.options.prefixUrl.toString(), 'https://example.com/');
 });
 
 test('extend with a chain', t => {
-	const a = got.extend({baseUrl: 'https://example.com/'});
+	const a = got.extend({prefixUrl: 'https://example.com/'});
 	const b = got.extend(a, {headers: {foo: 'bar'}});
-	t.is(b.defaults.options.baseUrl.toString(), 'https://example.com/');
+	t.is(b.defaults.options.prefixUrl.toString(), 'https://example.com/');
 	t.is(b.defaults.options.headers.foo, 'bar');
 });
 

--- a/test/create.ts
+++ b/test/create.ts
@@ -1,6 +1,7 @@
 import http = require('http');
 import {URL} from 'url';
 import test from 'ava';
+import is from '@sindresorhus/is';
 import got from '../source';
 import withServer from './helpers/with-server';
 
@@ -275,4 +276,23 @@ test('extend with a chain', t => {
 	const b = got.extend(a, {headers: {foo: 'bar'}});
 	t.is(b.defaults.options.baseUrl.toString(), 'https://example.com/');
 	t.is(b.defaults.options.headers.foo, 'bar');
+});
+
+test('async handlers', withServer, async (t, server, got) => {
+	server.get('/', echoHeaders);
+
+	const instance = got.extend({
+		handlers: [
+			async (options, next) => {
+				const result = await next(options);
+				result.modified = true;
+
+				return result;
+			}
+		]
+	});
+
+	const promise = instance('');
+	t.true(is.function_(promise.cancel));
+	t.true((await promise).modified);
 });

--- a/test/merge-instances.ts
+++ b/test/merge-instances.ts
@@ -14,7 +14,7 @@ test('merging instances', withServer, async (t, server) => {
 
 	const instanceA = got.extend({headers: {unicorn: 'rainbow'}});
 	const instanceB = got.extend({prefixUrl: server.url});
-	const merged = got.mergeInstances(instanceA, instanceB);
+	const merged = instanceA.extend(instanceB);
 
 	const headers = await merged('').json<TestReturn>();
 	t.is(headers.unicorn, 'rainbow');
@@ -25,16 +25,14 @@ test('works even if no default handler in the end', withServer, async (t, server
 	server.get('/', echoHeaders);
 
 	const instanceA = got.create({
-		options: {},
-		handler: (options, next) => next(options)
+		options: {}
 	});
 
 	const instanceB = got.create({
-		options: {},
-		handler: (options, next) => next(options)
+		options: {}
 	});
 
-	const merged = got.mergeInstances(instanceA, instanceB);
+	const merged = instanceA.extend(instanceB);
 	await t.notThrowsAsync(() => merged(server.url));
 });
 
@@ -44,12 +42,14 @@ test('merges default handlers & custom handlers', withServer, async (t, server) 
 	const instanceA = got.extend({headers: {unicorn: 'rainbow'}});
 	const instanceB = got.create({
 		options: {},
-		handler: (options, next) => {
-			options.headers.cat = 'meow';
-			return next(options);
-		}
+		handlers: [
+			(options, next) => {
+				options.headers.cat = 'meow';
+				return next(options);
+			}
+		]
 	});
-	const merged = got.mergeInstances(instanceA, instanceB);
+	const merged = instanceA.extend(instanceB);
 
 	const headers = await merged(server.url).json<TestReturn>();
 	t.is(headers.unicorn, 'rainbow');
@@ -64,8 +64,8 @@ test('merging one group & one instance', withServer, async (t, server) => {
 	const instanceC = got.extend({headers: {bird: 'tweet'}});
 	const instanceD = got.extend({headers: {mouse: 'squeek'}});
 
-	const merged = got.mergeInstances(instanceA, instanceB, instanceC);
-	const doubleMerged = got.mergeInstances(merged, instanceD);
+	const merged = instanceA.extend(instanceB, instanceC);
+	const doubleMerged = merged.extend(instanceD);
 
 	const headers = await doubleMerged(server.url).json<TestReturn>();
 	t.is(headers.dog, 'woof');
@@ -82,10 +82,10 @@ test('merging two groups of merged instances', withServer, async (t, server) => 
 	const instanceC = got.extend({headers: {bird: 'tweet'}});
 	const instanceD = got.extend({headers: {mouse: 'squeek'}});
 
-	const groupA = got.mergeInstances(instanceA, instanceB);
-	const groupB = got.mergeInstances(instanceC, instanceD);
+	const groupA = instanceA.extend(instanceB);
+	const groupB = instanceC.extend(instanceD);
 
-	const merged = got.mergeInstances(groupA, groupB);
+	const merged = groupA.extend(groupB);
 
 	const headers = await merged(server.url).json<TestReturn>();
 	t.is(headers.dog, 'woof');
@@ -112,7 +112,7 @@ test('hooks are merged', t => {
 		]
 	}});
 
-	const merged = got.mergeInstances(instanceA, instanceB);
+	const merged = instanceA.extend(instanceB);
 	t.deepEqual(getBeforeRequestHooks(merged), getBeforeRequestHooks(instanceA).concat(getBeforeRequestHooks(instanceB)));
 });
 
@@ -131,7 +131,7 @@ test('hooks are passed by though other instances don\'t have them', t => {
 		options: {hooks: {}}
 	});
 
-	const merged = got.mergeInstances(instanceA, instanceB, instanceC);
+	const merged = instanceA.extend(instanceB, instanceC);
 	t.deepEqual(merged.defaults.options.hooks.beforeRequest, instanceA.defaults.options.hooks.beforeRequest);
 });
 
@@ -144,7 +144,7 @@ test('URLSearchParams instances are merged', t => {
 		searchParams: new URLSearchParams({b: '2'})
 	});
 
-	const merged = got.mergeInstances(instanceA, instanceB);
+	const merged = instanceA.extend(instanceB);
 	// @ts-ignore Manual tests
 	t.is(merged.defaults.options.searchParams.get('a'), '1');
 	// @ts-ignore Manual tests

--- a/test/merge-instances.ts
+++ b/test/merge-instances.ts
@@ -150,3 +150,16 @@ test('URLSearchParams instances are merged', t => {
 	// @ts-ignore Manual tests
 	t.is(merged.defaults.options.searchParams.get('b'), '2');
 });
+
+// TODO: remove this before Got v11
+test('`got.mergeInstances()` works', t => {
+	const instance = got.mergeInstances(got, got.create({
+		options: {
+			headers: {
+				'user-agent': null
+			}
+		}
+	}));
+
+	t.is(instance.defaults.options.headers['user-agent'], null);
+});


### PR DESCRIPTION
The same instances, but their creation is much simpler.

- [x] Merging instances:
      Now: `instanceA.extend(instanceB, instanceC, ...)`
      Before: `got.mergeInstances(instanceA, instanceB, instanceC, ...)`
- [x] Merging options:
      Now: `instanceA.extend(optionsB, optionsC, ...)`
      Before: `instanceA.extend(optionsB).extend(optionsC).extend(...)`
- [x] Merging instances and options:
      Now: `instanceA.extend(optionsB, instanceC, ...)`
      Before: `got.mergeInstances(instanceA.extend(optionsB), instanceC)`
- [x] Extending handlers:
      Now: `instanceA.extend({handlers: [handlerB]})`
      Before: `got.mergeInstances(instanceA, got.create({handler: handlerB}))`
- [x] Cloning instances to make them mutable:
      Now: `instanceA.extend({mutableDefaults: true})` (not changed)
      Before: `instanceA.extend({mutableDefaults: true})`

#### Are there any breaking changes?

1. `got.create({handler: ...})` is pluralized and accepts an array.
- Before: `defaults.handler` was a function containing private array of handlers.
- Now: `defaults.handlers` is a public array of handlers.

This allows us to inherit properties from the original Promise.
Yup, it's safe to use async handlers now. All the properties (`.cancel()` etc.) will be proxied.

2. `got.mergeInstances(...instances)` is deprecated. Use `instanceA.extend(instanceB)` instead.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] If it's a new feature, I have included documentation updates.
- [x] Fixes #701
- [x] Closes #737