### PR TITLE
Enable the `noImplicitReturns` TypeScript setting

### DIFF
--- a/source/utils/timed-out.ts
+++ b/source/utils/timed-out.ts
@@ -31,7 +31,7 @@ export interface Delays {
 export default (request: ClientRequest, delays: Delays, options: any) => {
 	/* istanbul ignore next: this makes sure timed-out isn't called twice */
 	if (Reflect.has(request, reentry)) {
-		return;
+		return noop;
 	}
 
 	(request as any)[reentry] = true;

--- a/test/timeout.ts
+++ b/test/timeout.ts
@@ -16,7 +16,8 @@ const slowDataStream = () => {
 	let count = 0;
 	const interval = setInterval(() => {
 		if (count++ < 10) {
-			return slowStream.push('data\n'.repeat(100));
+			slowStream.push('data\n'.repeat(100));
+			return;
 		}
 
 		clearInterval(interval);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
 
 		// TODO: Make it strict
 		"strict": false,
-		"noImplicitReturns": false,
 		"noUnusedParameters": false
 	},
 	"include": [


### PR DESCRIPTION
This removes the two remaining implicit returns and removes `noImplicitReturns: false` from `tsconfig.json`. That checks off one of the items in #758.

Merging is blocked on #760, which removes another implicit return.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates.
