### PR TITLE
Export `GotRequestMethod` TypeScript type

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1016,7 +1016,7 @@ const addAccessToken = (accessToken: string): BeforeRequestHook => (options) => 
 }
 ```
 
- ## Errors
+## Errors
 
 Each error contains an `options` property which are the options Got used to create a request - just to make debugging easier.
 

--- a/readme.md
+++ b/readme.md
@@ -998,7 +998,7 @@ Got has a set of handy types and interfaces available, so you can integrate Got 
 
 ### Got
 
-Typescript will automatically infer types for Got instances but in case you want to define something like dependencies you can use following: `Got`, `GotStream`, `ReturnStream`, `GotRequestMethod`, `GotReturn`
+Typescript will automatically infer types for Got instances but in case you want to define something like dependencies you can import available types directly from `got`
 
 ```ts
 import {GotRequestMethod} from 'got';

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,7 @@ For browser usage, we recommend [Ky](https://github.com/sindresorhus/ky) by the 
 - [WHATWG URL support](#url)
 - [Hooks](#hooks)
 - [Instances with custom defaults](#instances)
+- [Types](#types)
 - [Composable](documentation/advanced-creation.md#merging-instances)
 - [Plugins](documentation/lets-make-a-plugin.md)
 - [Used by 3000+ packages and 1.6M+ repos](https://github.com/sindresorhus/got/network/dependents)
@@ -991,7 +992,31 @@ Default: `false`
 
 A read-only boolean describing whether the defaults are mutable or not. If set to `true`, you can [update headers over time](#hooksafterresponse), for example, update an access token when it expires.
 
-## Errors
+## Types
+
+Since Got was rewritten in TypeScript it has a set of handy types and interfaces available
+
+### Got
+Typescript will automatically infer types for Got instances but in case you want to define something like dependencies you can use following: `Got`, `GotStream`, `ReturnStream`, `GotRequestMethod`, `GotReturn`
+
+```typescript
+import { GotRequestMethod } from 'got'
+
+interface Dependencies {
+  readonly post: GotRequestMethod
+}
+```
+
+### Hooks
+Following types can be used to define isolated hooks and keep their interfaces consistent: `Hooks`, `HookEvent`, `HookType`, `InitHook`, `BeforeRequestHook`, `BeforeRedirectHook`, `BeforeRetryHook`, `BeforeErrorHook`, `AfterResponseHook`
+
+```typescript
+const addAccessToken = (accessToken: string): BeforeRequestHook => (options) => {
+  options.path = `${options.path}?access_token=${accessToken}`
+}
+```
+
+ ## Errors
 
 Each error contains an `options` property which are the options Got used to create a request - just to make debugging easier.
 

--- a/readme.md
+++ b/readme.md
@@ -994,25 +994,27 @@ A read-only boolean describing whether the defaults are mutable or not. If set t
 
 ## Types
 
-Since Got was rewritten in TypeScript it has a set of handy types and interfaces available
+When used in a TypeScript project, Got has a set of handy types and interfaces available.
 
 ### Got
+
 Typescript will automatically infer types for Got instances but in case you want to define something like dependencies you can use following: `Got`, `GotStream`, `ReturnStream`, `GotRequestMethod`, `GotReturn`
 
-```typescript
-import { GotRequestMethod } from 'got'
+```ts
+import {GotRequestMethod} from 'got';
 
 interface Dependencies {
-  readonly post: GotRequestMethod
+	readonly post: GotRequestMethod
 }
 ```
 
 ### Hooks
-Following types can be used to define isolated hooks and keep their interfaces consistent: `Hooks`, `HookEvent`, `HookType`, `InitHook`, `BeforeRequestHook`, `BeforeRedirectHook`, `BeforeRetryHook`, `BeforeErrorHook`, `AfterResponseHook`
 
-```typescript
-const addAccessToken = (accessToken: string): BeforeRequestHook => (options) => {
-  options.path = `${options.path}?access_token=${accessToken}`
+The following types can be used to define isolated hooks and keep their interfaces consistent: `Hooks`, `HookEvent`, `HookType`, `InitHook`, `BeforeRequestHook`, `BeforeRedirectHook`, `BeforeRetryHook`, `BeforeErrorHook`, `AfterResponseHook`
+
+```ts
+const addAccessToken = (accessToken: string): BeforeRequestHook => options => {
+	options.path = `${options.path}?access_token=${accessToken}`;
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -998,7 +998,7 @@ Got exports some handy TypeScript types and interfaces. See the type definition 
 
 ### Got
 
-TypeScript will automatically infer types for Got instances, but in case you want to define something like dependencies, you can import available types directly from Got.
+TypeScript will automatically infer types for Got instances, but in case you want to define something like dependencies, you can import the available types directly from Got.
 
 ```ts
 import {GotRequestMethod} from 'got';
@@ -1010,7 +1010,7 @@ interface Dependencies {
 
 ### Hooks
 
-When writing hooks, you can refer to their types and keep interfaces consistent.
+When writing hooks, you can refer to their types to keep your interfaces consistent.
 
 ```ts
 import {BeforeRequestHook} from 'got';

--- a/readme.md
+++ b/readme.md
@@ -994,7 +994,7 @@ A read-only boolean describing whether the defaults are mutable or not. If set t
 
 ## Types
 
-When used in a TypeScript project, Got has a set of handy types and interfaces available.
+Got has a set of handy types and interfaces available, so you can integrate Got with your TypeScript project seamlessly.
 
 ### Got
 

--- a/readme.md
+++ b/readme.md
@@ -994,11 +994,11 @@ A read-only boolean describing whether the defaults are mutable or not. If set t
 
 ## Types
 
-Got has a set of handy types and interfaces available, so you can integrate Got with your TypeScript project seamlessly.
+Got exports some handy TypeScript types and interfaces. See the type definition for all the exported types.
 
 ### Got
 
-Typescript will automatically infer types for Got instances but in case you want to define something like dependencies you can import available types directly from `got`.
+TypeScript will automatically infer types for Got instances, but in case you want to define something like dependencies, you can import available types directly from Got.
 
 ```ts
 import {GotRequestMethod} from 'got';
@@ -1010,7 +1010,7 @@ interface Dependencies {
 
 ### Hooks
 
-When writing hooks you can refer to their types and keep interfaces consistent
+When writing hooks, you can refer to their types and keep interfaces consistent.
 
 ```ts
 import {BeforeRequestHook} from 'got';

--- a/readme.md
+++ b/readme.md
@@ -1010,9 +1010,11 @@ interface Dependencies {
 
 ### Hooks
 
-The following types can be used to define isolated hooks and keep their interfaces consistent: `Hooks`, `HookEvent`, `HookType`, `InitHook`, `BeforeRequestHook`, `BeforeRedirectHook`, `BeforeRetryHook`, `BeforeErrorHook`, `AfterResponseHook`
+When writing hooks you can refer to their types and keep interfaces consistent
 
 ```ts
+import {BeforeRequestHook} from 'got';
+
 const addAccessToken = (accessToken: string): BeforeRequestHook => options => {
 	options.path = `${options.path}?access_token=${accessToken}`;
 }

--- a/readme.md
+++ b/readme.md
@@ -998,7 +998,7 @@ Got has a set of handy types and interfaces available, so you can integrate Got 
 
 ### Got
 
-Typescript will automatically infer types for Got instances but in case you want to define something like dependencies you can import available types directly from `got`
+Typescript will automatically infer types for Got instances but in case you want to define something like dependencies you can import available types directly from `got`.
 
 ```ts
 import {GotRequestMethod} from 'got';

--- a/source/create.ts
+++ b/source/create.ts
@@ -39,7 +39,7 @@ type OptionsOfJSONResponseBody = Merge<Options, {isStream?: false; resolveBodyOn
 type OptionsOfBufferResponseBody = Merge<Options, {isStream?: false; resolveBodyOnly?: false; responseType: 'buffer'}>;
 type ResponseBodyOnly = {resolveBodyOnly: true};
 
-export interface GotFunctions {
+export interface GotRequestMethod {
 	// `asPromise` usage
 	<T = string>(url: string | OptionsOfDefaultResponseBody, options?: OptionsOfDefaultResponseBody): CancelableRequest<Response<T>>;
 	(url: string | OptionsOfTextResponseBody, options?: OptionsOfTextResponseBody): CancelableRequest<Response<string>>;
@@ -54,7 +54,7 @@ export interface GotFunctions {
 	<T>(url: string | Merge<Options, {isStream: true}>, options?: Merge<Options, {isStream: true}>): ProxyStream<T>;
 }
 
-export interface Got extends Record<HTTPAlias, GotFunctions>, GotFunctions {
+export interface Got extends Record<HTTPAlias, GotRequestMethod>, GotRequestMethod {
 	stream: GotStream;
 	defaults: Defaults;
 	GotError: typeof errors.GotError;

--- a/source/create.ts
+++ b/source/create.ts
@@ -39,7 +39,7 @@ type OptionsOfJSONResponseBody = Merge<Options, {isStream?: false; resolveBodyOn
 type OptionsOfBufferResponseBody = Merge<Options, {isStream?: false; resolveBodyOnly?: false; responseType: 'buffer'}>;
 type ResponseBodyOnly = {resolveBodyOnly: true};
 
-interface GotFunctions {
+export interface GotFunctions {
 	// `asPromise` usage
 	<T = string>(url: string | OptionsOfDefaultResponseBody, options?: OptionsOfDefaultResponseBody): CancelableRequest<Response<T>>;
 	(url: string | OptionsOfTextResponseBody, options?: OptionsOfTextResponseBody): CancelableRequest<Response<string>>;

--- a/source/create.ts
+++ b/source/create.ts
@@ -39,7 +39,9 @@ type OptionsOfJSONResponseBody = Merge<Options, {isStream?: false; resolveBodyOn
 type OptionsOfBufferResponseBody = Merge<Options, {isStream?: false; resolveBodyOnly?: false; responseType: 'buffer'}>;
 type ResponseBodyOnly = {resolveBodyOnly: true};
 
-// Can be used to match methods explicitly or cases like parameters extraction e.g `Parameters<GotRequestMethod>`
+/**
+Can be used to match methods explicitly or parameters extraction: `Parameters<GotRequestMethod>`.
+*/
 export interface GotRequestMethod {
 	// `asPromise` usage
 	<T = string>(url: string | OptionsOfDefaultResponseBody, options?: OptionsOfDefaultResponseBody): CancelableRequest<Response<T>>;

--- a/source/create.ts
+++ b/source/create.ts
@@ -39,6 +39,7 @@ type OptionsOfJSONResponseBody = Merge<Options, {isStream?: false; resolveBodyOn
 type OptionsOfBufferResponseBody = Merge<Options, {isStream?: false; resolveBodyOnly?: false; responseType: 'buffer'}>;
 type ResponseBodyOnly = {resolveBodyOnly: true};
 
+// Can be used to match methods explicitly or cases like parameters extraction e.g `Parameters<GotRequestMethod>`
 export interface GotRequestMethod {
 	// `asPromise` usage
 	<T = string>(url: string | OptionsOfDefaultResponseBody, options?: OptionsOfDefaultResponseBody): CancelableRequest<Response<T>>;

--- a/source/index.ts
+++ b/source/index.ts
@@ -85,6 +85,7 @@ export {
 	Got,
 	GotStream,
 	ReturnStream,
+	GotFunctions,
 	GotReturn
 } from './create';
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -85,7 +85,7 @@ export {
 	Got,
 	GotStream,
 	ReturnStream,
-	GotFunctions,
+	GotRequestMethod,
 	GotReturn
 } from './create';
 


### PR DESCRIPTION
At this moment to be able to correctly define `got` methods as dependencies we need to import the module into type declaration files
```typescript
import got from 'got'

interface Dependencies {
  readonly get: typeof got.get
}
```

with introduced changes we can simply do as so:
```typescript
import { GotFunctions } from 'got'

interface Dependencies {
  readonly get: GotFunctions
}
```

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.

