### PR TITLE
Add option to ignore invalid cookies

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -248,7 +248,7 @@ Cookie support. You don't have to care about parsing or how to store them. [Exam
 Type: `boolean`<br>
 Default: `false`
 
-When set to `true`, silently ignore invalid cookies instead of throwing an error. Only useful when the `cookieJar` option has been set.
+Ignore invalid cookies instead of throwing an error. Only useful when the `cookieJar` option has been set. Not recommended.
 
 ###### encoding
 

--- a/readme.md
+++ b/readme.md
@@ -243,6 +243,13 @@ Type: [`tough.CookieJar` instance](https://github.com/salesforce/tough-cookie#co
 
 Cookie support. You don't have to care about parsing or how to store them. [Example.](#cookies)
 
+###### ignoreInvalidCookies
+
+Type: `boolean`<br>
+Default: `false`
+
+When set to `true`, silently ignore invalid cookies instead of throwing an error. Only useful when the `cookieJar` option has been set.
+
 ###### encoding
 
 Type: `string | null`<br>

--- a/source/request-as-event-emitter.ts
+++ b/source/request-as-event-emitter.ts
@@ -130,7 +130,12 @@ export default (options: NormalizedOptions, input?: TransformStream) => {
 
 				const rawCookies = typedResponse.headers['set-cookie'];
 				if (options.cookieJar && rawCookies) {
-					await Promise.all(rawCookies.map((rawCookie: string) => setCookie!(rawCookie, typedResponse.url!)));
+					let promises = rawCookies.map((rawCookie: string) => setCookie!(rawCookie, typedResponse.url!));
+					if (options.ignoreInvalidCookies) {
+						promises = promises.map(p => p.catch(() => {}));
+					}
+
+					await Promise.all(promises);
 				}
 
 				if (options.followRedirect && 'location' in typedResponse.headers) {

--- a/source/utils/types.ts
+++ b/source/utils/types.ts
@@ -124,6 +124,7 @@ export interface Options extends Omit<https.RequestOptions, 'agent' | 'timeout' 
 	retry?: number | Partial<RetryOption | NormalizedRetryOptions>;
 	throwHttpErrors?: boolean;
 	cookieJar?: CookieJar;
+	ignoreInvalidCookies?: boolean;
 	request?: RequestFunction;
 	agent?: http.Agent | https.Agent | boolean | AgentByProtocol;
 	gotTimeout?: number | Delays;

--- a/test/cookies.ts
+++ b/test/cookies.ts
@@ -70,6 +70,23 @@ test('throws on invalid cookies', withServer, async (t, server, got) => {
 	await t.throwsAsync(got({cookieJar}), 'Cookie has domain set to a public suffix');
 });
 
+test('does not throw on invalid cookies when options.ignoreInvalidCookies is set', withServer, async (t, server, got) => {
+	server.get('/', (_request, response) => {
+		response.setHeader('set-cookie', 'hello=world; domain=localhost');
+		response.end();
+	});
+
+	const cookieJar = new toughCookie.CookieJar();
+
+	await got({
+		cookieJar,
+		ignoreInvalidCookies: true
+	});
+
+	const cookies = cookieJar.getCookiesSync(server.url);
+	t.is(cookies.length, 0);
+});
+
 test('catches store errors', async t => {
 	const error = 'Some error';
 	// @ts-ignore


### PR DESCRIPTION
When `options.ignoreInvalidCookies` is set, ignore invalid cookies instead of throwing an error.

See previous: #802 (sorry for duplicate)

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] If it's a new feature, I have included documentation updates.
