### PR TITLE
Add new related project

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1456,6 +1456,7 @@ const h2got = got.extend({request});
 - [travis-got](https://github.com/samverschueren/travis-got) - Got convenience wrapper to interact with the Travis API
 - [graphql-got](https://github.com/kevva/graphql-got) - Got convenience wrapper to interact with GraphQL
 - [GotQL](https://github.com/khaosdoctor/gotql) - Got convenience wrapper to interact with GraphQL using JSON-parsed queries instead of strings
+- [got-fetch](https://github.com/alexghr/got-fetch) - Got with a `fetch` interface
 
 
 ## Maintainers


### PR DESCRIPTION
I've added a new related project to the README file https://github.com/alexghr/got-fetch. It's basically a `fetch`-compatible function which uses Got. 
I've enjoyed using Got directly for my HTTP requests but there were times when I needed a fetch function in Node and had to also add `node-fetch` to my project (e.g. GraphQL schema stitching on the backend). This project solves that by wrapping Got in a `fetch` function.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] ~I have included some tests.~
- [ ] ~If it's a new feature, I have included documentation updates.~
