### PR TITLE
Include invalid JSON body in `ParseError`s

### DIFF
--- a/source/as-promise.ts
+++ b/source/as-promise.ts
@@ -83,14 +83,14 @@ export default function asPromise<T>(options: NormalizedOptions): CancelableRequ
 			try {
 				response.body = parseBody(body, options.responseType, options.encoding);
 			} catch (error) {
+				// Fall back to `utf8`
+				response.body = body.toString();
+
 				if (isOk()) {
 					const parseError = new ParseError(error, response, options);
 					emitError(parseError);
 					return;
 				}
-
-				// Fall back to `utf8`
-				response.body = body.toString();
 			}
 
 			try {

--- a/test/response-parse.ts
+++ b/test/response-parse.ts
@@ -128,6 +128,7 @@ test('parse errors have `response` property', withServer, async (t, server, got)
 	const error = await t.throwsAsync<ParseError>(got({responseType: 'json'}), {instanceOf: ParseError});
 
 	t.is(error.response.statusCode, 200);
+	t.is(error.response.body, '/');
 });
 
 test('sets correct headers', withServer, async (t, server, got) => {


### PR DESCRIPTION
The docs state that a `ParseError` includes a `response` as does `HTTPError`, for example.

A `HTTPError` includes `response.body` and PR makes `ParseError` behave similarly by including the invalid "JSON" in `response.body`. This is useful for error handling and debugging than the the `SyntaxError: Unexpected token / in JSON at position 0` in the actual error message.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
