### PR TITLE
prepare build the code

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"test": "xo && nyc ava",
 		"release": "np",
 		"build": "del-cli dist && tsc",
-		"prepublishOnly": "npm run build"
+		"prepare": "npm run build"
 	},
 	"files": [
 		"dist"


### PR DESCRIPTION
Install from git result on an empty module due to the "files": ["dist"] configuration, using "prepare" is a more elegant solution than pushing the disk folder

#749 was maybe an attempt to describe this problem