### PR TITLE
Fix `got.mergeOptions(...)` types

### DIFF
--- a/source/create.ts
+++ b/source/create.ts
@@ -70,7 +70,7 @@ export interface Got extends Record<HTTPAlias, GotFunctions>, GotFunctions {
 
 	extend(...instancesOrOptions: Array<Got | ExtendOptions>): Got;
 	mergeInstances(parent: Got, ...instances: Got[]): Got;
-	mergeOptions<T extends PartialDeep<Options>>(...sources: T[]): T;
+	mergeOptions(...sources: Options[]): NormalizedOptions;
 }
 
 export interface GotStream extends Record<HTTPAlias, ReturnStream> {

--- a/source/create.ts
+++ b/source/create.ts
@@ -1,4 +1,4 @@
-import {Merge, PartialDeep} from 'type-fest';
+import {Merge} from 'type-fest';
 import asPromise from './as-promise';
 import asStream, {ProxyStream} from './as-stream';
 import * as errors from './errors';

--- a/test/normalize-arguments.ts
+++ b/test/normalize-arguments.ts
@@ -1,10 +1,10 @@
 import test from 'ava';
 import got from '../source';
 
-test('should merge options replacing responseType', async t => {
+test('should merge options replacing responseType', t => {
 	const responseType = 'json';
 	const options = got.mergeOptions(got.defaults.options, {
-		responseType,
+		responseType
 	});
 
 	t.is(options.responseType, responseType);

--- a/test/normalize-arguments.ts
+++ b/test/normalize-arguments.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import got from '../source';
 
-test('https request without ca', async t => {
+test('should merge options replacing responseType', async t => {
 	const responseType = 'json';
 	const options = got.mergeOptions(got.defaults.options, {
 		responseType,

--- a/test/normalize-arguments.ts
+++ b/test/normalize-arguments.ts
@@ -1,0 +1,11 @@
+import test from 'ava';
+import got from '../source';
+
+test('https request without ca', async t => {
+	const responseType = 'json';
+	const options = got.mergeOptions(got.defaults.options, {
+		responseType,
+	});
+
+	t.is(options.responseType, responseType);
+});


### PR DESCRIPTION
Adds test coverage for mergeOptions usage similar to that in the readme.

Not passing because I'm not sure what the fix should be, willing to make the change. Partial?