### PR TITLE
Fix reusing Got options

### DIFF
--- a/source/normalize-arguments.ts
+++ b/source/normalize-arguments.ts
@@ -285,36 +285,20 @@ export const normalizeArguments = (url: URLOrOptions, options?: Options, default
 
 	const hasUrl = is.urlInstance(url) || is.string(url);
 	if (hasUrl) {
-		if (options) {
-			if (Reflect.has(options, 'url')) {
-				throw new TypeError('The `url` option cannot be used if the input is a valid URL.');
-			}
-		} else {
-			options = {};
+		options = mergeOptions(defaults?.options ?? {}, options ?? {});
+		if (Reflect.has(options, 'url')) {
+			throw new TypeError('The `url` option cannot be used if the input is a valid URL.');
 		}
-
 		// @ts-ignore URL is not URL
 		options.url = url;
-
-		runInitHooks(defaults?.options.hooks.init, options);
-		runInitHooks(options.hooks?.init, options);
 	} else if (Reflect.has(url as object, 'resolve')) {
 		throw new Error('The legacy `url.Url` is deprecated. Use `URL` instead.');
 	} else {
-		runInitHooks(defaults?.options.hooks.init, url as Options);
-		runInitHooks((url as Options).hooks?.init, url as Options);
-
-		if (options) {
-			runInitHooks(defaults?.options.hooks.init, options);
-			runInitHooks(options.hooks?.init, options);
-		}
-	}
-
-	if (hasUrl) {
-		options = mergeOptions(defaults?.options ?? {}, options ?? {});
-	} else {
 		options = mergeOptions(defaults?.options ?? {}, url as object, options ?? {});
 	}
+
+	runInitHooks(defaults?.options.hooks.init, options);
+	runInitHooks(options.hooks?.init, options);
 
 	// Normalize URL
 	// TODO: drop `optionsToUrl` in Got 12

--- a/source/normalize-arguments.ts
+++ b/source/normalize-arguments.ts
@@ -286,7 +286,7 @@ export const normalizeArguments = (url: URLOrOptions, options?: Options, default
 	const hasUrl = is.urlInstance(url) || is.string(url);
 	if (hasUrl) {
 		if (options) {
-			if (Reflect.has(options, 'url')) {
+			if (options.url) {
 				throw new TypeError('The `url` option cannot be used if the input is a valid URL.');
 			}
 		} else {

--- a/source/normalize-arguments.ts
+++ b/source/normalize-arguments.ts
@@ -302,7 +302,11 @@ export const normalizeArguments = (url: URLOrOptions, options?: Options, default
 		runInitHooks(options.hooks?.init, options);
 
 		url = options.url as URLOrOptions;
-		options.url = optionsUrl;
+		if (optionsUrl) {
+			options.url = optionsUrl;
+		} else {
+			delete options.url;
+		}
 	} else if (Reflect.has(url as object, 'resolve')) {
 		throw new Error('The legacy `url.Url` is deprecated. Use `URL` instead.');
 	} else {

--- a/source/normalize-arguments.ts
+++ b/source/normalize-arguments.ts
@@ -301,7 +301,7 @@ export const normalizeArguments = (url: URLOrOptions, options?: Options, default
 		runInitHooks(defaults?.options.hooks.init, options);
 		runInitHooks(options.hooks?.init, options);
 
-		url = options.url;
+		url = options.url as URLOrOptions;
 		options.url = optionsUrl;
 	} else if (Reflect.has(url as object, 'resolve')) {
 		throw new Error('The legacy `url.Url` is deprecated. Use `URL` instead.');

--- a/source/normalize-arguments.ts
+++ b/source/normalize-arguments.ts
@@ -285,20 +285,40 @@ export const normalizeArguments = (url: URLOrOptions, options?: Options, default
 
 	const hasUrl = is.urlInstance(url) || is.string(url);
 	if (hasUrl) {
-		options = mergeOptions(defaults?.options ?? {}, options ?? {});
-		if (Reflect.has(options, 'url')) {
-			throw new TypeError('The `url` option cannot be used if the input is a valid URL.');
+		if (options) {
+			if (Reflect.has(options, 'url')) {
+				throw new TypeError('The `url` option cannot be used if the input is a valid URL.');
+			}
+		} else {
+			options = {};
 		}
+
+		const {url: optionsUrl} = options;
+
 		// @ts-ignore URL is not URL
 		options.url = url;
+
+		runInitHooks(defaults?.options.hooks.init, options);
+		runInitHooks(options.hooks?.init, options);
+
+		options.url = optionsUrl;
 	} else if (Reflect.has(url as object, 'resolve')) {
 		throw new Error('The legacy `url.Url` is deprecated. Use `URL` instead.');
 	} else {
-		options = mergeOptions(defaults?.options ?? {}, url as object, options ?? {});
+		runInitHooks(defaults?.options.hooks.init, url as Options);
+		runInitHooks((url as Options).hooks?.init, url as Options);
+
+		if (options) {
+			runInitHooks(defaults?.options.hooks.init, options);
+			runInitHooks(options.hooks?.init, options);
+		}
 	}
 
-	runInitHooks(defaults?.options.hooks.init, options);
-	runInitHooks(options.hooks?.init, options);
+	if (hasUrl) {
+		options = mergeOptions(defaults?.options ?? {}, options ?? {});
+	} else {
+		options = mergeOptions(defaults?.options ?? {}, url as object, options ?? {});
+	}
 
 	// Normalize URL
 	// TODO: drop `optionsToUrl` in Got 12

--- a/source/normalize-arguments.ts
+++ b/source/normalize-arguments.ts
@@ -301,6 +301,7 @@ export const normalizeArguments = (url: URLOrOptions, options?: Options, default
 		runInitHooks(defaults?.options.hooks.init, options);
 		runInitHooks(options.hooks?.init, options);
 
+		url = options.url;
 		options.url = optionsUrl;
 	} else if (Reflect.has(url as object, 'resolve')) {
 		throw new Error('The legacy `url.Url` is deprecated. Use `URL` instead.');

--- a/source/normalize-arguments.ts
+++ b/source/normalize-arguments.ts
@@ -286,7 +286,7 @@ export const normalizeArguments = (url: URLOrOptions, options?: Options, default
 	const hasUrl = is.urlInstance(url) || is.string(url);
 	if (hasUrl) {
 		if (options) {
-			if (options.url) {
+			if (Reflect.has(options, 'url')) {
 				throw new TypeError('The `url` option cannot be used if the input is a valid URL.');
 			}
 		} else {

--- a/test/normalize-arguments.ts
+++ b/test/normalize-arguments.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 import got, {Options} from '../source';
-import {normalizeArguments} from "../source/normalize-arguments";
+import {normalizeArguments} from '../source/normalize-arguments';
 
 test('should merge options replacing responseType', t => {
 	const responseType = 'json';
@@ -13,11 +13,11 @@ test('should merge options replacing responseType', t => {
 
 test('should be able to reuse options', t => {
 	const options: Options = {};
-	normalizeArguments("http://localhost", options);
-	t.notThrows(() => normalizeArguments("http://localhost", options));
+	normalizeArguments('http://localhost', options);
+	t.notThrows(() => normalizeArguments('http://localhost', options));
 });
 
 test.failing('should handle frozen objects', t => {
 	const options: Options = Object.freeze({});
-	t.notThrows(() => normalizeArguments("http://localhost", options));
+	t.notThrows(() => normalizeArguments('http://localhost', options));
 });

--- a/test/normalize-arguments.ts
+++ b/test/normalize-arguments.ts
@@ -12,12 +12,12 @@ test('should merge options replacing responseType', t => {
 });
 
 test('should be able to reuse options', t => {
-	const  options: Options = {};
+	const options: Options = {};
 	normalizeArguments("http://localhost", options);
 	t.notThrows(() => normalizeArguments("http://localhost", options));
 });
 
-test('should handle frozen objects', t => {
+test.failing('should handle frozen objects', t => {
 	const options: Options = Object.freeze({});
 	t.notThrows(() => normalizeArguments("http://localhost", options));
 });

--- a/test/normalize-arguments.ts
+++ b/test/normalize-arguments.ts
@@ -1,5 +1,6 @@
 import test from 'ava';
-import got from '../source';
+import got, {Options} from '../source';
+import {normalizeArguments} from "../source/normalize-arguments";
 
 test('should merge options replacing responseType', t => {
 	const responseType = 'json';
@@ -8,4 +9,15 @@ test('should merge options replacing responseType', t => {
 	});
 
 	t.is(options.responseType, responseType);
+});
+
+test('should be able to reuse options', t => {
+	const  options: Options = {};
+	normalizeArguments("http://localhost", options);
+	t.notThrows(() => normalizeArguments("http://localhost", options));
+});
+
+test('should handle frozen objects', t => {
+	const options: Options = Object.freeze({});
+	t.notThrows(() => normalizeArguments("http://localhost", options));
 });


### PR DESCRIPTION
Restores the original `options.url` after calling the init hooks.

Fixes #1118 

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates.
