### PR TITLE
Replace `readonly []` with `ReadonlyArray` for pre-3.4 TS versions

### DIFF
--- a/source/create.ts
+++ b/source/create.ts
@@ -77,7 +77,7 @@ export interface GotStream extends Record<HTTPAlias, ReturnStream> {
 	(url: URLOrOptions, options?: Options): ProxyStream;
 }
 
-const aliases: readonly HTTPAlias[] = [
+const aliases: ReadonlyArray<HTTPAlias> = [
 	'get',
 	'post',
 	'put',

--- a/source/known-hook-events.ts
+++ b/source/known-hook-events.ts
@@ -105,7 +105,7 @@ export interface Hooks {
 
 export type HookEvent = keyof Hooks;
 
-const knownHookEvents: readonly HookEvent[] = [
+const knownHookEvents: ReadonlyArray<HookEvent> = [
 	'beforeError',
 	'init',
 	'beforeRequest',


### PR DESCRIPTION
Since `readonly []` syntax was [released in TypeScript 3.4](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#improvements-for-readonlyarray-and-readonly-tuples), consumers of this library that have an earlier TS compiler are unable to compile. The functionality is the same, but this syntax is at least backwards compatible.