### PR TITLE
Make a fix regarding UNIX domain socket support

### DIFF
--- a/source/normalize-arguments.ts
+++ b/source/normalize-arguments.ts
@@ -485,12 +485,11 @@ export const normalizeRequestArguments = async (options: NormalizedOptions): Pro
 		if (matches?.groups) {
 			const {socketPath, path} = matches.groups;
 
-			options = {
-				...options,
+			Object.assign(options, {
 				socketPath,
 				path,
 				host: ''
-			};
+			});
 		}
 	}
 


### PR DESCRIPTION
I have no idea why this is happening, but for some reason the `body` property (which is a ReadableStream) of the `options` object gets lost when the `options` object is extended using the object spread syntax. This doesn't happen when we make use of `Object.assign`.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates.
