### PR TITLE
Fix `Stream.pipeline(...)` usage and properly detect aborted requests

### DIFF
--- a/source/utils/timed-out.ts
+++ b/source/utils/timed-out.ts
@@ -40,10 +40,7 @@ export default (request: ClientRequest, delays: Delays, options: TimedOutOptions
 		const timeout: NodeJS.Timeout = setTimeout(() => {
 			// @ts-ignore https://github.com/microsoft/TypeScript/issues/26113
 			immediate = setImmediate(callback, delay, ...args);
-			/* istanbul ignore next: added in node v9.7.0 */
-			if (immediate.unref) {
-				immediate.unref();
-			}
+			immediate.unref();
 		}, delay);
 
 		/* istanbul ignore next: in order to support electron renderer */

--- a/test/gzip.ts
+++ b/test/gzip.ts
@@ -43,17 +43,13 @@ test('handles gzip error', withServer, async (t, server, got) => {
 	t.is(error.name, 'ReadError');
 });
 
-// FIXME: This causes an unhandled rejection.
-// eslint-disable-next-line ava/no-skip-test
-test.skip('handles gzip error - stream', withServer, async (t, server, got) => {
+test('handles gzip error - stream', withServer, async (t, server, got) => {
 	server.get('/', (_request, response) => {
 		response.setHeader('Content-Encoding', 'gzip');
 		response.end('Not gzipped content');
 	});
 
-	const error = await t.throws(() => {
-		got.stream('');
-	}, 'incorrect header check');
+	const error = await t.throwsAsync(getStream(got.stream('')), 'incorrect header check');
 
 	// @ts-ignore
 	t.is(error.options.path, '/');

--- a/test/http.ts
+++ b/test/http.ts
@@ -119,3 +119,13 @@ test('response contains got options', withServer, async (t, server, got) => {
 
 	t.is((await got(options)).request.options.auth, options.auth);
 });
+
+test('socket destroyed by the server throws ECONNRESET', withServer, async (t, server, got) => {
+	server.get('/', request => {
+		request.socket.destroy();
+	});
+
+	await t.throwsAsync(got('', {retry: 0}), {
+		code: 'ECONNRESET'
+	});
+});

--- a/test/timeout.ts
+++ b/test/timeout.ts
@@ -116,9 +116,7 @@ test.serial('send timeout', withServerAndLolex, async (t, server, got, clock) =>
 	);
 });
 
-// FIXME: This causes an unhandled rejection.
-// eslint-disable-next-line ava/no-skip-test
-test.serial.skip('send timeout (keepalive)', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('send timeout (keepalive)', withServerAndLolex, async (t, server, got, clock) => {
 	server.post('/', defaultHandler(clock));
 	server.get('/prime', (_request, response) => {
 		response.end('ok');

--- a/test/timeout.ts
+++ b/test/timeout.ts
@@ -412,13 +412,9 @@ test.serial('no unhandled `socket hung up` errors', withServerAndLolex, async (t
 	server.get('/', defaultHandler(clock));
 
 	await t.throwsAsync(
-		got({retry: 0, timeout: requestDelay / 2}).on('request', () => {
-			clock.tick(requestDelay);
-		}),
+		got({retry: 0, timeout: requestDelay / 2}),
 		{instanceOf: got.TimeoutError}
 	);
-
-	clock.tick(requestDelay);
 });
 
 test.serial('no more timeouts after an error', withServerAndLolex, async (t, _server, got, clock) => {


### PR DESCRIPTION
Fixes #907 