### PR TITLE
Add `backoff` option to pagination

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -912,6 +912,13 @@ Default: `Infinity`
 
 The maximum amount of items that should be emitted.
 
+###### pagination.backoff
+
+Type: `number`\
+Default: `0`
+
+Milliseconds to wait before the next request is triggered.
+
 ###### pagination.requestLimit
 
 Type: `number`\

--- a/source/as-promise/types.ts
+++ b/source/as-promise/types.ts
@@ -37,6 +37,7 @@ export interface PaginationOptions<T, R> {
 		paginate?: (response: Response<R>, allItems: T[], currentItems: T[]) => Options | false;
 		shouldContinue?: (item: T, allItems: T[], currentItems: T[]) => boolean;
 		countLimit?: number;
+		backoff?: number;
 		requestLimit?: number;
 		stackAllItems?: boolean;
 	};

--- a/source/create.ts
+++ b/source/create.ts
@@ -54,6 +54,9 @@ const errors = {
 	UploadError
 };
 
+// The `delay` package weighs 10KB (!)
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
 const {normalizeArguments, mergeOptions} = PromisableRequest;
 
 const getPromiseOrStream = (options: NormalizedOptions): GotReturn => options.isStream ? new Request(options.url, options) : asPromise(options);
@@ -254,6 +257,8 @@ const create = (defaults: InstanceDefaults): Got => {
 				normalizedOptions = normalizeArguments(undefined, optionsToMerge, normalizedOptions);
 			}
 
+			// eslint-disable-next-line no-await-in-loop
+			await delay(pagination.backoff);
 			numberOfRequests++;
 		}
 	});

--- a/source/create.ts
+++ b/source/create.ts
@@ -217,6 +217,11 @@ const create = (defaults: InstanceDefaults): Got => {
 
 		let numberOfRequests = 0;
 		while (numberOfRequests < pagination.requestLimit) {
+			if (numberOfRequests !== 0) {
+				// eslint-disable-next-line no-await-in-loop
+				await delay(pagination.backoff);
+			}
+
 			// TODO: Throw when result is not an instance of Response
 			// eslint-disable-next-line no-await-in-loop
 			const result = (await got(normalizedOptions)) as Response;
@@ -257,8 +262,6 @@ const create = (defaults: InstanceDefaults): Got => {
 				normalizedOptions = normalizeArguments(undefined, optionsToMerge, normalizedOptions);
 			}
 
-			// eslint-disable-next-line no-await-in-loop
-			await delay(pagination.backoff);
 			numberOfRequests++;
 		}
 	});

--- a/source/create.ts
+++ b/source/create.ts
@@ -55,7 +55,7 @@ const errors = {
 };
 
 // The `delay` package weighs 10KB (!)
-const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+const delay = async (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 const {normalizeArguments, mergeOptions} = PromisableRequest;
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -108,6 +108,7 @@ const defaults: InstanceDefaults = {
 			filter: () => true,
 			shouldContinue: () => true,
 			countLimit: Infinity,
+			backoff: 0,
 			requestLimit: 10000,
 			stackAllItems: true
 		},

--- a/test/pagination.ts
+++ b/test/pagination.ts
@@ -459,7 +459,7 @@ test('`backoff` works', withServer, async (t, server, got) => {
 		pagination: {
 			backoff
 		}
-	});;
+	});
 
 	t.is((await asyncIterator.next()).value, 1);
 
@@ -473,7 +473,7 @@ test('`backoff` works', withServer, async (t, server, got) => {
 	await delay(backoff / 2);
 	t.false(receivedLastOne);
 
-	await delay(backoff / 2 + 100);
+	await delay((backoff / 2) + 100);
 	t.true(receivedLastOne);
 });
 


### PR DESCRIPTION
This PR adds an easy possibility to respect rate limits that are enforced by some APIs. If the rate limit is 600 per hour and you know that you will most likely hit the limit you can set `backoff` to `100` which means that paginated requests are triggered only every 100 milliseconds. Unfortunately, I had no clever idea how to implement a test but maybe you have an idea?

#### Checklist

- [X] I have read the documentation.
- [X] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [X] If it's a new feature, I have included documentation updates.
