### PR TITLE
Use socket instead of connection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - '13'
   - '12'
   - '10'
 after_success:

--- a/source/request-as-event-emitter.ts
+++ b/source/request-as-event-emitter.ts
@@ -127,6 +127,7 @@ export default (options: NormalizedOptions, input?: TransformStream) => {
 				delete typedResponse.fromCache;
 
 				if (!typedResponse.isFromCache) {
+					// @ts-ignore Node typings haven't been updated yet
 					typedResponse.ip = response.socket.remoteAddress;
 				}
 

--- a/source/request-as-event-emitter.ts
+++ b/source/request-as-event-emitter.ts
@@ -127,7 +127,7 @@ export default (options: NormalizedOptions, input?: TransformStream) => {
 				delete typedResponse.fromCache;
 
 				if (!typedResponse.isFromCache) {
-					typedResponse.ip = response.connection.remoteAddress;
+					typedResponse.ip = response.socket.remoteAddress;
 				}
 
 				const rawCookies = typedResponse.headers['set-cookie'];

--- a/source/utils/types.ts
+++ b/source/utils/types.ts
@@ -71,7 +71,7 @@ export interface Response extends http.IncomingMessage {
 // TODO: The `ResponseLike` type should be properly fixed instead:
 // https://github.com/sindresorhus/got/pull/827/files#r323633794
 export interface ResponseObject extends ResponseLike {
-	connection: {
+	socket: {
 		remoteAddress: string;
 	};
 }


### PR DESCRIPTION
The request.connection and response.connection properties are now runtime deprecated. (https://github.com/sindresorhus/got/pull/827)

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] If it's a new feature, I have included documentation updates.
