### PR TITLE
Rewrite `create.js` in TypeScript

### DIFF
--- a/source/create.ts
+++ b/source/create.ts
@@ -3,7 +3,7 @@ import {URL} from 'url';
 import errors from './errors';
 import asStream from './as-stream';
 import asPromise from './as-promise';
-import {normalize, preNormalize} from './normalize-arguments';
+import { normalize, preNormalize } from './normalize-arguments';
 import merge, { mergeOptions, mergeInstances} from './merge';
 import deepFreeze from './utils/deep-freeze';
 import { InterfaceWithDefaults, Method, Options, NextFunction } from './utils/types';

--- a/source/create.ts
+++ b/source/create.ts
@@ -1,9 +1,9 @@
 'use strict';
 import {URL} from 'url';
-import * as errors from './errors';
-import * as  asStream  from './as-stream';
-import * as asPromise from './as-promise';
-import * as normalizeArguments from './normalize-arguments';
+import errors from './errors';
+import asStream from './as-stream';
+import asPromise from './as-promise';
+import {normalize, preNormalize} from './normalize-arguments';
 import merge, { mergeOptions, mergeInstances} from './merge';
 import deepFreeze from './utils/deep-freeze';
 import { InterfaceWithDefaults, Method, Options, NextFunction } from './utils/types';
@@ -21,7 +21,7 @@ const aliases : Method[]  = [
 
 const create = (defaults : any) => {
 	defaults = merge({}, defaults);
-	normalizeArguments.preNormalize(defaults.options);
+	preNormalize(defaults.options);
 
 	if (!defaults.handler) {
 		// This can't be getPromiseOrStream, because when merging
@@ -31,7 +31,7 @@ const create = (defaults : any) => {
 
 	function got(url: URL, options: Options) {
 		try {
-			return defaults.handler(normalizeArguments.normalize(url, options, defaults), getPromiseOrStream);
+			return defaults.handler(normalize(url, options, defaults), getPromiseOrStream);
 		} catch (error) {
 			if (options && options.stream) {
 				throw error;

--- a/source/create.ts
+++ b/source/create.ts
@@ -1,14 +1,14 @@
 'use strict';
-const errors = require('./errors');
-const asStream = require('./as-stream');
-const asPromise = require('./as-promise');
-const normalizeArguments = require('./normalize-arguments');
-const {default: merge, mergeOptions, mergeInstances} = require('./merge');
-const deepFreeze = require('./utils/deep-freeze').default;
+import * as errors from './errors';
+import * as  asStream  from './as-stream';
+import * as asPromise from './as-promise';
+import * as normalizeArguments from './normalize-arguments';
+import merge, { mergeOptions, mergeInstances} from './merge';
+import deepFreeze from './utils/deep-freeze';
 
-const getPromiseOrStream = options => options.stream ? asStream(options) : asPromise(options);
+const getPromiseOrStream = ( options : any ) => options.stream ? asStream(options) : asPromise(options);
 
-const aliases = [
+const aliases :  = [
 	'get',
 	'post',
 	'put',
@@ -67,7 +67,7 @@ const create = defaults => {
 
 	Object.assign(got, {...errors, mergeOptions});
 	Object.defineProperty(got, 'defaults', {
-		value: defaults.mutableDefaults ? defaults : deepFreeze(defaults),
+		value: defaults.mutableDefaults ? defaults : deepFreeze.default(defaults),
 		writable: defaults.mutableDefaults,
 		configurable: defaults.mutableDefaults,
 		enumerable: true

--- a/source/normalize-arguments.js
+++ b/source/normalize-arguments.js
@@ -245,5 +245,6 @@ const normalize = (url, options, defaults) => {
 const reNormalize = options => normalize(urlLib.format(options), options);
 
 module.exports = normalize;
+module.exports.normalize= normalize;
 module.exports.preNormalize = preNormalize;
 module.exports.reNormalize = reNormalize;

--- a/source/utils/types.ts
+++ b/source/utils/types.ts
@@ -3,7 +3,7 @@ import {RequestOptions} from 'https';
 import {PCancelable} from 'p-cancelable';
 import {Hooks} from '../known-hook-events';
 
-export type Method = 'GET' | 'PUT' | 'HEAD' | 'DELETE' | 'OPTIONS' | 'TRACE' | 'get' | 'put' | 'head' | 'delete' | 'options' | 'trace';
+export type Method = 'GET' | 'PUT' | 'POST' | 'PATCH' | 'HEAD' | 'DELETE' | 'OPTIONS' | 'TRACE' | 'get' | 'put' | 'post' | 'patch' | 'head' | 'delete' | 'options' | 'trace';
 
 export type NextFunction = (error?: Error | string) => void;
 


### PR DESCRIPTION
#### After npm run build
I have one issue I encountered I am not really sure how to solve on line 67 and 68 of [create.ts](source/create.ts). It is generating the following errors:

- Element implicitly has 'any' type because type '{ (url: URL, options: Options): any; create: (defaults: any ) => ...; has no index signature, and 
- Element implicitly has 'any' type because type '( url: URL, options: Options) => any' has no index signature.

I am not sure how to approach the issue... however if, instead of using the `for (const method of aliases){` on line 66 and I assign each alias individually, i.e `got.put = (url: Url ....` the problem goes away but I presume there is a better way 