### PR TITLE
Fix code coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,11 @@
 			"ts-node/register"
 		]
 	},
+	"nyc": {
+		"extension": [
+			".ts"
+		]
+	},
 	"xo": {
 		"extends": "xo-typescript",
 		"extensions": [


### PR DESCRIPTION
see https://istanbul.js.org/docs/tutorials/typescript/

As the current behaviour is not using `all` (also the nyc default) I did not included it from the linked tutorial. Also the exclude of typing files is not needed then.

see `nyc --help` entry for `all`: `whether or not to instrument all files of the  project (not just the ones touched by your test suite)  [boolean] [default: false]`

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates.