### PR TITLE
Export useful types for end-users

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -64,3 +64,43 @@ export default got;
 // For CommonJS default export support
 module.exports = got;
 module.exports.default = got;
+
+// Export types
+export * from './utils/types';
+export {
+	Got,
+	GotStream,
+	ReturnResponse,
+	ReturnStream,
+	GotReturn
+} from './create';
+export {
+	ProxyStream
+} from './as-stream';
+export {
+	GotError,
+	CacheError,
+	RequestError,
+	ParseError,
+	HTTPError,
+	MaxRedirectsError,
+	UnsupportedProtocolError,
+	TimeoutError,
+	CancelError
+} from './errors';
+export {
+	InitHook,
+	BeforeRequestHook,
+	BeforeRedirectHook,
+	BeforeRetryHook,
+	BeforeErrorHook,
+	AfterResponseHook,
+	HookType,
+	Hooks,
+	HookEvent
+} from './known-hook-events';
+export {
+	GetMethodRedirectCodes,
+	AllMethodRedirectCodes,
+	RequestAsEventEmitter
+} from './request-as-event-emitter';

--- a/source/index.ts
+++ b/source/index.ts
@@ -75,7 +75,7 @@ export {
 	GotReturn
 } from './create';
 export {
-	ProxyStream
+	ProxyStream as ResponseStream
 } from './as-stream';
 export {
 	GotError,

--- a/source/index.ts
+++ b/source/index.ts
@@ -99,8 +99,3 @@ export {
 	Hooks,
 	HookEvent
 } from './known-hook-events';
-export {
-	GetMethodRedirectCodes,
-	AllMethodRedirectCodes,
-	RequestAsEventEmitter
-} from './request-as-event-emitter';


### PR DESCRIPTION
As discussed in https://github.com/sindresorhus/got/issues/876 this PR exports most of the types in the index file, e.g. instead of:
```
import { CancelableRequest, Response } from 'got/dist/utils/types'
import { Got, GotStream } from 'got/dist/create'
import { ProxyStream } from 'got/dist/as-stream'
```

it would be:
```
import { Got, GotStream, ProxyStream, CancelableRequest, Response } from 'got'
```

#### Checklist

- [X] I have read the documentation.
- [X] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates.
