### PR TITLE
Pass `allItems` and `currentItems` to `_pagination.paginate()`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -689,7 +689,7 @@ The function takes three arguments:
 
 It should return an object representing Got options pointing to the next page. If there are no more pages, `false` should be returned.
 
-For example, if you want to stop when the response contains less items than expected, you should use:
+For example, if you want to stop when the response contains less items than expected, you can use something like this:
 
 ```js
 (response, allItems, currentItems) => {

--- a/readme.md
+++ b/readme.md
@@ -692,17 +692,33 @@ It should return an object representing Got options pointing to the next page. I
 For example, if you want to stop when the response contains less items than expected, you can use something like this:
 
 ```js
-(response, allItems, currentItems) => {
-	const entriesPerPage = response.request.options.searchParams.get('entriesPerPage');
+(async () => {
+	const limit = 10;
 
-	if (entriesPerPage !== undefined && currentItems.length < entriesPerPage) {
-		return false;
-	}
-  
-	return { 
-		url: getNextLink(response, allItems, currentItems) 
-	};
-}
+	const items = got.paginate('/items', {
+		searchParams: {
+			limit,
+			offset: 0,
+		},
+		_pagination: {
+			paginate: (response, allItems, currentItems) => {
+				const previousSearchParams = response.request.options.searchParams;
+				const { offset: previousOffset } = previousSearchParams;
+
+				if (currentItems.length < limit) {
+					return false;
+				}
+
+				return { 
+				      searchParams: {
+					...previousSearchParams,
+					offset: previousOffset + limit,
+				      },
+				};
+			}
+		}
+	});
+})();
 ```
 
 ###### \_pagination.filter

--- a/readme.md
+++ b/readme.md
@@ -688,7 +688,9 @@ It should return an object representing Got options pointing to the next page. I
 For example, if you want to stop when the response contains less items than expected, you should use:
 ```
 (response, allItems, currentItems) => {
-	if (currentItems.length < response.request.options.searchParams.entriesPerPage) {
+	const entriesPerPage = response.request.options.searchParams.get('entriesPerPage');
+
+	if (entriesPerPage !== undefined && currentItems.length < entriesPerPage) {
 		return false;
 	}
   

--- a/readme.md
+++ b/readme.md
@@ -698,7 +698,7 @@ Default: `(item, allItems, currentItems) => true`
 
 Checks whether the pagination should continue. `allItems` is an array of the all emitted items, while `currentItems` is an array of the current response items.
 
-For example, if you need to stop **before** emitting an entry with some flag, you should use `(item, allItems, currentItems) => !item.flag`. If you want to stop **after** emitting the entry, you should use `(item, allItems) => allItems.some(entry => entry.flag)` instead.
+For example, if you need to stop **before** emitting an entry with some flag, you should use `(item, allItems, currentItems) => !item.flag`. If you want to stop **after** emitting the entry, you should use `(item, allItems, currentItems) => allItems.some(entry => entry.flag)` instead.
 
 ###### \_pagination.countLimit
 

--- a/readme.md
+++ b/readme.md
@@ -687,18 +687,18 @@ A function that returns an object representing Got options pointing to the next 
 ###### \_pagination.filter
 
 Type: `Function`\
-Default: `(item, allItems) => true`
+Default: `(item, allItems, currentItems) => true`
 
-Checks whether the item should be emitted or not.
+Checks whether the item should be emitted or not. `currentItems` is an array of the emitted of items of the current response and `allItems` is an error of _all_ the previously emitted items.
 
 ###### \_pagination.shouldContinue
 
 Type: `Function`\
-Default: `(item, allItems) => true`
+Default: `(item, allItems, currentItems) => true`
 
-Checks whether the pagination should continue.
+Checks whether the pagination should continue. `currentItems` is an array of the emitted of items of the current response and `allItems` is an error of _all_ the previously emitted items.
 
-For example, if you need to stop **before** emitting an entry with some flag, you should use `(item, allItems) => !item.flag`. If you want to stop **after** emitting the entry, you should use `(item, allItems) => allItems.some(entry => entry.flag)` instead.
+For example, if you need to stop **before** emitting an entry with some flag, you should use `(item, allItems, currentItems) => !item.flag`. If you want to stop **after** emitting the entry, you should use `(item, allItems) => allItems.some(entry => entry.flag)` instead.
 
 ###### \_pagination.countLimit
 

--- a/readme.md
+++ b/readme.md
@@ -682,7 +682,11 @@ A function that transform [`Response`](#response) into an array of items. This i
 Type: `Function`\
 Default: [`Link` header logic](source/index.ts)
 
-The function takes three arguments: `response` (response object), `allItems` (array) and `currentItems` (array).
+The function takes three arguments:
+- `response` (the current response object)
+- `allItems` (an array of the emitted items)
+- `currentItems` (items from the current response).
+
 It should return an object representing Got options pointing to the next page. If there are no more pages, `false` should be returned.
 
 For example, if you want to stop when the response contains less items than expected, you should use:
@@ -705,14 +709,14 @@ For example, if you want to stop when the response contains less items than expe
 Type: `Function`\
 Default: `(item, allItems, currentItems) => true`
 
-Checks whether the item should be emitted or not. `allItems` is an array of the all emitted items, while `currentItems` is an array of the current response items.
+Checks whether the item should be emitted or not.
 
 ###### \_pagination.shouldContinue
 
 Type: `Function`\
 Default: `(item, allItems, currentItems) => true`
 
-Checks whether the pagination should continue. `allItems` is an array of the all emitted items, while `currentItems` is an array of the current response items.
+Checks whether the pagination should continue.
 
 For example, if you need to stop **before** emitting an entry with some flag, you should use `(item, allItems, currentItems) => !item.flag`. If you want to stop **after** emitting the entry, you should use `(item, allItems, currentItems) => allItems.some(entry => entry.flag)` instead.
 

--- a/readme.md
+++ b/readme.md
@@ -680,9 +680,11 @@ A function that transform [`Response`](#response) into an array of items. This i
 ###### \_pagination.paginate
 
 Type: `Function`\
-Default: [`Link` header logic](source/index.ts)
+Default: `(response, allItems, currentItems) => getLinkFromHeaders(response)` (find details [here](source/index.ts))
 
 A function that returns an object representing Got options pointing to the next page. If there are no more pages, `false` should be returned.
+
+For example, if you want to stop when the response contains less items that expected, you should use `(response, allItems, currentItems) => currentItems.length < LIMIT ? false : { url: getNextLink(response, allItems, currentItems) }`.
 
 ###### \_pagination.filter
 

--- a/readme.md
+++ b/readme.md
@@ -685,7 +685,18 @@ Default: [`Link` header logic](source/index.ts)
 The function takes three arguments: `response` (response object), `allItems` (array) and `currentItems` (array).
 It should return an object representing Got options pointing to the next page. If there are no more pages, `false` should be returned.
 
-For example, if you want to stop when the response contains less items than expected, you should use `(response, allItems, currentItems) => currentItems.length < response.request.options.searchParams.entriesPerPage ? false : { url: getNextLink(response, allItems, currentItems) }`.
+For example, if you want to stop when the response contains less items than expected, you should use:
+```
+(response, allItems, currentItems) => {
+	if (currentItems.length < response.request.options.searchParams.entriesPerPage) {
+		return false;
+	}
+  
+	return { 
+		url: getNextLink(response, allItems, currentItems) 
+	};
+}
+```
 
 ###### \_pagination.filter
 

--- a/readme.md
+++ b/readme.md
@@ -692,6 +692,8 @@ It should return an object representing Got options pointing to the next page. I
 For example, if you want to stop when the response contains less items than expected, you can use something like this:
 
 ```js
+import got from 'got';
+
 (async () => {
 	const limit = 10;
 
@@ -718,6 +720,8 @@ For example, if you want to stop when the response contains less items than expe
 			}
 		}
 	});
+	
+	console.log('Items from all pages: %o', items);
 })();
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -680,11 +680,12 @@ A function that transform [`Response`](#response) into an array of items. This i
 ###### \_pagination.paginate
 
 Type: `Function`\
-Default: `(response, allItems, currentItems) => getLinkFromHeaders(response)` (find details [here](source/index.ts))
+Default: [`Link` header logic](source/index.ts)
 
-A function that returns an object representing Got options pointing to the next page. If there are no more pages, `false` should be returned.
+The function takes three arguments: `response` (response object), `allItems` (array) and `currentItems` (array).
+It should return an object representing Got options pointing to the next page. If there are no more pages, `false` should be returned.
 
-For example, if you want to stop when the response contains less items that expected, you should use `(response, allItems, currentItems) => currentItems.length < LIMIT ? false : { url: getNextLink(response, allItems, currentItems) }`.
+For example, if you want to stop when the response contains less items than expected, you should use `(response, allItems, currentItems) => currentItems.length < response.request.options.searchParams.entriesPerPage ? false : { url: getNextLink(response, allItems, currentItems) }`.
 
 ###### \_pagination.filter
 

--- a/readme.md
+++ b/readme.md
@@ -683,9 +683,9 @@ Type: `Function`\
 Default: [`Link` header logic](source/index.ts)
 
 The function takes three arguments:
-- `response` (the current response object)
-- `allItems` (an array of the emitted items)
-- `currentItems` (items from the current response).
+- `response` - The current response object.
+- `allItems` - An array of the emitted items.
+- `currentItems` - Items from the current response.
 
 It should return an object representing Got options pointing to the next page. If there are no more pages, `false` should be returned.
 

--- a/readme.md
+++ b/readme.md
@@ -692,36 +692,36 @@ It should return an object representing Got options pointing to the next page. I
 For example, if you want to stop when the response contains less items than expected, you can use something like this:
 
 ```js
-import got from 'got';
+const got = require('got');
 
 (async () => {
 	const limit = 10;
 
-	const items = got.paginate('/items', {
+	const items = got.paginate('https://example.com/items', {
 		searchParams: {
 			limit,
-			offset: 0,
+			offset: 0
 		},
 		_pagination: {
 			paginate: (response, allItems, currentItems) => {
 				const previousSearchParams = response.request.options.searchParams;
-				const { offset: previousOffset } = previousSearchParams;
+				const {offset: previousOffset} = previousSearchParams;
 
 				if (currentItems.length < limit) {
 					return false;
 				}
 
-				return { 
-				      searchParams: {
-					...previousSearchParams,
-					offset: previousOffset + limit,
-				      },
+				return {
+					searchParams: {
+						...previousSearchParams,
+						offset: previousOffset + limit,
+					}
 				};
 			}
 		}
 	});
-	
-	console.log('Items from all pages: %o', items);
+
+	console.log('Items from all pages:', items);
 })();
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -696,7 +696,7 @@ Checks whether the item should be emitted or not. `currentItems` is an array of 
 Type: `Function`\
 Default: `(item, allItems, currentItems) => true`
 
-Checks whether the pagination should continue. `currentItems` is an array of the emitted of items of the current response and `allItems` is an error of _all_ the previously emitted items.
+Checks whether the pagination should continue. `allItems` is an array of the all emitted items, while `currentItems` is an array of the current response items.
 
 For example, if you need to stop **before** emitting an entry with some flag, you should use `(item, allItems, currentItems) => !item.flag`. If you want to stop **after** emitting the entry, you should use `(item, allItems) => allItems.some(entry => entry.flag)` instead.
 

--- a/readme.md
+++ b/readme.md
@@ -689,7 +689,7 @@ A function that returns an object representing Got options pointing to the next 
 Type: `Function`\
 Default: `(item, allItems, currentItems) => true`
 
-Checks whether the item should be emitted or not. `currentItems` is an array of the emitted of items of the current response and `allItems` is an error of _all_ the previously emitted items.
+Checks whether the item should be emitted or not. `allItems` is an array of the all emitted items, while `currentItems` is an array of the current response items.
 
 ###### \_pagination.shouldContinue
 

--- a/readme.md
+++ b/readme.md
@@ -690,7 +690,8 @@ The function takes three arguments:
 It should return an object representing Got options pointing to the next page. If there are no more pages, `false` should be returned.
 
 For example, if you want to stop when the response contains less items than expected, you should use:
-```
+
+```js
 (response, allItems, currentItems) => {
 	const entriesPerPage = response.request.options.searchParams.get('entriesPerPage');
 

--- a/source/create.ts
+++ b/source/create.ts
@@ -216,7 +216,7 @@ const create = (defaults: Defaults): Got => {
 
 			// eslint-disable-next-line no-await-in-loop
 			const parsed = await pagination.transform!(result);
-
+			const current: T[] = [];
 			for (const item of parsed) {
 				if (pagination.filter!(item, all)) {
 					if (!pagination.shouldContinue!(item, all)) {
@@ -226,6 +226,7 @@ const create = (defaults: Defaults): Got => {
 					yield item;
 
 					all.push(item as T);
+					current.push(item as T);
 
 					if (all.length === pagination.countLimit) {
 						return;
@@ -233,7 +234,7 @@ const create = (defaults: Defaults): Got => {
 				}
 			}
 
-			const optionsToMerge = pagination.paginate!(result);
+			const optionsToMerge = pagination.paginate!(result, all, current);
 
 			if (optionsToMerge === false) {
 				return;

--- a/source/create.ts
+++ b/source/create.ts
@@ -218,8 +218,8 @@ const create = (defaults: Defaults): Got => {
 			const parsed = await pagination.transform!(result);
 			const current: T[] = [];
 			for (const item of parsed) {
-				if (pagination.filter!(item, all)) {
-					if (!pagination.shouldContinue!(item, all)) {
+				if (pagination.filter!(item, all, current)) {
+					if (!pagination.shouldContinue!(item, all, current)) {
 						return;
 					}
 

--- a/source/create.ts
+++ b/source/create.ts
@@ -217,6 +217,7 @@ const create = (defaults: Defaults): Got => {
 			// eslint-disable-next-line no-await-in-loop
 			const parsed = await pagination.transform!(result);
 			const current: T[] = [];
+
 			for (const item of parsed) {
 				if (pagination.filter!(item, all, current)) {
 					if (!pagination.shouldContinue!(item, all, current)) {

--- a/source/types.ts
+++ b/source/types.ts
@@ -164,7 +164,7 @@ export interface PaginationOptions<T> {
 	_pagination?: {
 		transform?: (response: Response) => Promise<T[]> | T[];
 		filter?: (item: T, allItems: T[]) => boolean;
-		paginate?: (response: Response) => Options | false;
+		paginate?: (response: Response, allItems: T[], currentItems: T[]) => Options | false;
 		shouldContinue?: (item: T, allItems: T[]) => boolean;
 		countLimit?: number;
 	};

--- a/source/types.ts
+++ b/source/types.ts
@@ -165,7 +165,7 @@ export interface PaginationOptions<T> {
 		transform?: (response: Response) => Promise<T[]> | T[];
 		filter?: (item: T, allItems: T[], currentItems: T[]) => boolean;
 		paginate?: (response: Response, allItems: T[], currentItems: T[]) => Options | false;
-		shouldContinue?: (item: T, allItems: T[]) => boolean;
+		shouldContinue?: (item: T, allItems: T[], currentItems: T[]) => boolean;
 		countLimit?: number;
 	};
 }

--- a/source/types.ts
+++ b/source/types.ts
@@ -163,7 +163,7 @@ export type DefaultOptions = Merge<
 export interface PaginationOptions<T> {
 	_pagination?: {
 		transform?: (response: Response) => Promise<T[]> | T[];
-		filter?: (item: T, allItems: T[]) => boolean;
+		filter?: (item: T, allItems: T[], currentItems: T[]) => boolean;
 		paginate?: (response: Response, allItems: T[], currentItems: T[]) => Options | false;
 		shouldContinue?: (item: T, allItems: T[]) => boolean;
 		countLimit?: number;

--- a/test/pagination.ts
+++ b/test/pagination.ts
@@ -73,8 +73,8 @@ test('filters elements', withServer, async (t, server, got) => {
 	const result = await got.paginate.all({
 		_pagination: {
 			filter: (element, allItems, currentItems) => {
-				t.true(is.array(allItems));
-				t.true(is.array(currentItems));
+				t.true(Array.isArray(allItems));
+				t.true(Array.isArray(currentItems));
 
 				return element !== 2
 			}
@@ -180,8 +180,8 @@ test('`shouldContinue` works', withServer, async (t, server, got) => {
 	const options = {
 		_pagination: {
 			shouldContinue: (_element: any, allItems: any, currentItems: any) => {
-				t.true(is.array(allItems));
-				t.true(is.array(currentItems));
+				t.true(Array.isArray(allItems));
+				t.true(Array.isArray(currentItems));
 
 				return false
 			}
@@ -194,7 +194,7 @@ test('`shouldContinue` works', withServer, async (t, server, got) => {
 		results.push(item);
 	}
 
-	t.deepEqual(results, []);
+llup tig	t.deepEqual(results, []);
 });
 
 test('`countLimit` works', withServer, async (t, server, got) => {

--- a/test/pagination.ts
+++ b/test/pagination.ts
@@ -194,7 +194,7 @@ test('`shouldContinue` works', withServer, async (t, server, got) => {
 		results.push(item);
 	}
 
-llup tig	t.deepEqual(results, []);
+	t.deepEqual(results, []);
 });
 
 test('`countLimit` works', withServer, async (t, server, got) => {

--- a/test/pagination.ts
+++ b/test/pagination.ts
@@ -179,7 +179,7 @@ test('`shouldContinue` works', withServer, async (t, server, got) => {
 
 	const options = {
 		_pagination: {
-			shouldContinue: (_element: any, allItems: any, currentItems: any) => {
+			shouldContinue: (_element: unknown, allItems: unknown[], currentItems: unknown[]) => {
 				t.true(Array.isArray(allItems));
 				t.true(Array.isArray(currentItems));
 

--- a/test/pagination.ts
+++ b/test/pagination.ts
@@ -72,7 +72,16 @@ test('filters elements', withServer, async (t, server, got) => {
 
 	const result = await got.paginate.all({
 		_pagination: {
-			filter: element => element !== 2
+			filter: (element, allItems, currentItems) => {
+				if (!Array.isArray(allItems)) {
+					throw new Error('allItems is not an array');
+				}
+				if (!Array.isArray(currentItems)) {
+					throw new Error('currentItems is not an array');
+				}
+
+				return element !== 2
+			}
 		}
 	});
 
@@ -174,7 +183,16 @@ test('`shouldContinue` works', withServer, async (t, server, got) => {
 
 	const options = {
 		_pagination: {
-			shouldContinue: () => false
+			shouldContinue: (element: any, allItems: any, currentItems: any) => {
+				if (!Array.isArray(allItems)) {
+					throw new Error('allItems is not an array');
+				}
+				if (!Array.isArray(currentItems)) {
+					throw new Error('currentItems is not an array');
+				}
+
+				return false
+			}
 		}
 	};
 

--- a/test/pagination.ts
+++ b/test/pagination.ts
@@ -73,12 +73,8 @@ test('filters elements', withServer, async (t, server, got) => {
 	const result = await got.paginate.all({
 		_pagination: {
 			filter: (element, allItems, currentItems) => {
-				if (!Array.isArray(allItems)) {
-					throw new Error('allItems is not an array');
-				}
-				if (!Array.isArray(currentItems)) {
-					throw new Error('currentItems is not an array');
-				}
+				t.true(is.array(allItems));
+				t.true(is.array(currentItems));
 
 				return element !== 2
 			}

--- a/test/pagination.ts
+++ b/test/pagination.ts
@@ -76,7 +76,7 @@ test('filters elements', withServer, async (t, server, got) => {
 				t.true(Array.isArray(allItems));
 				t.true(Array.isArray(currentItems));
 
-				return element !== 2
+				return element !== 2;
 			}
 		}
 	});
@@ -183,7 +183,7 @@ test('`shouldContinue` works', withServer, async (t, server, got) => {
 				t.true(Array.isArray(allItems));
 				t.true(Array.isArray(currentItems));
 
-				return false
+				return false;
 			}
 		}
 	};

--- a/test/pagination.ts
+++ b/test/pagination.ts
@@ -121,6 +121,42 @@ test('custom paginate function', withServer, async (t, server, got) => {
 	t.deepEqual(result, [1, 3]);
 });
 
+test('custom paginate function using allItems', withServer, async (t, server, got) => {
+	attachHandler(server, 3);
+
+	const result = await got.paginate.all({
+		_pagination: {
+			paginate: (_response, allItems) => {
+				if (allItems.length === 2) {
+					return false;
+				}
+
+				return {path: '/?page=3'};
+			}
+		}
+	});
+
+	t.deepEqual(result, [1, 3]);
+});
+
+test('custom paginate function using currentItems', withServer, async (t, server, got) => {
+	attachHandler(server, 3);
+
+	const result = await got.paginate.all({
+		_pagination: {
+			paginate: (_response, _allItems, currentItems) => {
+				if (currentItems[0] === 3) {
+					return false;
+				}
+
+				return {path: '/?page=3'};
+			}
+		}
+	});
+
+	t.deepEqual(result, [1, 3]);
+});
+
 test('iterator works', withServer, async (t, server, got) => {
 	attachHandler(server, 5);
 

--- a/test/pagination.ts
+++ b/test/pagination.ts
@@ -180,12 +180,8 @@ test('`shouldContinue` works', withServer, async (t, server, got) => {
 	const options = {
 		_pagination: {
 			shouldContinue: (_element: any, allItems: any, currentItems: any) => {
-				if (!Array.isArray(allItems)) {
-					throw new Error('allItems is not an array');
-				}
-				if (!Array.isArray(currentItems)) {
-					throw new Error('currentItems is not an array');
-				}
+				t.true(is.array(allItems));
+				t.true(is.array(currentItems));
 
 				return false
 			}

--- a/test/pagination.ts
+++ b/test/pagination.ts
@@ -183,7 +183,7 @@ test('`shouldContinue` works', withServer, async (t, server, got) => {
 
 	const options = {
 		_pagination: {
-			shouldContinue: (element: any, allItems: any, currentItems: any) => {
+			shouldContinue: (_element: any, allItems: any, currentItems: any) => {
 				if (!Array.isArray(allItems)) {
 					throw new Error('allItems is not an array');
 				}


### PR DESCRIPTION
Sometimes you need `alltems` or the items from the last response in the `paginate` function (e.g. to compare if current length of items are less than requested size).

#### Checklist

- [X] I have read the documentation.
- [X] I have included a pull request description of my changes.
- [X] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates.
