### PR TITLE
Do not ignore `decompress-response` when bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
 	"types": "dist/source",
 	"sideEffects": false,
 	"browser": {
-		"decompress-response": false,
 		"electron": false
 	},
 	"ava": {


### PR DESCRIPTION
Currently, using got with webpack to build target `electron-renderer` will throw an error from `get-response.js` like:

```
decompressResponse is not a Function
```

The root cause is webpack ignoring the `decompress-response` module in got, according the `browser` setting in package.json.

Like the issue #945 described, after removing this field, the webpack will bundle this module and `got` works correctly.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates.
