### PR TITLE
Fix TypeScript definition for projects not using the DOM types

### DIFF
--- a/source/utils/types.ts
+++ b/source/utils/types.ts
@@ -2,7 +2,7 @@ import http = require('http');
 import https = require('https');
 import {Readable as ReadableStream} from 'stream';
 import PCancelable = require('p-cancelable');
-import {URL} from 'url';
+import {URL, URLSearchParams} from 'url';
 import {CookieJar} from 'tough-cookie';
 import {StorageAdapter} from 'cacheable-request';
 import {Except} from 'type-fest';


### PR DESCRIPTION
Fixes [this](https://github.com/sindresorhus/got/issues/876#issuecomment-537127127).

`url` comes from `@types/node`, which is a devDependency, and more importantly should be present in any project using this library as this library targets Node.js.