### PR TITLE
Add package.json funding property

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
 	"files": [
 		"dist/source"
 	],
+	"funding": {
+		"type": "Tidelift",
+		"url": "https://tidelift.com/subscription/pkg/npm-got"
+	},
 	"keywords": [
 		"http",
 		"https",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"description": "Simplified HTTP requests",
 	"license": "MIT",
 	"repository": "sindresorhus/got",
+	"funding": "https://github.com/sindresorhus/got?sponsor=1",
 	"main": "dist/source",
 	"engines": {
 		"node": ">=10"
@@ -17,10 +18,6 @@
 	"files": [
 		"dist/source"
 	],
-	"funding": {
-		"type": "Tidelift",
-		"url": "https://tidelift.com/subscription/pkg/npm-got"
-	},
 	"keywords": [
 		"http",
 		"https",


### PR DESCRIPTION
**npm** just added a new [`npm fund` command](https://blog.npmjs.org/post/188841555980/updates-to-community-docs-more) in it's [v6.13.0](https://github.com/npm/cli/releases/tag/v6.13.0) release as part of the efforts to help out the OSS community.

This PR adds `funding` info to **got** so that users depending on it can actually retrieve the funding url when they run `npm fund` in their projects.

Note: The funding information will only be available once a new version of the package is published to the npm registry.