### PR TITLE
Fix types: Allow promises in `afterResponse` hook

### DIFF
--- a/source/known-hook-events.ts
+++ b/source/known-hook-events.ts
@@ -39,7 +39,7 @@ Called with [response object](https://github.com/sindresorhus/got#response) and 
 
 Each function should return the response. This is especially useful when you want to refresh an access token.
 */
-export type AfterResponseHook = (response: Response, retryWithMergedOptions: (options: NormalizedOptions) => CancelableRequest<Response>) => Response | CancelableRequest<Response>;
+export type AfterResponseHook = (response: Response, retryWithMergedOptions: (options: NormalizedOptions) => CancelableRequest<Response>) => Response | CancelableRequest<Response> | Promise <Response | CancelableRequest<Response>>;
 
 export type HookType =
 	| BeforeErrorHook

--- a/source/known-hook-events.ts
+++ b/source/known-hook-events.ts
@@ -39,7 +39,7 @@ Called with [response object](https://github.com/sindresorhus/got#response) and 
 
 Each function should return the response. This is especially useful when you want to refresh an access token.
 */
-export type AfterResponseHook = (response: Response, retryWithMergedOptions: (options: NormalizedOptions) => CancelableRequest<Response>) => Response | CancelableRequest<Response> | Promise <Response | CancelableRequest<Response>>;
+export type AfterResponseHook = (response: Response, retryWithMergedOptions: (options: NormalizedOptions) => CancelableRequest<Response>) => Response | CancelableRequest<Response> | Promise<Response | CancelableRequest<Response>>;
 
 export type HookType =
 	| BeforeErrorHook


### PR DESCRIPTION
Solves https://github.com/sindresorhus/got/issues/876

#### Checklist

- [X] I have read the documentation.
- [X] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates.
