### PR TITLE
Remove leading slashes from the `prefixUrl` in examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -804,7 +804,7 @@ const client = got.extend({
 	}
 });
 
-client.get('/demo');
+client.get('demo');
 
 /* HTTP Request =>
  * GET /demo HTTP/1.1
@@ -821,7 +821,7 @@ client.get('/demo');
 			'x-foo': 'bar'
 		}
 	});
-	const {headers} = await client.get('/headers').json();
+	const {headers} = await client.get('headers').json();
 	//=> headers['x-foo'] === 'bar'
 
 	const jsonClient = client.extend({
@@ -831,7 +831,7 @@ client.get('/demo');
 			'x-baz': 'qux'
 		}
 	});
-	const {headers: headers2} = await jsonClient.get('/headers');
+	const {headers: headers2} = await jsonClient.get('headers');
 	//=> headers2['x-foo'] === 'bar'
 	//=> headers2['x-baz'] === 'qux'
 })();
@@ -1391,7 +1391,7 @@ const custom = got.extend({
 
 // Use `custom` exactly how you use `got`
 (async () => {
-	const list = await custom('/v1/users/list');
+	const list = await custom('v1/users/list');
 })();
 ```
 


### PR DESCRIPTION
With 10.0.0, if `prefixUrl` option is used to extend the instance, `url` should have no leading slashes. It is explained in the note [here](https://github.com/sindresorhus/got#prefixurl) but some examples across the documentation have been missing this change.

This PR is fixing it.

Fixes #952