### PR TITLE
Allow request body to be sent with a DELETE request

### DIFF
--- a/source/normalize-arguments.ts
+++ b/source/normalize-arguments.ts
@@ -404,7 +404,7 @@ export const normalizeRequestArguments = async (options: NormalizedOptions): Pro
 	// body.
 	if (is.undefined(headers['content-length']) && is.undefined(headers['transfer-encoding'])) {
 		if (
-			(options.method === 'POST' || options.method === 'PUT' || options.method === 'PATCH') &&
+			(options.method === 'POST' || options.method === 'PUT' || options.method === 'PATCH' || options.method === 'DELETE') &&
 			!is.undefined(uploadBodySize)
 		) {
 			// @ts-ignore We assign if it is undefined, so this IS correct

--- a/test/post.ts
+++ b/test/post.ts
@@ -262,12 +262,8 @@ test('the `form` payload is not touched', withServer, async (t, server, got) => 
 	});
 });
 
-test.failing('DELETE method sends plain objects as JSON', withServer, async (t, server, got) => {
-	server.delete('/', (request, response) => {
-		// Not using streams here to avoid this unhandled rejection:
-		// Error [ERR_STREAM_PREMATURE_CLOSE]: Premature close
-		response.json(request.body);
-	});
+test('DELETE method sends plain objects as JSON', withServer, async (t, server, got) => {
+	server.delete('/', defaultEndpoint);
 
 	const {body} = await got.delete({
 		json: {such: 'wow'},


### PR DESCRIPTION
Fixes #1028.

Adds DELETE to the methods that apply a `content-length` header when a request body is given, to allow the request body to actually be sent.

Fixes the expected failing test added in #1031 (by using streams directly instead of requiring the body to be parsed) and removes the `failing` modifier.

Thanks to @jrnelson90 for finding the solution!