### PR TITLE
Do not use deprecated `request.abort()`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - '14'
   - '13'
   - '12'
   - '10'

--- a/readme.md
+++ b/readme.md
@@ -921,7 +921,7 @@ Returns a [duplex stream](https://nodejs.org/api/stream.html#stream_class_stream
 
 ```js
 got.stream('https://github.com')
-	.on('request', request => setTimeout(() => request.close(), 50));
+	.on('request', request => setTimeout(() => request.destroy(), 50));
 ```
 
 ##### .on('response', response)

--- a/readme.md
+++ b/readme.md
@@ -921,7 +921,7 @@ Returns a [duplex stream](https://nodejs.org/api/stream.html#stream_class_stream
 
 ```js
 got.stream('https://github.com')
-	.on('request', request => setTimeout(() => request.abort(), 50));
+	.on('request', request => setTimeout(() => request.close(), 50));
 ```
 
 ##### .on('response', response)

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -1489,7 +1489,7 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 	}
 
 	get aborted(): boolean {
-		return Boolean(this[kRequest]?.aborted);
+		return Boolean(this[kRequest]?.destroyed);
 	}
 
 	get socket(): Socket | undefined {

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -1475,8 +1475,7 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 
 			// TODO: Remove the next `if` when these get fixed:
 			// - https://github.com/nodejs/node/issues/32851
-			// - https://github.com/nock/nock/issues/1981
-			if (!this[kResponse]?.complete && !this[kRequest]!.destroyed) {
+			if (!this[kResponse]?.complete) {
 				this[kRequest]!.destroy();
 			}
 		}

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -437,7 +437,6 @@ export class UnsupportedProtocolError extends RequestError {
 
 const proxiedRequestEvents = [
 	'socket',
-	'abort',
 	'connect',
 	'continue',
 	'information',
@@ -549,7 +548,7 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 				await this._makeRequest();
 
 				if (this.destroyed) {
-					this[kRequest]?.abort();
+					this[kRequest]?.destroy();
 					return;
 				}
 
@@ -1474,7 +1473,7 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 			// - https://github.com/nodejs/node/issues/32851
 			// - https://github.com/nock/nock/issues/1981
 			if (!this[kResponse]?.complete && !this[kRequest]!.destroyed) {
-				this[kRequest]!.abort();
+				this[kRequest]!.destroy();
 			}
 		}
 

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -566,7 +566,10 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 					return;
 				}
 
-				this.destroy(error);
+				// This is a workaround for https://github.com/nodejs/node/issues/33335
+				if (!this.destroyed) {
+					this.destroy(error);
+				}
 			}
 		})(options);
 	}
@@ -1372,7 +1375,10 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 			error = new RequestError(error_.message, error_, this);
 		}
 
-		this.destroy(error);
+		// This is a workaround for https://github.com/nodejs/node/issues/33335
+		if (!this.destroyed) {
+			this.destroy(error);
+		}
 	}
 
 	_read(): void {

--- a/source/core/utils/timed-out.ts
+++ b/source/core/utils/timed-out.ts
@@ -89,7 +89,7 @@ export default (request: ClientRequest, delays: Delays, options: TimedOutOptions
 		}
 	});
 
-	request.once('abort', cancelTimeouts);
+	request.once('close', cancelTimeouts);
 
 	once(request, 'response', (response: IncomingMessage): void => {
 		once(response, 'end', cancelTimeouts);

--- a/test/stream.ts
+++ b/test/stream.ts
@@ -273,16 +273,16 @@ test('proxies `content-encoding` header when `options.decompress` is false', wit
 	t.is(headers['content-encoding'], 'gzip');
 });
 
-test('destroying got.stream() cancels the request - `request` event', withServer, async (t, server, got) => {
+test('destroying got.stream() destroys the request - `request` event', withServer, async (t, server, got) => {
 	server.get('/', defaultHandler);
 
 	const stream = got.stream('');
 	const request = await pEvent(stream, 'request');
 	stream.destroy();
-	t.truthy(request.aborted);
+	t.truthy(request.destroyed);
 });
 
-test('destroying got.stream() cancels the request - `response` event', withServer, async (t, server, got) => {
+test('destroying got.stream() destroys the request - `response` event', withServer, async (t, server, got) => {
 	server.get('/', (_request, response) => {
 		response.write('hello');
 	});
@@ -291,7 +291,7 @@ test('destroying got.stream() cancels the request - `response` event', withServe
 	const request = await pEvent(stream, 'request');
 	await pEvent(stream, 'response');
 	stream.destroy();
-	t.truthy(request.aborted);
+	t.truthy(request.destroyed);
 });
 
 test('piping to got.stream.put()', withServer, async (t, server, got) => {

--- a/test/stream.ts
+++ b/test/stream.ts
@@ -273,26 +273,31 @@ test('proxies `content-encoding` header when `options.decompress` is false', wit
 	t.is(headers['content-encoding'], 'gzip');
 });
 
-test('destroying got.stream() destroys the request - `request` event', withServer, async (t, server, got) => {
-	server.get('/', defaultHandler);
+{
+	const nodejsMajorVersion = Number(process.versions.node.split('.')[0]);
+	const testFn = nodejsMajorVersion < 14 ? test.failing : test;
 
-	const stream = got.stream('');
-	const request = await pEvent(stream, 'request');
-	stream.destroy();
-	t.truthy(request.destroyed);
-});
+	testFn('destroying got.stream() destroys the request - `request` event', withServer, async (t, server, got) => {
+		server.get('/', defaultHandler);
 
-test('destroying got.stream() destroys the request - `response` event', withServer, async (t, server, got) => {
-	server.get('/', (_request, response) => {
-		response.write('hello');
+		const stream = got.stream('');
+		const request = await pEvent(stream, 'request');
+		stream.destroy();
+		t.truthy(request.destroyed);
 	});
 
-	const stream = got.stream('');
-	const request = await pEvent(stream, 'request');
-	await pEvent(stream, 'response');
-	stream.destroy();
-	t.truthy(request.destroyed);
-});
+	testFn('destroying got.stream() destroys the request - `response` event', withServer, async (t, server, got) => {
+		server.get('/', (_request, response) => {
+			response.write('hello');
+		});
+
+		const stream = got.stream('');
+		const request = await pEvent(stream, 'request');
+		await pEvent(stream, 'response');
+		stream.destroy();
+		t.truthy(request.destroyed);
+	});
+}
 
 test('piping to got.stream.put()', withServer, async (t, server, got) => {
 	server.get('/', defaultHandler);


### PR DESCRIPTION
#### Checklist

- [x] I have read the documentation.
- [x] I have included some tests.

Fixes #1216 