### PR TITLE
Pass the response as the second argument to the `beforeRedirect` hook

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -408,7 +408,7 @@ See the [AWS section](#aws) for an example.
 Type: `Function[]`<br>
 Default: `[]`
 
-Called with [normalized](source/normalize-arguments.ts) [request options](#options). Got will make no further changes to the request. This is especially useful when you want to avoid dead sites. Example:
+Called with [normalized](source/normalize-arguments.ts) [request options](#options) and the redirect [response](#response). Got will make no further changes to the request. This is especially useful when you want to avoid dead sites. Example:
 
 ```js
 const got = require('got');
@@ -416,7 +416,7 @@ const got = require('got');
 got('https://example.com', {
 	hooks: {
 		beforeRedirect: [
-			options => {
+			(options, response) => {
 				if (options.hostname === 'deadSite') {
 					options.hostname = 'fallbackSite';
 				}

--- a/source/known-hook-events.ts
+++ b/source/known-hook-events.ts
@@ -20,7 +20,7 @@ export type BeforeRequestHook = (options: NormalizedOptions) => void | Promise<v
 /**
 Called with normalized [request options](https://github.com/sindresorhus/got#options). Got will make no further changes to the request. This is especially useful when you want to avoid dead sites.
 */
-export type BeforeRedirectHook = (options: NormalizedOptions) => void | Promise<void>;
+export type BeforeRedirectHook = (options: NormalizedOptions, response: any) => void | Promise<void>;
 
 /**
 Called with normalized [request options](https://github.com/sindresorhus/got#options), the error and the retry count. Got will make no further changes to the request. This is especially useful when some extra work is required before the next try.

--- a/source/known-hook-events.ts
+++ b/source/known-hook-events.ts
@@ -1,3 +1,6 @@
+
+import http = require('http');
+import ResponseLike = require('responselike');
 import {Options, CancelableRequest, Response, NormalizedOptions} from './utils/types';
 import {HTTPError, GotError, ParseError, MaxRedirectsError} from './errors';
 
@@ -20,7 +23,7 @@ export type BeforeRequestHook = (options: NormalizedOptions) => void | Promise<v
 /**
 Called with normalized [request options](https://github.com/sindresorhus/got#options). Got will make no further changes to the request. This is especially useful when you want to avoid dead sites.
 */
-export type BeforeRedirectHook = (options: NormalizedOptions, response: any) => void | Promise<void>;
+export type BeforeRedirectHook = (options: NormalizedOptions, response: http.ServerResponse | ResponseLike) => void | Promise<void>;
 
 /**
 Called with normalized [request options](https://github.com/sindresorhus/got#options), the error and the retry count. Got will make no further changes to the request. This is especially useful when some extra work is required before the next try.

--- a/source/known-hook-events.ts
+++ b/source/known-hook-events.ts
@@ -1,4 +1,3 @@
-
 import http = require('http');
 import ResponseLike = require('responselike');
 import {Options, CancelableRequest, Response, NormalizedOptions} from './utils/types';

--- a/source/known-hook-events.ts
+++ b/source/known-hook-events.ts
@@ -1,5 +1,3 @@
-import http = require('http');
-import ResponseLike = require('responselike');
 import {Options, CancelableRequest, Response, NormalizedOptions} from './utils/types';
 import {HTTPError, GotError, ParseError, MaxRedirectsError} from './errors';
 
@@ -22,7 +20,7 @@ export type BeforeRequestHook = (options: NormalizedOptions) => void | Promise<v
 /**
 Called with normalized [request options](https://github.com/sindresorhus/got#options). Got will make no further changes to the request. This is especially useful when you want to avoid dead sites.
 */
-export type BeforeRedirectHook = (options: NormalizedOptions, response: http.ServerResponse | ResponseLike) => void | Promise<void>;
+export type BeforeRedirectHook = (options: NormalizedOptions, response: Response) => void | Promise<void>;
 
 /**
 Called with normalized [request options](https://github.com/sindresorhus/got#options), the error and the retry count. Got will make no further changes to the request. This is especially useful when some extra work is required before the next try.

--- a/source/request-as-event-emitter.ts
+++ b/source/request-as-event-emitter.ts
@@ -163,7 +163,7 @@ export default (options: NormalizedOptions, input?: TransformStream) => {
 
 						for (const hook of options.hooks.beforeRedirect) {
 							// eslint-disable-next-line no-await-in-loop
-							await hook(redirectOptions, response);
+							await hook(redirectOptions, typedResponse);
 						}
 
 						emitter.emit('redirect', response, redirectOptions);

--- a/source/request-as-event-emitter.ts
+++ b/source/request-as-event-emitter.ts
@@ -163,7 +163,7 @@ export default (options: NormalizedOptions, input?: TransformStream) => {
 
 						for (const hook of options.hooks.beforeRedirect) {
 							// eslint-disable-next-line no-await-in-loop
-							await hook(redirectOptions);
+							await hook(redirectOptions, response);
 						}
 
 						emitter.emit('redirect', response, redirectOptions);

--- a/test/hooks.ts
+++ b/test/hooks.ts
@@ -1,3 +1,4 @@
+import {URL} from 'url';
 import test from 'ava';
 import delay = require('delay');
 import got from '../source';
@@ -222,7 +223,7 @@ test('beforeRequest allows modifications', withServer, async (t, server, got) =>
 	t.is(body.foo, 'bar');
 });
 
-test('beforeRedirect is called with options', withServer, async (t, server, got) => {
+test('beforeRedirect is called with options and response', withServer, async (t, server, got) => {
 	server.get('/', echoHeaders);
 	server.get('/redirect', redirectEndpoint);
 
@@ -230,9 +231,13 @@ test('beforeRedirect is called with options', withServer, async (t, server, got)
 		responseType: 'json',
 		hooks: {
 			beforeRedirect: [
-				options => {
+				(options, response) => {
 					t.is(options.path, '/');
 					t.is(options.hostname, 'localhost');
+
+					t.is(response.statusCode, 302);
+					t.is(new URL(response.url).pathname, '/redirect');
+					t.is(response.redirectUrls.length, 1);
 				}
 			]
 		}


### PR DESCRIPTION
Closes #810

> The `beforeRedirect` hook will receive the original response (the one that has a 3xx status code) as the second argument.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] If it's a new feature, I have included documentation updates.
