### PR TITLE
Fix readme `beforeError` hook typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -497,7 +497,7 @@ const got = require('got');
 
 got('https://api.github.com/some-endpoint', {
 	hooks: {
-		onError: [
+		beforeError: [
 			error => {
 				const {response} = error;
  				if (response && response.body) {


### PR DESCRIPTION
#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates.

Fixed small typo on **beforeError** docs :memo: