### PR TITLE
Add more tests for `options.allowGetBody`

### DIFF
--- a/test/arguments.ts
+++ b/test/arguments.ts
@@ -4,7 +4,7 @@ import test from 'ava';
 import {Handler} from 'express';
 import pEvent = require('p-event');
 import got, {StrictOptions} from '../source';
-import withServer from './helpers/with-server';
+import withServer, {withBodyParsingServer} from './helpers/with-server';
 
 const echoUrl: Handler = (request, response) => {
 	response.end(request.url);
@@ -482,4 +482,22 @@ test('reuse options while using init hook', withServer, async (t, server, got) =
 
 	await got('', options);
 	await got('', options);
+});
+
+test('allowGetBody sends json payload', withBodyParsingServer, async (t, server, got) => {
+	server.get('/', (request, response) => {
+		if (request.body.hello !== 'world') {
+			response.statusCode = 400;
+		}
+
+		response.end();
+	});
+
+	const {statusCode} = await got({
+		allowGetBody: true,
+		json: {hello: 'world'},
+		retry: 0,
+		throwHttpErrors: false
+	});
+	t.is(statusCode, 200);
 });

--- a/test/pagination.ts
+++ b/test/pagination.ts
@@ -1,7 +1,7 @@
 import {URL} from 'url';
 import test from 'ava';
 import got, {Response} from '../source';
-import withServer from './helpers/with-server';
+import withServer, {withBodyParsingServer} from './helpers/with-server';
 import {ExtendedTestServer} from './helpers/types';
 
 const thrower = (): any => {
@@ -307,4 +307,24 @@ test('ignores the `resolveBodyOnly` option', withServer, async (t, server, got) 
 	});
 
 	t.deepEqual(items, [1, 2]);
+});
+
+test.failing('allowGetBody sends json payload with .paginate()', withBodyParsingServer, async (t, server, got) => {
+	server.get('/', (request, response) => {
+		if (request.body.hello !== 'world') {
+			response.statusCode = 400;
+		}
+
+		response.end(JSON.stringify([1, 2, 3]));
+	});
+
+	const iterator = got.paginate({
+		allowGetBody: true,
+		json: {hello: 'world'},
+		retry: 0
+	});
+
+	const result = await iterator.next();
+
+	t.is(result.value, 1);
 });

--- a/test/pagination.ts
+++ b/test/pagination.ts
@@ -326,5 +326,5 @@ test.failing('allowGetBody sends json payload with .paginate()', withBodyParsing
 
 	const result = await iterator.next();
 
-	t.is(result.value, 1);
+	t.deepEqual(result.value, [1, 2, 3]);
 });


### PR DESCRIPTION
To help investigate #1186 this PR adds:

- `withBodyParsingServer` helper to allow the use of `request.body` in test cases
- two test cases for using `allowGetBody` with a json payload

Adding more allowGetBody with non-json payloads might be relevant but not in the current scope of originating issue.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates.
