### PR TITLE
Throw when passing an object with no protocol

### DIFF
--- a/source/normalize-arguments.ts
+++ b/source/normalize-arguments.ts
@@ -173,8 +173,11 @@ export const normalizeArguments = (url: URLOrOptions, options: Options, defaults
 		urlObj = urlArgument;
 	}
 
-	// Override both null/undefined with default protocol
-	options = mergeOptions({path: ''}, urlObj, {protocol: urlObj.protocol || 'https:'}, options);
+	if (!Reflect.has(urlObj, 'protocol') && !Reflect.has(options, 'protocol')) {
+		throw new TypeError('No URL protocol specified');
+	}
+
+	options = mergeOptions(urlObj, options);
 
 	for (const hook of options.hooks.init) {
 		if (is.asyncFunction(hook)) {

--- a/test/arguments.ts
+++ b/test/arguments.ts
@@ -34,6 +34,11 @@ test('throws an error if the protocol is not specified', async t => {
 		instanceOf: TypeError,
 		message: 'Invalid URL: example.com'
 	});
+
+	await t.throwsAsync(got({}), {
+		instanceOf: TypeError,
+		message: 'No URL protocol specified'
+	});
 });
 
 test('string url with searchParams is preserved', withServer, async (t, server, got) => {


### PR DESCRIPTION
See #850

A follow-up to 92bc8082137d7d085750359bbd76c801e213d7d2