### PR TITLE
Allow response body to be typed for pagination API

### DIFF
--- a/source/as-promise/types.ts
+++ b/source/as-promise/types.ts
@@ -70,18 +70,18 @@ export interface Hooks extends RequestHooks {
 	afterResponse?: AfterResponseHook[];
 }
 
-export interface PaginationOptions<T> {
+export interface PaginationOptions<T, R> {
 	pagination?: {
-		transform?: (response: Response) => Promise<T[]> | T[];
+		transform?: (response: Response<R>) => Promise<T[]> | T[];
 		filter?: (item: T, allItems: T[], currentItems: T[]) => boolean;
-		paginate?: (response: Response, allItems: T[], currentItems: T[]) => Options | false;
+		paginate?: (response: Response<R>, allItems: T[], currentItems: T[]) => Options | false;
 		shouldContinue?: (item: T, allItems: T[], currentItems: T[]) => boolean;
 		countLimit?: number;
 		requestLimit?: number;
 	};
 }
 
-export interface Options extends RequestOptions, PaginationOptions<unknown> {
+export interface Options extends RequestOptions, PaginationOptions<unknown, unknown> {
 	hooks?: Hooks;
 	responseType?: ResponseType;
 	resolveBodyOnly?: boolean;
@@ -97,7 +97,7 @@ export interface NormalizedOptions extends RequestNormalizedOptions {
 	retry: RequiredRetryOptions;
 	isStream: boolean;
 	encoding?: BufferEncoding;
-	pagination?: Required<PaginationOptions<unknown>['pagination']>;
+	pagination?: Required<PaginationOptions<unknown, unknown>['pagination']>;
 }
 
 export interface Defaults extends RequestDefaults {
@@ -106,7 +106,7 @@ export interface Defaults extends RequestDefaults {
 	resolveBodyOnly: boolean;
 	retry: RequiredRetryOptions;
 	isStream: boolean;
-	pagination?: Required<PaginationOptions<unknown>['pagination']>;
+	pagination?: Required<PaginationOptions<unknown, unknown>['pagination']>;
 }
 
 export class ParseError extends RequestError {

--- a/source/create.ts
+++ b/source/create.ts
@@ -194,7 +194,7 @@ const create = (defaults: InstanceDefaults): Got => {
 		});
 	};
 
-	got.paginate = (async function * <T>(url: string | URL, options?: OptionsWithPagination<T>) {
+	got.paginate = (async function * <T, R>(url: string | URL, options?: OptionsWithPagination<T, R>) {
 		let normalizedOptions = normalizeArguments(url, options, defaults.options);
 		normalizedOptions.resolveBodyOnly = false;
 
@@ -247,10 +247,10 @@ const create = (defaults: InstanceDefaults): Got => {
 		}
 	}) as GotPaginate;
 
-	got.paginate.all = (async <T>(url: string | URL, options?: OptionsWithPagination<T>) => {
+	got.paginate.all = (async <T, R>(url: string | URL, options?: OptionsWithPagination<T, R>) => {
 		const results: T[] = [];
 
-		for await (const item of got.paginate<T>(url, options)) {
+		for await (const item of got.paginate<T, R>(url, options)) {
 			results.push(item);
 		}
 

--- a/source/types.ts
+++ b/source/types.ts
@@ -48,18 +48,18 @@ export type StrictOptions = Except<Options, 'isStream' | 'responseType' | 'resol
 export type StreamOptions = Merge<Options, {isStream?: true}>;
 type ResponseBodyOnly = {resolveBodyOnly: true};
 
-export type OptionsWithPagination<T = unknown> = Merge<Options, PaginationOptions<T>>;
+export type OptionsWithPagination<T = unknown, R = unknown> = Merge<Options, PaginationOptions<T, R>>;
 
 export interface GotPaginate {
-	<T>(url: string | URL, options?: OptionsWithPagination<T>): AsyncIterableIterator<T>;
-	all<T>(url: string | URL, options?: OptionsWithPagination<T>): Promise<T[]>;
+	<T, R = unknown>(url: string | URL, options?: OptionsWithPagination<T, R>): AsyncIterableIterator<T>;
+	all<T, R = unknown>(url: string | URL, options?: OptionsWithPagination<T, R>): Promise<T[]>;
 
 	// A bug.
 	// eslint-disable-next-line @typescript-eslint/adjacent-overload-signatures
-	<T>(options?: OptionsWithPagination<T>): AsyncIterableIterator<T>;
+	<T, R = unknown>(options?: OptionsWithPagination<T, R>): AsyncIterableIterator<T>;
 	// A bug.
 	// eslint-disable-next-line @typescript-eslint/adjacent-overload-signatures
-	all<T>(options?: OptionsWithPagination<T>): Promise<T[]>;
+	all<T, R = unknown>(options?: OptionsWithPagination<T, R>): Promise<T[]>;
 }
 
 export interface GotRequestFunction {

--- a/test/pagination.ts
+++ b/test/pagination.ts
@@ -1,6 +1,6 @@
 import {URL} from 'url';
 import test from 'ava';
-import got, {Response} from '../source';
+import got from '../source';
 import withServer, {withBodyParsingServer} from './helpers/with-server';
 import {ExtendedTestServer} from './helpers/types';
 
@@ -98,9 +98,9 @@ test('filters elements', withServer, async (t, server, got) => {
 test('parses elements', withServer, async (t, server, got) => {
 	attachHandler(server, 100);
 
-	const result = await got.paginate.all<number>('?page=100', {
+	const result = await got.paginate.all<number, string>('?page=100', {
 		pagination: {
-			transform: (response: Response) => [(response as Response<string>).body.length]
+			transform: response => [response.body.length]
 		}
 	});
 
@@ -110,9 +110,9 @@ test('parses elements', withServer, async (t, server, got) => {
 test('parses elements - async function', withServer, async (t, server, got) => {
 	attachHandler(server, 100);
 
-	const result = await got.paginate.all<number>('?page=100', {
+	const result = await got.paginate.all<number, string>('?page=100', {
 		pagination: {
-			transform: async (response: Response) => [(response as Response<string>).body.length]
+			transform: async response => [response.body.length]
 		}
 	});
 
@@ -124,7 +124,7 @@ test('custom paginate function', withServer, async (t, server, got) => {
 
 	const result = await got.paginate.all<number>({
 		pagination: {
-			paginate: (response: Response) => {
+			paginate: response => {
 				const url = new URL(response.url);
 
 				if (url.search === '?page=3') {
@@ -146,7 +146,7 @@ test('custom paginate function using allItems', withServer, async (t, server, go
 
 	const result = await got.paginate.all<number>({
 		pagination: {
-			paginate: (_response: Response, allItems: number[]) => {
+			paginate: (_response, allItems: number[]) => {
 				if (allItems.length === 2) {
 					return false;
 				}
@@ -164,7 +164,7 @@ test('custom paginate function using currentItems', withServer, async (t, server
 
 	const result = await got.paginate.all<number>({
 		pagination: {
-			paginate: (_response: Response, _allItems: number[], currentItems: number[]) => {
+			paginate: (_response, _allItems: number[], currentItems: number[]) => {
 				if (currentItems[0] === 3) {
 					return false;
 				}


### PR DESCRIPTION
When using got with TypeScript, this PR allows the `Response` generic body type to be set when using the pagination API, meaning that the `transform()` and `paginate()` functions will work without any typecasting necessary.

For example we can now do:

``` ts
interface Account {
  id: string;
  name: string;
}

interface ResponseBody {
  data: Account[];
}

const accounts = await got.paginate.all<Account, ResponseBody>(url, {
  pagination: {
    transform: response => response.body.data  // No typecasting necessary: response.body is typed as ResponseBody
  }
});
```

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] If it's a new feature, I have included documentation updates.
