### PR TITLE
Fix a JSON example in the `readme.md`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1338,7 +1338,7 @@ const got = require('got');
 
 (async () => {
 	const body = await got.post('https://httpbin.org/anything', {
-		body: {
+		json: {
 			hello: 'world'
 		}
 	}).json();


### PR DESCRIPTION
Running the example with v10.0.1 currently results in:

```
TypeError: The `body` option must be a stream.Readable, string or Buffer
```

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates.
