### PR TITLE
Avoid parsing JSON twice in `_pagination.transform`

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -69,6 +69,10 @@ const defaults: Defaults = {
 		context: {},
 		_pagination: {
 			transform: (response: Response) => {
+				if (response.request.optinos.responseType === 'json') {
+					return response.body;
+				}
+
 				return JSON.parse(response.body as string);
 			},
 			paginate: response => {

--- a/source/index.ts
+++ b/source/index.ts
@@ -69,7 +69,7 @@ const defaults: Defaults = {
 		context: {},
 		_pagination: {
 			transform: (response: Response) => {
-				if (response.request.optinos.responseType === 'json') {
+				if (response.request.options.responseType === 'json') {
 					return response.body;
 				}
 

--- a/test/pagination.ts
+++ b/test/pagination.ts
@@ -47,6 +47,16 @@ test('retrieves all elements', withServer, async (t, server, got) => {
 	t.deepEqual(result, [1, 2]);
 });
 
+test('retrieves all elements with JSON responseType', withServer, async (t, server, got) => {
+	attachHandler(server, 2);
+
+	const result = await got.extend({
+		responseType: 'json'
+	}).paginate.all('');
+
+	t.deepEqual(result, [1, 2]);
+});
+
 test('points to defaults when extending Got without custom `_pagination`', withServer, async (t, server, got) => {
 	attachHandler(server, 2);
 


### PR DESCRIPTION
If the `responseType` is `json` we do not need to parse the response again in the default transform function.

#### Checklist

- [X] I have read the documentation.
- [X] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates.
