### PR TITLE
Fix parsing response when using `afterResponse` hook

### DIFF
--- a/source/as-promise.ts
+++ b/source/as-promise.ts
@@ -57,7 +57,8 @@ export default function asPromise(options: Options) {
 							...updatedOptions,
 							retry: 0,
 							throwHttpErrors: false,
-							responseType: 'text'
+							responseType: 'text',
+							resolveBodyOnly: false
 						}));
 
 						// Remove any further hooks for that request, because we we'll call them anyway.

--- a/source/as-promise.ts
+++ b/source/as-promise.ts
@@ -56,7 +56,8 @@ export default function asPromise(options: Options) {
 						updatedOptions = reNormalizeArguments(mergeOptions(options, {
 							...updatedOptions,
 							retry: 0,
-							throwHttpErrors: false
+							throwHttpErrors: false,
+							responseType: 'text'
 						}));
 
 						// Remove any further hooks for that request, because we we'll call them anyway.

--- a/source/request-as-event-emitter.ts
+++ b/source/request-as-event-emitter.ts
@@ -151,6 +151,7 @@ export default (options, input?: TransformStream) => {
 						const redirectOptions = {
 							...options,
 							port: null,
+							auth: null,
 							...urlToOptions(redirectURL)
 						};
 

--- a/test/hooks.ts
+++ b/test/hooks.ts
@@ -477,3 +477,24 @@ test('beforeError allows modifications', async t => {
 		}
 	}), errorString2);
 });
+
+test('does not break on `afterResponse` hook with JSON mode', withServer, async (t, server, got) => {
+	server.get('/foobar', echoHeaders);
+
+	await t.notThrowsAsync(got('/', {
+		hooks: {
+			afterResponse: [
+				(response, retryWithMergedOptions) => {
+					if (response.statusCode === 404) {
+						return retryWithMergedOptions({
+							path: '/foobar'
+						});
+					}
+
+					return response;
+				}
+			]
+		},
+		responseType: 'json'
+	}));
+});


### PR DESCRIPTION
Fixes #761 