### PR TITLE
Add option `allowGetBody` to allow GET requests with payload

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -188,7 +188,7 @@ Type: `string | Buffer | stream.Readable` or [`form-data` instance](https://gith
 
 **Note #2:** If you provide this option, `got.stream()` will be read-only.
 
-**Note #3:** If you provide a payload with the `GET` or `HEAD` method, it will throw a `TypeError`.
+**Note #3:** If you provide a payload with the `HEAD` method, it will throw a `TypeError`. If you provide a a payload with a 'GET' method, without specifying `allowGetBody` as true, it will also throw a `TypeError`. See [here](https://github.com/dopecodez/got#allowgetbody) for more information regarding this.
 
 The `content-length` header will be automatically set if `body` is a `string` / `Buffer` / `fs.createReadStream` instance / [`form-data` instance](https://github.com/form-data/form-data), and `content-length` and `transfer-encoding` are not manually set in `options.headers`.
 
@@ -415,7 +415,7 @@ By default, redirects will use [method rewriting](https://tools.ietf.org/html/rf
 Type: `boolean`\
 Default: `false`
 
-By default, GET methods are not allowed to have a body. This option is to force GET requests to have a body. Please note that this is an [anti-pattern](https://en.wikipedia.org/wiki/Anti-pattern) and NOT RECOMMENDED. In many servers, the body in a GET request could be ignored or even lead to errors. Please read the [RF 7321](https://tools.ietf.org/html/rfc7231#section-4.3.1) docs for more information. Please note this option is only enabled for interacting with non-compliant servers when you have no other choice.
+By default, GET methods are not allowed to have a payload. This option is to force GET requests to have a payload. Please note that this is an [anti-pattern](https://en.wikipedia.org/wiki/Anti-pattern) and NOT RECOMMENDED. In many servers, the payload in a GET request could be ignored or even lead to errors. Please read the [RF 7321](https://tools.ietf.org/html/rfc7231#section-4.3.1) docs for more information. Please note this option is only enabled for interacting with non-compliant servers when you have no other choice.
 
 **Note:**  **Not Reccomended**
 

--- a/readme.md
+++ b/readme.md
@@ -188,7 +188,7 @@ Type: `string | Buffer | stream.Readable` or [`form-data` instance](https://gith
 
 **Note #2:** If you provide this option, `got.stream()` will be read-only.
 
-**Note #3:** If you provide a payload with the `HEAD` method, it will throw a `TypeError`. If you provide a a payload with a 'GET' method, without specifying `allowGetBody` as true, it will also throw a `TypeError`. See [here](https://github.com/dopecodez/got#allowgetbody) for more information regarding this.
+**Note #3:** If you provide a payload with the `HEAD` method, it will throw a `TypeError`. If you provide a a payload with a `GET` method, without specifying `allowGetBody` as true, it will also throw a `TypeError`. See [here](https://github.com/sindresorhus/got#allowgetbody) for more information regarding this.
 
 The `content-length` header will be automatically set if `body` is a `string` / `Buffer` / `fs.createReadStream` instance / [`form-data` instance](https://github.com/form-data/form-data), and `content-length` and `transfer-encoding` are not manually set in `options.headers`.
 

--- a/readme.md
+++ b/readme.md
@@ -410,6 +410,15 @@ Default: `true`
 
 By default, redirects will use [method rewriting](https://tools.ietf.org/html/rfc7231#section-6.4). For example, when sending a POST request and receiving a `302`, it will resend the body to the new location using the same HTTP method (`POST` in this case).
 
+###### allowGetBody
+
+Type: `boolean`\
+Default: `false`
+
+By default, GET methods are not allowed to have a body. This option is to force GET requests to have a body. Please note that this is an [anti-pattern](https://en.wikipedia.org/wiki/Anti-pattern) and NOT RECOMMENDED. In many servers, the body in a GET request could be ignored or even lead to errors. Please note this option is only enabled for interacting with non-compliant servers when you have no other choice.
+
+**Note:** Not Reccomended
+
 ###### maxRedirects
 
 Type: `number`\

--- a/readme.md
+++ b/readme.md
@@ -188,7 +188,7 @@ Type: `string | Buffer | stream.Readable` or [`form-data` instance](https://gith
 
 **Note #2:** If you provide this option, `got.stream()` will be read-only.
 
-**Note #3:** If you provide a payload with the `HEAD` method, it will throw a `TypeError`. If you provide a a payload with a `GET` method, without specifying `allowGetBody` as true, it will also throw a `TypeError`. See [here](https://github.com/sindresorhus/got#allowgetbody) for more information regarding this.
+**Note #3:** If you provide a payload with the `GET` or `HEAD` method, it will throw a `TypeError` unless the method is `GET` and the `allowGetBody` option is set to `true`.
 
 The `content-length` header will be automatically set if `body` is a `string` / `Buffer` / `fs.createReadStream` instance / [`form-data` instance](https://github.com/form-data/form-data), and `content-length` and `transfer-encoding` are not manually set in `options.headers`.
 

--- a/readme.md
+++ b/readme.md
@@ -415,9 +415,9 @@ By default, redirects will use [method rewriting](https://tools.ietf.org/html/rf
 Type: `boolean`\
 Default: `false`
 
-By default, GET methods are not allowed to have a body. This option is to force GET requests to have a body. Please note that this is an [anti-pattern](https://en.wikipedia.org/wiki/Anti-pattern) and NOT RECOMMENDED. In many servers, the body in a GET request could be ignored or even lead to errors. Please note this option is only enabled for interacting with non-compliant servers when you have no other choice.
+By default, GET methods are not allowed to have a body. This option is to force GET requests to have a body. Please note that this is an [anti-pattern](https://en.wikipedia.org/wiki/Anti-pattern) and NOT RECOMMENDED. In many servers, the body in a GET request could be ignored or even lead to errors. Please read the [RF 7321](https://tools.ietf.org/html/rfc7231#section-4.3.1) docs for more information. Please note this option is only enabled for interacting with non-compliant servers when you have no other choice.
 
-**Note:** Not Reccomended
+**Note:**  **Not Reccomended**
 
 ###### maxRedirects
 

--- a/readme.md
+++ b/readme.md
@@ -415,8 +415,9 @@ By default, redirects will use [method rewriting](https://tools.ietf.org/html/rf
 Type: `boolean`\
 Default: `false`
 
-By default, GET methods are not allowed to have a payload. This option is to allow GET requests to have a payload. The [RFC 7321](https://tools.ietf.org/html/rfc7231#section-4.3.1) doesn't specify any particular behavior for the GET method having a payload, therefore it's considered an [anti-pattern](https://en.wikipedia.org/wiki/Anti-pattern) and NOT RECOMMENDED. Please note this option is only enabled for interacting with non-compliant servers when you have no other choice.
+**Note:** The [RFC 7321](https://tools.ietf.org/html/rfc7231#section-4.3.1) doesn't specify any particular behavior for the GET method having a payload, therefore **it's considered an [anti-pattern](https://en.wikipedia.org/wiki/Anti-pattern)**.
 
+Set this to `true` to allow sending body for the `GET` method. However, the [HTTP/2 specification](https://tools.ietf.org/html/rfc7540#section-8.1.3) says that `An HTTP GET request includes request header fields and no payload body`, therefore when using the HTTP/2 protocol this option will have no effect. This option is only meant to interact with non-compliant servers when you have no other choice.
 
 ###### maxRedirects
 

--- a/readme.md
+++ b/readme.md
@@ -417,7 +417,6 @@ Default: `false`
 
 By default, GET methods are not allowed to have a payload. This option is to force GET requests to have a payload. Please note that this is an [anti-pattern](https://en.wikipedia.org/wiki/Anti-pattern) and NOT RECOMMENDED. In many servers, the payload in a GET request could be ignored or even lead to errors. Please read the [RF 7321](https://tools.ietf.org/html/rfc7231#section-4.3.1) docs for more information. Please note this option is only enabled for interacting with non-compliant servers when you have no other choice.
 
-**Note:**  **Not Reccomended**
 
 ###### maxRedirects
 

--- a/readme.md
+++ b/readme.md
@@ -415,7 +415,7 @@ By default, redirects will use [method rewriting](https://tools.ietf.org/html/rf
 Type: `boolean`\
 Default: `false`
 
-By default, GET methods are not allowed to have a payload. This option is to force GET requests to have a payload. Please note that this is an [anti-pattern](https://en.wikipedia.org/wiki/Anti-pattern) and NOT RECOMMENDED. In many servers, the payload in a GET request could be ignored or even lead to errors. Please read the [RF 7321](https://tools.ietf.org/html/rfc7231#section-4.3.1) docs for more information. Please note this option is only enabled for interacting with non-compliant servers when you have no other choice.
+By default, GET methods are not allowed to have a payload. This option is to allow GET requests to have a payload. The [RFC 7321](https://tools.ietf.org/html/rfc7231#section-4.3.1) doesn't specify any particular behavior for the GET method having a payload, therefore it's considered an [anti-pattern](https://en.wikipedia.org/wiki/Anti-pattern) and NOT RECOMMENDED. Please note this option is only enabled for interacting with non-compliant servers when you have no other choice.
 
 
 ###### maxRedirects

--- a/source/as-stream.ts
+++ b/source/as-stream.ts
@@ -23,7 +23,7 @@ export default function asStream<T>(options: NormalizedOptions): ProxyStream<T> 
 			proxy.destroy();
 			throw new Error('Got\'s stream is not writable when the `body`, `json` or `form` option is used');
 		};
-	} else if (options.method === 'POST' || options.method === 'PUT' || options.method === 'PATCH') {
+	} else if (options.method === 'POST' || options.method === 'PUT' || options.method === 'PATCH' || (options.allowGetBody && options.method === 'GET')) {
 		options.body = input;
 	} else {
 		proxy.write = () => {

--- a/source/index.ts
+++ b/source/index.ts
@@ -64,6 +64,7 @@ const defaults: Defaults = {
 		maxRedirects: 10,
 		prefixUrl: '',
 		methodRewriting: true,
+		allowGetBody: false,
 		ignoreInvalidCookies: false,
 		context: {},
 		_pagination: {

--- a/source/normalize-arguments.ts
+++ b/source/normalize-arguments.ts
@@ -231,6 +231,7 @@ export const preNormalizeArguments = (options: Options, defaults?: NormalizedOpt
 	options.dnsCache = options.dnsCache ?? false;
 	options.useElectronNet = Boolean(options.useElectronNet);
 	options.methodRewriting = Boolean(options.methodRewriting);
+	options.allowGetBody = Boolean(options.allowGetBody);
 	options.context = options.context ?? {};
 
 	return options as NormalizedOptions;
@@ -362,7 +363,8 @@ export const normalizeArguments = (url: URLOrOptions, options?: Options, default
 	return normalizedOptions;
 };
 
-const withoutBody: ReadonlySet<string> = new Set(['GET', 'HEAD']);
+const withoutBody: ReadonlySet<string> = new Set(['HEAD']);
+const withoutBodyUnlessSpecified = 'GET';
 
 export type NormalizedRequestArguments = Merge<https.RequestOptions, {
 	body?: stream.Readable;
@@ -384,6 +386,10 @@ export const normalizeRequestArguments = async (options: NormalizedOptions): Pro
 		const isBody = !is.undefined(options.body);
 		if ((isBody || isForm || isJson) && withoutBody.has(options.method)) {
 			throw new TypeError(`The \`${options.method}\` method cannot be used with a body`);
+		}
+
+		if (!options.allowGetBody && (isBody || isForm || isJson) && withoutBodyUnlessSpecified === options.method) {
+			throw new TypeError(`The \`${options.method}\` method cannot be used with a body unless \`allowGetBody\` option is set to true(Not reccomended)`);
 		}
 
 		if ([isBody, isForm, isJson].filter(isTrue => isTrue).length > 1) {
@@ -441,7 +447,7 @@ export const normalizeRequestArguments = async (options: NormalizedOptions): Pro
 	// body.
 	if (is.undefined(headers['content-length']) && is.undefined(headers['transfer-encoding'])) {
 		if (
-			(options.method === 'POST' || options.method === 'PUT' || options.method === 'PATCH' || options.method === 'DELETE') &&
+			(options.method === 'POST' || options.method === 'PUT' || options.method === 'PATCH' || options.method === 'DELETE' || (options.allowGetBody && options.method === 'GET')) &&
 			!is.undefined(uploadBodySize)
 		) {
 			// @ts-ignore We assign if it is undefined, so this IS correct

--- a/source/normalize-arguments.ts
+++ b/source/normalize-arguments.ts
@@ -389,7 +389,7 @@ export const normalizeRequestArguments = async (options: NormalizedOptions): Pro
 		}
 
 		if (!options.allowGetBody && (isBody || isForm || isJson) && withoutBodyUnlessSpecified === options.method) {
-			throw new TypeError(`The \`${options.method}\` method cannot be used with a body unless \`allowGetBody\` option is set to true(Not reccomended)`);
+			throw new TypeError(`The \`${options.method}\` method cannot be used with a body`);
 		}
 
 		if ([isBody, isForm, isJson].filter(isTrue => isTrue).length > 1) {

--- a/source/types.ts
+++ b/source/types.ts
@@ -199,6 +199,7 @@ export interface GotOptions extends PaginationOptions<unknown> {
 	context?: {[key: string]: any};
 	maxRedirects?: number;
 	lookup?: CacheableLookup['lookup'];
+	allowGetBody?: boolean;
 	methodRewriting?: boolean;
 }
 
@@ -232,6 +233,7 @@ export interface NormalizedOptions extends Options {
 	followRedirect: boolean;
 	useElectronNet: boolean;
 	methodRewriting: boolean;
+	allowGetBody: boolean;
 	context: {[key: string]: any};
 
 	// UNIX socket support

--- a/test/arguments.ts
+++ b/test/arguments.ts
@@ -158,8 +158,15 @@ test('throws when passing body with a non payload method', async t => {
 	// @ts-ignore Error tests
 	await t.throwsAsync(got('https://example.com', {body: 'asdf'}), {
 		instanceOf: TypeError,
-		message: 'The `GET` method cannot be used with a body'
+		message: 'The `GET` method cannot be used with a body unless `allowGetBody` option is set to true(Not reccomended)'
 	});
+});
+
+test('passes when passing option allowGetBody with a GET method', withServer, async (t, server, got) => {
+	server.get('/test', echoUrl);
+
+	const url = new URL(`${server.url}/test`);
+	await t.notThrowsAsync(got(url, {body: 'asdf', allowGetBody: true}));
 });
 
 test('WHATWG URL support', withServer, async (t, server, got) => {

--- a/test/arguments.ts
+++ b/test/arguments.ts
@@ -158,7 +158,7 @@ test('throws when passing body with a non payload method', async t => {
 	// @ts-ignore Error tests
 	await t.throwsAsync(got('https://example.com', {body: 'asdf'}), {
 		instanceOf: TypeError,
-		message: 'The `GET` method cannot be used with a body unless `allowGetBody` option is set to true(Not reccomended)'
+		message: 'The `GET` method cannot be used with a body'
 	});
 });
 

--- a/test/arguments.ts
+++ b/test/arguments.ts
@@ -162,7 +162,7 @@ test('throws when passing body with a non payload method', async t => {
 	});
 });
 
-test('passes when passing option allowGetBody with a GET method', withServer, async (t, server, got) => {
+test('`allowGetBody` option', withServer, async (t, server, got) => {
 	server.get('/test', echoUrl);
 
 	const url = new URL(`${server.url}/test`);

--- a/test/post.ts
+++ b/test/post.ts
@@ -20,7 +20,7 @@ const echoHeaders: Handler = (request, response) => {
 	response.end(JSON.stringify(request.headers));
 };
 
-test('GET cannot have body without option allowGetBody', withServer, async (t, server, got) => {
+test('GET cannot have body without the `allowGetBody` option', withServer, async (t, server, got) => {
 	server.post('/', defaultEndpoint);
 
 	await t.throwsAsync(got.get({body: 'hi'}), {message: 'The `GET` method cannot be used with a body unless `allowGetBody` option is set to true(Not reccomended)'});

--- a/test/post.ts
+++ b/test/post.ts
@@ -23,7 +23,7 @@ const echoHeaders: Handler = (request, response) => {
 test('GET cannot have body without the `allowGetBody` option', withServer, async (t, server, got) => {
 	server.post('/', defaultEndpoint);
 
-	await t.throwsAsync(got.get({body: 'hi'}), {message: 'The `GET` method cannot be used with a body unless `allowGetBody` option is set to true(Not reccomended)'});
+	await t.throwsAsync(got.get({body: 'hi'}), {message: 'The `GET` method cannot be used with a body'});
 });
 
 test('GET can have body with option allowGetBody', withServer, async (t, server, got) => {

--- a/test/post.ts
+++ b/test/post.ts
@@ -20,10 +20,16 @@ const echoHeaders: Handler = (request, response) => {
 	response.end(JSON.stringify(request.headers));
 };
 
-test('GET cannot have body', withServer, async (t, server, got) => {
+test('GET cannot have body without option allowGetBody', withServer, async (t, server, got) => {
 	server.post('/', defaultEndpoint);
 
-	await t.throwsAsync(got.get({body: 'hi'}), {message: 'The `GET` method cannot be used with a body'});
+	await t.throwsAsync(got.get({body: 'hi'}), {message: 'The `GET` method cannot be used with a body unless `allowGetBody` option is set to true(Not reccomended)'});
+});
+
+test('GET can have body with option allowGetBody', withServer, async (t, server, got) => {
+	server.get('/', defaultEndpoint);
+
+	await t.notThrowsAsync(got.get({body: 'hi', allowGetBody: true}));
 });
 
 test('invalid body', async t => {


### PR DESCRIPTION
#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] If it's a new feature, I have included documentation updates.

Fix for #1074 