### PR TITLE
Fix duplicated searchParams for pagination API

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1175,7 +1175,7 @@ Options are deeply merged to a new object. The value of each key is determined a
 	- If the parent property is a plain `object`, the parent value is deeply cloned.
 	- Otherwise, `undefined` is used.
 - If the parent value is an instance of `URLSearchParams`:
-	- If the new value is a `string`, an `object` or an instance of `URLSearchParams`, a new `URLSearchParams` instance is created. The values are merged using [`urlSearchParams.append(key, value)`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/append).
+	- If the new value is a `string`, an `object` or an instance of `URLSearchParams`, a new `URLSearchParams` instance is created. The values are merged using [`urlSearchParams.append(key, value)`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/append). The keys defined in the new value override the keys defined in the parent value.
 	- Otherwise, the only available value is `undefined`.
 - If the new property is a plain `object`:
 	- If the parent property is a plain `object` too, both values are merged recursively into a new `object`.

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -644,16 +644,17 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 					validateSearchParameters(options.searchParams);
 				}
 
-				options.searchParams = new URLSearchParams(options.searchParams as Record<string, string>);
+				const searchParameters = new URLSearchParams(options.searchParams as Record<string, string>);
 
 				// `normalizeArguments()` is also used to merge options
 				defaults?.searchParams?.forEach((value, key) => {
 					// Only use default if one isn't already defined
-					const currentSearchParameters = (options!.searchParams as URLSearchParams);
-					if (!currentSearchParameters.has(key)) {
-						currentSearchParameters.append(key, value);
+					if (!searchParameters.has(key)) {
+						searchParameters.append(key, value);
 					}
 				});
+
+				options.searchParams = searchParameters;
 			}
 		}
 

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -648,7 +648,11 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 
 				// `normalizeArguments()` is also used to merge options
 				defaults?.searchParams?.forEach((value, key) => {
-					(options!.searchParams as URLSearchParams).append(key, value);
+					// Only use default if one isn't already defined
+					const currentSearchParameters = (options!.searchParams as URLSearchParams);
+					if (!currentSearchParameters.has(key)) {
+						currentSearchParameters.append(key, value);
+					}
 				});
 			}
 		}

--- a/test/pagination.ts
+++ b/test/pagination.ts
@@ -601,7 +601,7 @@ test('pagination using extended searchParams', withServer, async (t, server, got
 		searchParams: {
 			limit: 10
 		}
-	})
+	});
 
 	const all = await client.paginate.all('', {
 		searchParams: {

--- a/test/pagination.ts
+++ b/test/pagination.ts
@@ -456,7 +456,7 @@ test('next url in json response', withServer, async (t, server, got) => {
 	]);
 });
 
-test.failing('pagiantion using searchParams', withServer, async (t, server, got) => {
+test('pagination using searchParams', withServer, async (t, server, got) => {
 	server.get('/', (request, response) => {
 		const parameters = new URLSearchParams(request.url.slice(2));
 		const page = Number(parameters.get('page') ?? 0);
@@ -503,5 +503,61 @@ test.failing('pagiantion using searchParams', withServer, async (t, server, got)
 		'/?page=1',
 		'/?page=2',
 		'/?page=3'
+	]);
+});
+
+test('pagination using extended searchParams', withServer, async (t, server, got) => {
+	server.get('/', (request, response) => {
+		const parameters = new URLSearchParams(request.url.slice(2));
+		const page = Number(parameters.get('page') ?? 0);
+
+		response.end(JSON.stringify({
+			currentUrl: request.url,
+			next: page < 3
+		}));
+	});
+
+	interface Page {
+		currentUrl: string;
+		next?: string;
+	}
+
+	const client = got.extend({
+		searchParams: {
+			limit: 10
+		}
+	})
+
+	const all = await client.paginate.all('', {
+		searchParams: {
+			page: 0
+		},
+		responseType: 'json',
+		pagination: {
+			transform: (response: Response<Page>) => {
+				return [response.body.currentUrl];
+			},
+			paginate: (response: Response<Page>) => {
+				const {next} = response.body;
+				const previousPage = Number(response.request.options.searchParams!.get('page'));
+
+				if (!next) {
+					return false;
+				}
+
+				return {
+					searchParams: {
+						page: previousPage + 1
+					}
+				};
+			}
+		}
+	});
+
+	t.deepEqual(all, [
+		'/?page=0&limit=10',
+		'/?page=1&limit=10',
+		'/?page=2&limit=10',
+		'/?page=3&limit=10'
 	]);
 });


### PR DESCRIPTION
#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] If it's a new feature, I have included documentation updates.

As described in [this comment](https://github.com/sindresorhus/got/issues/1052#issuecomment-619969689), when using the pagination API searchParams are being erroneously duplicated.

This PR attempts to fix this problem by first checking for the existance of a searchParam before setting the default (or previous one, in the case of the pagination API).

A test case was also added to check that this works for default searchParams included using `got.extend`.