### PR TITLE
Add fair warning about rfc7231 support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ For browser usage, we recommend [Ky](https://github.com/sindresorhus/ky) by the 
 
 ## Highlights
 
+- [Partial support of the RFC] (#partial)
 - [Promise API](#api)
 - [Stream API](#streams)
 - [Pagination API (experimental)](#pagination)
@@ -69,6 +70,9 @@ const got = require('got');
 	}
 })();
 ```
+###### Partial support of the RFC
+
+GOT, support *most of the rfc7231* but the goal of GOT is not to fully support the RFC and some of the HTTP features won't be developped. If you need a full support of the Http protocol GOT is not the appropriate library.
 
 ###### Streams
 


### PR DESCRIPTION
I think many people assume GOT support or will support 100% of the rfc and anything that is not compliant is considered as a bug, with different priority of development but a bug.
We should add a warning so developers can check if this library feed their needs or if they should use a different one.

Close #966
