### PR TITLE
Cancel all timeouts when one occurs

### DIFF
--- a/source/utils/unhandle.ts
+++ b/source/utils/unhandle.ts
@@ -33,6 +33,8 @@ export default (): Unhandler => {
 				const {origin, event, fn} = handler;
 				origin.removeListener(event, fn);
 			}
+
+			handlers.length = 0;
 		}
 	};
 };


### PR DESCRIPTION
As I've explained a few times under previous issues that our team reported, our HTTP client code relies heavily on socket reuse. In this case, it's imperative that all listeners and timeouts attached to a request get cleaned up before got finishes handling the request. Sorry to keep coming back to that use case but issues with it can hurt us badly.

So... When firing many requests to the same IP, we see spurious `lookup` timeout errors. They seem to be happening because a timeout from a previous call leaked into the current one due to socket reuse. Our `lookup` timeout is 500 ms and we heavily optimize DNS so that the `lookup()` call actually takes less than 1 ms, so the 500 ms is only supposed to hit at 100% CPU, which is definitely not the case.

`timed-out` currently seems to do a better job at removing event listeners than at clearing timeouts. Timeouts will only get cleared upon an error event (unless it's a socket hang up?), but the occurrence of one timeout will not cancel any other ones.

This PR tries to address that by:

- calling `cancelTimeouts` from the timeout callback itself, so that any timeout will clear all the other ones;

- clearing the arrays of listeners and timeouts so that they only get removed once.

We're still setting up a high-volume test for this logic but I already wanted to test the water.

Along the way, I also noticed some related things:

- `cancelTimeouts` actually clears timeouts _and_ removes event listeners, so something like `dispose`, `finalize`, `cleanUp`, ... would probably be a better name.

- `unhandle` could be useful to other people as well so it could be factored out into a package. In fact, many years ago, I already wrote [event-registry](https://npmjs.com/package/event-registry) which addresses the same problem. I may have mentioned that before.

- Conversely, I'm not sure `unhandle` is necessary if you already maintain an array of `cancelers`. Currently, disposal/cleanup is spread across two modules and I think it'd be much nicer if there were a single place where all of the cleanup logic converged. As mentioned above, `cancelTimeouts` also does part of it but not all. Is there a good reason for keeping the two separate?