### PR TITLE
Use full URL for teaser image so it shows up on npm

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 <div align="center">
 	<br>
 	<br>
-	<img width="360" src="media/logo.svg" alt="Got">
+	<img width="360" src="https://raw.githubusercontent.com/sindresorhus/got/master/media/logo.svg" alt="Got">
 	<br>
 	<br>
 	<br>


### PR DESCRIPTION
Currently the [npm page](https://www.npmjs.com/package/got) looks like this:
![image](https://user-images.githubusercontent.com/2564094/73495485-7c0cd980-436b-11ea-9480-84bb88cdfb20.png)


#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] *N/A* I have included some tests.
- [ ] *N/A* If it's a new feature, I have included documentation updates.
