### PR TITLE
Reject normalization errors with CancelableRequest

### DIFF
--- a/source/as-promise.ts
+++ b/source/as-promise.ts
@@ -23,6 +23,18 @@ const parseBody = (body: Buffer, responseType: NormalizedOptions['responseType']
 	throw new TypeError(`Unknown body type '${responseType as string}'`);
 };
 
+export function createRejection(error: Error): CancelableRequest<never> {
+	const promise = Promise.reject(error) as CancelableRequest<never>;
+	const returnPromise = (): CancelableRequest<never> => promise;
+
+	promise.json = returnPromise;
+	promise.text = returnPromise;
+	promise.buffer = returnPromise;
+	promise.on = returnPromise;
+
+	return promise;
+}
+
 export default function asPromise<T>(options: NormalizedOptions): CancelableRequest<T> {
 	const proxy = new EventEmitter();
 	let body: Buffer;

--- a/source/create.ts
+++ b/source/create.ts
@@ -1,5 +1,5 @@
 import {Merge} from 'type-fest';
-import asPromise from './as-promise';
+import asPromise, {createRejection} from './as-promise';
 import asStream, {ProxyStream} from './as-stream';
 import * as errors from './errors';
 import {normalizeArguments, mergeOptions} from './normalize-arguments';
@@ -126,7 +126,7 @@ const create = (defaults: Defaults): Got => {
 				throw error;
 			} else {
 				// @ts-ignore It's an Error not a response, but TS thinks it's calling .resolve
-				return Promise.reject(error);
+				return createRejection(error);
 			}
 		}
 		/* eslint-enable @typescript-eslint/return-await */

--- a/test/error.ts
+++ b/test/error.ts
@@ -194,7 +194,8 @@ test('errors are thrown directly when options.stream is true', t => {
 });
 
 test('normalization errors using convenience methods', async t => {
-	await t.throwsAsync(got('undefined/https://example.com').json());
+	const url = 'undefined/https://example.com';
+	await t.throwsAsync(got(url).json().text().buffer(), `Invalid URL: ${url}`);
 });
 
 // Fails randomly on Node 10:

--- a/test/error.ts
+++ b/test/error.ts
@@ -193,6 +193,12 @@ test('errors are thrown directly when options.stream is true', t => {
 	});
 });
 
+test('normalization errors using convenience methods', async t => {
+	const error = await t.throwsAsync(got('undefined/https://example.com'));
+
+	t.true(error.message.includes('Invalid URL'));
+});
+
 // Fails randomly on Node 10:
 // Blocked by https://github.com/istanbuljs/nyc/issues/619
 // eslint-disable-next-line ava/no-skip-test

--- a/test/error.ts
+++ b/test/error.ts
@@ -194,9 +194,7 @@ test('errors are thrown directly when options.stream is true', t => {
 });
 
 test('normalization errors using convenience methods', async t => {
-	const error = await t.throwsAsync(got('undefined/https://example.com'));
-
-	t.true(error.message.includes('Invalid URL'));
+	await t.throwsAsync(got('undefined/https://example.com').json());
 });
 
 // Fails randomly on Node 10:


### PR DESCRIPTION
Closes #1025

In the event of an error being thrown during argument normalization a normal promise was being returned which prevented users from calling any of the CancelableRequest convenience methods. This changes makes it so a rejected CancelableRequest is returned instead.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
