### PR TITLE
Fix `got.paginate(...)` typings

### DIFF
--- a/source/create.ts
+++ b/source/create.ts
@@ -62,10 +62,11 @@ export interface GotRequestMethod {
 }
 
 export type GotPaginateOptions<T> = Except<Options, keyof PaginationOptions<unknown>> & PaginationOptions<T>;
+export type URLOrGotPaginateOptions<T> = string | GotPaginateOptions<T>;
 
 export interface GotPaginate {
-	<T>(url: string | GotPaginateOptions<T>, options?: GotPaginateOptions<T>): AsyncIterableIterator<T>;
-	all<T>(url: string | GotPaginateOptions<T>, options?: GotPaginateOptions<T>): Promise<T[]>;
+	<T>(url: URLOrGotPaginateOptions<T>, options?: GotPaginateOptions<T>): AsyncIterableIterator<T>;
+	all<T>(url: URLOrGotPaginateOptions<T>, options?: GotPaginateOptions<T>): Promise<T[]>;
 }
 
 export interface Got extends Record<HTTPAlias, GotRequestMethod>, GotRequestMethod {
@@ -200,7 +201,7 @@ const create = (defaults: Defaults): Got => {
 	}
 
 	// @ts-ignore The missing property is added below
-	got.paginate = async function * <T>(url: string | GotPaginateOptions<T>, options?: GotPaginateOptions<T>) {
+	got.paginate = async function * <T>(url: URLOrGotPaginateOptions<T>, options?: GotPaginateOptions<T>) {
 		let normalizedOptions = normalizeArguments(url as URLOrOptions, options as Options, defaults);
 
 		const pagination = normalizedOptions._pagination!;
@@ -247,7 +248,7 @@ const create = (defaults: Defaults): Got => {
 		}
 	};
 
-	got.paginate.all = async <T>(url: string | GotPaginateOptions<T>, options?: GotPaginateOptions<T>) => {
+	got.paginate.all = async <T>(url: URLOrGotPaginateOptions<T>, options?: GotPaginateOptions<T>) => {
 		const results: T[] = [];
 
 		for await (const item of got.paginate<T>(url, options)) {

--- a/source/create.ts
+++ b/source/create.ts
@@ -1,4 +1,4 @@
-import {Merge} from 'type-fest';
+import {Merge, Except} from 'type-fest';
 import is from '@sindresorhus/is';
 import asPromise, {createRejection} from './as-promise';
 import asStream, {ProxyStream} from './as-stream';
@@ -61,7 +61,7 @@ export interface GotRequestMethod {
 	<T>(url: string | Merge<Options, {isStream: true}>, options?: Merge<Options, {isStream: true}>): ProxyStream<T>;
 }
 
-export type GotPaginateOptions<T> = Omit<Options, keyof PaginationOptions<unknown>> & PaginationOptions<T>;
+export type GotPaginateOptions<T> = Except<Options, keyof PaginationOptions<unknown>> & PaginationOptions<T>;
 
 export interface GotPaginate {
 	<T>(url: string | GotPaginateOptions<T>, options?: GotPaginateOptions<T>): AsyncIterableIterator<T>;

--- a/source/create.ts
+++ b/source/create.ts
@@ -1,4 +1,4 @@
-import {Merge} from 'type-fest';
+import {Merge, Except} from 'type-fest';
 import is from '@sindresorhus/is';
 import asPromise, {createRejection} from './as-promise';
 import asStream, {ProxyStream} from './as-stream';
@@ -61,9 +61,11 @@ export interface GotRequestMethod {
 	<T>(url: string | Merge<Options, {isStream: true}>, options?: Merge<Options, {isStream: true}>): ProxyStream<T>;
 }
 
+export type GotPaginateOptions<T> = Except<Options, keyof PaginationOptions<unknown>> & PaginationOptions<T>
+
 export interface GotPaginate {
-	<T>(url: URLOrOptions & PaginationOptions<T>, options?: Options & PaginationOptions<T>): AsyncIterableIterator<T>;
-	all<T>(url: URLOrOptions & PaginationOptions<T>, options?: Options & PaginationOptions<T>): Promise<T[]>;
+	<T>(url: string | GotPaginateOptions<T>, options?: GotPaginateOptions<T>): AsyncIterableIterator<T>;
+	all<T>(url: string | GotPaginateOptions<T>, options?: GotPaginateOptions<T>): Promise<T[]>;
 }
 
 export interface Got extends Record<HTTPAlias, GotRequestMethod>, GotRequestMethod {
@@ -198,8 +200,8 @@ const create = (defaults: Defaults): Got => {
 	}
 
 	// @ts-ignore The missing property is added below
-	got.paginate = async function * <T>(url: URLOrOptions, options?: Options) {
-		let normalizedOptions = normalizeArguments(url, options, defaults);
+	got.paginate = async function * <T>(url: string | GotPaginateOptions<T>, options?: GotPaginateOptions<T>) {
+		let normalizedOptions = normalizeArguments(url as URLOrOptions, options as Options, defaults);
 
 		const pagination = normalizedOptions._pagination!;
 
@@ -245,11 +247,11 @@ const create = (defaults: Defaults): Got => {
 		}
 	};
 
-	got.paginate.all = async <T>(url: URLOrOptions, options?: Options) => {
+	got.paginate.all = async <T>(url: string | GotPaginateOptions<T>, options?: GotPaginateOptions<T>) => {
 		const results: T[] = [];
 
-		for await (const item of got.paginate<unknown>(url, options)) {
-			results.push(item as T);
+		for await (const item of got.paginate<T>(url, options)) {
+			results.push(item);
 		}
 
 		return results;

--- a/source/create.ts
+++ b/source/create.ts
@@ -61,7 +61,7 @@ export interface GotRequestMethod {
 	<T>(url: string | Merge<Options, {isStream: true}>, options?: Merge<Options, {isStream: true}>): ProxyStream<T>;
 }
 
-export type GotPaginateOptions<T> = Except<Options, keyof PaginationOptions<unknown>> & PaginationOptions<T>
+export type GotPaginateOptions<T> = Except<Options, keyof PaginationOptions<unknown>> & PaginationOptions<T>;
 
 export interface GotPaginate {
 	<T>(url: string | GotPaginateOptions<T>, options?: GotPaginateOptions<T>): AsyncIterableIterator<T>;

--- a/source/create.ts
+++ b/source/create.ts
@@ -1,4 +1,4 @@
-import {Merge, Except} from 'type-fest';
+import {Merge} from 'type-fest';
 import is from '@sindresorhus/is';
 import asPromise, {createRejection} from './as-promise';
 import asStream, {ProxyStream} from './as-stream';
@@ -61,7 +61,7 @@ export interface GotRequestMethod {
 	<T>(url: string | Merge<Options, {isStream: true}>, options?: Merge<Options, {isStream: true}>): ProxyStream<T>;
 }
 
-export type GotPaginateOptions<T> = Except<Options, keyof PaginationOptions<unknown>> & PaginationOptions<T>;
+export type GotPaginateOptions<T> = Omit<Options, keyof PaginationOptions<unknown>> & PaginationOptions<T>;
 
 export interface GotPaginate {
 	<T>(url: string | GotPaginateOptions<T>, options?: GotPaginateOptions<T>): AsyncIterableIterator<T>;

--- a/test/pagination.ts
+++ b/test/pagination.ts
@@ -42,7 +42,7 @@ test('the link header has no next value', withServer, async (t, server, got) => 
 test('retrieves all elements', withServer, async (t, server, got) => {
 	attachHandler(server, 2);
 
-	const result = await got.paginate.all('');
+	const result = await got.paginate.all<number>('');
 
 	t.deepEqual(result, [1, 2]);
 });
@@ -50,7 +50,7 @@ test('retrieves all elements', withServer, async (t, server, got) => {
 test('points to defaults when extending Got without custom `_pagination`', withServer, async (t, server, got) => {
 	attachHandler(server, 2);
 
-	const result = await got.extend().paginate.all('');
+	const result = await got.extend().paginate.all<number>('');
 
 	t.deepEqual(result, [1, 2]);
 });
@@ -62,7 +62,7 @@ test('pagination options can be extended', withServer, async (t, server, got) =>
 		_pagination: {
 			shouldContinue: () => false
 		}
-	}).paginate.all('');
+	}).paginate.all<number>('');
 
 	t.deepEqual(result, []);
 });
@@ -70,7 +70,7 @@ test('pagination options can be extended', withServer, async (t, server, got) =>
 test('filters elements', withServer, async (t, server, got) => {
 	attachHandler(server, 3);
 
-	const result = await got.paginate.all({
+	const result = await got.paginate.all<number>({
 		_pagination: {
 			filter: element => element !== 2
 		}
@@ -82,7 +82,7 @@ test('filters elements', withServer, async (t, server, got) => {
 test('parses elements', withServer, async (t, server, got) => {
 	attachHandler(server, 100);
 
-	const result = await got.paginate.all('?page=100', {
+	const result = await got.paginate.all<number>('?page=100', {
 		_pagination: {
 			transform: (response: Response) => [(response as Response<string>).body.length]
 		}
@@ -94,7 +94,7 @@ test('parses elements', withServer, async (t, server, got) => {
 test('parses elements - async function', withServer, async (t, server, got) => {
 	attachHandler(server, 100);
 
-	const result = await got.paginate.all('?page=100', {
+	const result = await got.paginate.all<number>('?page=100', {
 		_pagination: {
 			transform: async (response: Response) => [(response as Response<string>).body.length]
 		}
@@ -106,7 +106,7 @@ test('parses elements - async function', withServer, async (t, server, got) => {
 test('custom paginate function', withServer, async (t, server, got) => {
 	attachHandler(server, 3);
 
-	const result = await got.paginate.all({
+	const result = await got.paginate.all<number>({
 		_pagination: {
 			paginate: response => {
 				if (response.request.options.path === '/?page=3') {
@@ -142,9 +142,9 @@ test('`shouldContinue` works', withServer, async (t, server, got) => {
 		}
 	};
 
-	const results = [];
+	const results: number[] = [];
 
-	for await (const item of got.paginate(options)) {
+	for await (const item of got.paginate<number>(options)) {
 		results.push(item);
 	}
 
@@ -160,9 +160,9 @@ test('`countLimit` works', withServer, async (t, server, got) => {
 		}
 	};
 
-	const results = [];
+	const results: number[] = [];
 
-	for await (const item of got.paginate(options)) {
+	for await (const item of got.paginate<number>(options)) {
 		results.push(item);
 	}
 


### PR DESCRIPTION
Currently, if you use `got.paginate` or `got.paginate.all` you cannot properly use the pagination options because `GotOptions` extend `PaginationOptions<unknown>`: https://github.com/sindresorhus/got/blob/526b4bb03eed5196a3c6375beeb7699e8f512d4f/source/types.ts#L173

This would result in unknown types:
```ts
got.paginate.all<Item>('/test', { 
  _pagination: {
    // item is of type unknown instead of Item
    filter: (item) => true
  }
})
```

#### Checklist

- [X] I have read the documentation.
- [X] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates.
