### PR TITLE
Fix type problem with `URL` and `URLSearchParams` globals

### DIFF
--- a/source/utils/types.ts
+++ b/source/utils/types.ts
@@ -247,3 +247,44 @@ export interface CancelableRequest<T extends Response | Response['body']> extend
 	buffer(): CancelableRequest<Buffer>;
 	text(): CancelableRequest<string>;
 }
+
+// TODO: Remove this when https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34960 is resolved
+declare global {
+	// @ts-ignore TypeScript complains about duplicated identifier.
+	class URL {
+		readonly origin: string;
+		readonly searchParams: URLSearchParams;
+		hash: string;
+		host: string;
+		hostname: string;
+		href: string;
+		password: string;
+		pathname: string;
+		port: string;
+		protocol: string;
+		search: string;
+		username: string;
+
+		constructor(input: string, base?: string | URL);
+		toString(): string;
+		toJSON(): string;
+	}
+
+	// @ts-ignore TypeScript complains about duplicated identifier.
+	class URLSearchParams implements Iterable<[string, string]> {
+		constructor(init?: URLSearchParams | string | {[key: string]: string | string[] | undefined} | Iterable<[string, string]> | Array<[string, string]>);
+		append(name: string, value: string): void;
+		delete(name: string): void;
+		entries(): IterableIterator<[string, string]>;
+		forEach(callback: (value: string, name: string, searchParams: this) => void): void;
+		get(name: string): string | null;
+		getAll(name: string): string[];
+		has(name: string): boolean;
+		keys(): IterableIterator<string>;
+		set(name: string, value: string): void;
+		sort(): void;
+		toString(): string;
+		values(): IterableIterator<string>;
+		[Symbol.iterator](): IterableIterator<[string, string]>;
+	}
+}


### PR DESCRIPTION
This fixes #960 , basically duplicating the URL global shim to the types file which is exported to user-land.
