### PR TITLE
Preserve header key capitalization

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
 		"decompress-response": "^5.0.0",
 		"get-stream": "^5.0.0",
 		"http2-wrapper": "^1.0.0-beta.4.3",
-		"lowercase-keys": "^2.0.0",
 		"p-cancelable": "^2.0.0",
 		"responselike": "^2.0.0"
 	},

--- a/readme.md
+++ b/readme.md
@@ -178,7 +178,8 @@ Default: `{}`
 
 Request headers.
 
-Existing headers will be overwritten. Headers set to `undefined` will be omitted.
+Header capitalization is preserved.
+Existing headers, even with different capitalization, will be overwritten. Headers set to `undefined` will be omitted.
 
 ###### isStream
 

--- a/source/core/utils/normalize-headers.ts
+++ b/source/core/utils/normalize-headers.ts
@@ -1,0 +1,20 @@
+import {Headers} from '..';
+
+export default (input: Headers): Headers => {
+	const output: Headers = {};
+	const entries = Object.entries(input);
+	/* If there are multiple keys that are equal, except for capitalization,
+	   then use the last key's capitalization
+	 */
+	const usedKeys = new Set();
+	for (let i = entries.length - 1; i >= 0; i--) {
+		const [key, value] = entries[i];
+		const lowercaseKey = key.toLowerCase();
+		if (!usedKeys.has(lowercaseKey)) {
+			output[key] = value;
+			usedKeys.add(lowercaseKey);
+		}
+	}
+
+	return output;
+};

--- a/test/headers.ts
+++ b/test/headers.ts
@@ -103,7 +103,7 @@ test('preserve header key capitalization', withServer, async (t, server, got) =>
 		headers: {
 			'ACCEPT-ENCODING': 'abc'
 		}
-	}).json<Array<string>>();
+	}).json<string[]>();
 
 	let key;
 	let value;
@@ -119,6 +119,7 @@ test('preserve header key capitalization', withServer, async (t, server, got) =>
 			}
 		}
 	}
+
 	t.is(key, 'ACCEPT-ENCODING');
 	t.is(value, 'abc');
 });


### PR DESCRIPTION
#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] If it's a new feature, I have included documentation updates.

This pull request makes `got` preserve the capitalization of header keys. For example, if you pass pass the header `X-Custom: 123`, the server will receive `X-Custom: 123` instead of `x-custom: 123`. Overriding headers still works the same--`User-Agent` will override `user-agent`.