### PR TITLE
Make the TypeScript types strict and better

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"node": ">=8.6"
 	},
 	"scripts": {
-		"test": "xo && nyc ava",
+		"test": "xo && nyc ava && tsc --noEmit --strict",
 		"release": "np",
 		"build": "del-cli dist && tsc",
 		"prepublishOnly": "npm run build"

--- a/source/request-as-event-emitter.ts
+++ b/source/request-as-event-emitter.ts
@@ -130,7 +130,7 @@ export default (options: NormalizedOptions, input?: TransformStream) => {
 
 				const rawCookies = typedResponse.headers['set-cookie'];
 				if (options.cookieJar && rawCookies) {
-					let promises = rawCookies.map((rawCookie: string) => setCookie!(rawCookie, typedResponse.url!));
+					let promises: Array<Promise<unknown>> = rawCookies.map((rawCookie: string) => setCookie!(rawCookie, typedResponse.url!));
 					if (options.ignoreInvalidCookies) {
 						promises = promises.map(p => p.catch(() => {}));
 					}

--- a/source/utils/timed-out.ts
+++ b/source/utils/timed-out.ts
@@ -3,7 +3,7 @@ import {ClientRequest, IncomingMessage} from 'http';
 import {Delays} from './types';
 import unhandler from './unhandle';
 
-// Help TypeScript to understand how we are passing arguments thru setImmediate
+// Help TypeScript understand how we are passing arguments through `setImmediate`.
 declare function setImmediate<T extends any[]>(callback: (arg0: number, ...args: T) => void, arg0: number, ...args: T): NodeJS.Immediate;
 
 const reentry = Symbol('reentry');

--- a/source/utils/types.ts
+++ b/source/utils/types.ts
@@ -69,7 +69,7 @@ export interface Response extends http.IncomingMessage {
 
 export type RetryFunction = (retry: number, error: Error | GotError | ParseError | HTTPError | MaxRedirectsError) => number;
 
-export type HandlerFunction = <T extends ProxyStream | CancelableRequest<Response>>(options: Options, next: (options: Options) => T) => T;
+export type HandlerFunction = <T extends ProxyStream | CancelableRequest<Response>>(options: NormalizedOptions, next: (options: NormalizedOptions) => T) => T;
 
 export interface RetryOption {
 	retries?: RetryFunction | number;
@@ -146,7 +146,7 @@ export interface Options extends Omit<https.RequestOptions, 'agent' | 'timeout' 
 	context?: {[key: string]: unknown};
 }
 
-export interface NormalizedOptions extends Omit<Required<Options>, 'timeout' | 'dnsCache' | 'retry'> {
+export interface NormalizedOptions extends Omit<Required<Options>, 'timeout' | 'dnsCache' | 'retry' | 'auth' | 'body' | 'port'> {
 	hooks: Hooks;
 	gotTimeout: Required<Delays>;
 	retry: NormalizedRetryOptions;
@@ -155,6 +155,9 @@ export interface NormalizedOptions extends Omit<Required<Options>, 'timeout' | '
 	path: string;
 	hostname: string;
 	host: string;
+	auth?: Options['auth'];
+	body?: Options['body'];
+	port?: Options['port'];
 }
 
 export interface Defaults {

--- a/source/utils/unhandle.ts
+++ b/source/utils/unhandle.ts
@@ -2,7 +2,7 @@ import EventEmitter = require('events');
 
 type Origin = EventEmitter;
 type Event = string | symbol;
-type Fn = (...args: unknown[]) => void;
+type Fn = (...args: any[]) => void;
 
 interface Handler {
 	origin: Origin;


### PR DESCRIPTION
Blocked on: form-data/form-data#435 or DefinitelyTyped/DefinitelyTyped#37331

Next steps:

- [x] Upgrade to TypeScript 3.5
- [ ] Make `test/**/*.ts` conform to strict mode
- [ ] Turn on strict mode in `tsconfig.json`
- [ ] Everything else from #758

There is currently 1218 TypeScript errors in test files when running in strict mode 😂 

Will submit some typings upstream and then type everything up!