### PR TITLE
Limit number of requests in pagination

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -765,7 +765,7 @@ The maximum amount of items that should be emitted.
 Type: `number`\
 Default: `10000`
 
-The maximum amount of request that should be triggered.
+The maximum amount of request that should be triggered. [Retries on failure](#retry) are not count towards this limit.
 
 For example, if you need the first 10 pages but don't know how many items there are per page. It can also be helpful during development to avoid an infinite number of requests.
 

--- a/readme.md
+++ b/readme.md
@@ -760,6 +760,13 @@ Default: `Infinity`
 
 The maximum amount of items that should be emitted.
 
+###### pagination.requestLimit
+
+Type: `number`\
+Default: `100`
+
+The maximum amount of request that should be triggered.
+
 ##### localAddress
 
 Type: `string`

--- a/readme.md
+++ b/readme.md
@@ -763,9 +763,11 @@ The maximum amount of items that should be emitted.
 ###### pagination.requestLimit
 
 Type: `number`\
-Default: `100`
+Default: `10000`
 
 The maximum amount of request that should be triggered.
+
+For example, if you need the first 10 pages but don't know how many items there are per page. It can also be helpful during development to avoid an infinite number of requests.
 
 ##### localAddress
 

--- a/readme.md
+++ b/readme.md
@@ -765,7 +765,7 @@ The maximum amount of items that should be emitted.
 Type: `number`\
 Default: `10000`
 
-The maximum amount of request that should be triggered. [Retries on failure](#retry) are not count towards this limit.
+The maximum amount of request that should be triggered. [Retries on failure](#retry) are not counted towards this limit.
 
 For example, if you need the first 10 pages but don't know how many items there are per page. It can also be helpful during development to avoid an infinite number of requests.
 

--- a/readme.md
+++ b/readme.md
@@ -767,7 +767,7 @@ Default: `10000`
 
 The maximum amount of request that should be triggered. [Retries on failure](#retry) are not counted towards this limit.
 
-For example, if you need the first 10 pages but don't know how many items there are per page. It can also be helpful during development to avoid an infinite number of requests.
+For example, it can be helpful during development to avoid an infinite number of requests.
 
 ##### localAddress
 

--- a/source/as-promise/types.ts
+++ b/source/as-promise/types.ts
@@ -77,6 +77,7 @@ export interface PaginationOptions<T> {
 		paginate?: (response: Response, allItems: T[], currentItems: T[]) => Options | false;
 		shouldContinue?: (item: T, allItems: T[], currentItems: T[]) => boolean;
 		countLimit?: number;
+		requestLimit?: number;
 	};
 }
 

--- a/source/create.ts
+++ b/source/create.ts
@@ -206,7 +206,8 @@ const create = (defaults: InstanceDefaults): Got => {
 
 		const all: T[] = [];
 
-		while (true) {
+		let numberOfRequests = 0;
+		while (numberOfRequests <= pagination.requestLimit) {
 			// TODO: Throw when result is not an instance of Response
 			// eslint-disable-next-line no-await-in-loop
 			const result = (await got('', normalizedOptions)) as Response;
@@ -241,6 +242,8 @@ const create = (defaults: InstanceDefaults): Got => {
 			if (optionsToMerge !== undefined) {
 				normalizedOptions = normalizeArguments(undefined, optionsToMerge, normalizedOptions);
 			}
+
+			numberOfRequests++;
 		}
 	}) as GotPaginate;
 

--- a/source/create.ts
+++ b/source/create.ts
@@ -207,7 +207,7 @@ const create = (defaults: InstanceDefaults): Got => {
 		const all: T[] = [];
 
 		let numberOfRequests = 0;
-		while (numberOfRequests <= pagination.requestLimit) {
+		while (numberOfRequests < pagination.requestLimit) {
 			// TODO: Throw when result is not an instance of Response
 			// eslint-disable-next-line no-await-in-loop
 			const result = (await got('', normalizedOptions)) as Response;

--- a/source/index.ts
+++ b/source/index.ts
@@ -109,7 +109,7 @@ const defaults: InstanceDefaults = {
 			filter: () => true,
 			shouldContinue: () => true,
 			countLimit: Infinity,
-			requestLimit: 100
+			requestLimit: 10000
 		}
 	},
 	handlers: [defaultHandler],

--- a/source/index.ts
+++ b/source/index.ts
@@ -108,7 +108,8 @@ const defaults: InstanceDefaults = {
 			},
 			filter: () => true,
 			shouldContinue: () => true,
-			countLimit: Infinity
+			countLimit: Infinity,
+			requestLimit: 100,
 		}
 	},
 	handlers: [defaultHandler],

--- a/source/index.ts
+++ b/source/index.ts
@@ -109,7 +109,7 @@ const defaults: InstanceDefaults = {
 			filter: () => true,
 			shouldContinue: () => true,
 			countLimit: Infinity,
-			requestLimit: 100,
+			requestLimit: 100
 		}
 	},
 	handlers: [defaultHandler],

--- a/test/pagination.ts
+++ b/test/pagination.ts
@@ -308,3 +308,21 @@ test('ignores the `resolveBodyOnly` option', withServer, async (t, server, got) 
 
 	t.deepEqual(items, [1, 2]);
 });
+
+test('`requestLimit` works', withServer, async (t, server, got) => {
+	attachHandler(server, 2);
+
+	const options = {
+		pagination: {
+			requestLimit: 1
+		}
+	};
+
+	const results: number[] = [];
+
+	for await (const item of got.paginate<number>(options)) {
+		results.push(item);
+	}
+
+	t.deepEqual(results, [1]);
+});


### PR DESCRIPTION
Currently, it's easily possible to trigger an infinite amount of requests during development because we use a `while(true)` construct. This PR adds a new option to limit the number of requests.

#### Checklist

- [X] I have read the documentation.
- [X] I have included a pull request description of my changes.
- [X] I have included some tests.
- [X] If it's a new feature, I have included documentation updates.
