### PR TITLE
Clarify docs for got.HTTPError

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1298,13 +1298,11 @@ When reading from response stream fails.
 
 #### got.ParseError
 
-> *ok*: 2xx or 304, and includes other 3xx if `options.followRedirect` is set
-
-When server response code is ***ok***, and parsing body fails. Includes a `response` property.
+When server response code is 2xx, and parsing body fails. Includes a `response` property.
 
 #### got.HTTPError
 
-When the server response code is not ***ok***. Includes a `response` property.
+When the server response code is not 2xx nor 3xx if `options.followRedirect` is `true`, but always except for 304. Includes a `response` property.
 
 #### got.MaxRedirectsError
 

--- a/readme.md
+++ b/readme.md
@@ -523,7 +523,7 @@ const got = require('got');
 Type: `boolean`\
 Default: `true`
 
-Determines if a [`got.HTTPError`](#gothttperror) is thrown for error responses.
+Determines if a [`got.HTTPError`](#gothttperror) is thrown for unsuccessful responses.
 
 If this is disabled, requests that encounter an error status code will be resolved with the `response` instead of throwing. This may be useful if you are checking for resource availability and are expecting error responses.
 

--- a/readme.md
+++ b/readme.md
@@ -523,7 +523,7 @@ const got = require('got');
 Type: `boolean`\
 Default: `true`
 
-Determines if a `got.HTTPError` is thrown for error responses (non-2xx status codes).
+Determines if a [`got.HTTPError`](#gothttperror) is thrown for error responses.
 
 If this is disabled, requests that encounter an error status code will be resolved with the `response` instead of throwing. This may be useful if you are checking for resource availability and are expecting error responses.
 
@@ -1298,11 +1298,13 @@ When reading from response stream fails.
 
 #### got.ParseError
 
-When server response code is 2xx, and parsing body fails. Includes a `response` property.
+> *ok*: 2xx or 304, and includes other 3xx if `options.followRedirect` is set
+
+When server response code is ***ok***, and parsing body fails. Includes a `response` property.
 
 #### got.HTTPError
 
-When the server response code is not 2xx. Includes a `response` property.
+When the server response code is not ***ok***. Includes a `response` property.
 
 #### got.MaxRedirectsError
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates.

Closed #1213. The preview is as following, and note that the anchor is a relative link so it doesn't work here but doesn't matter in fact.

----

Determines if a [`got.HTTPError`](#gothttperror) is thrown for error responses.

#### got.ParseError

> *ok*: 2xx or 304, and includes other 3xx if `options.followRedirect` is set

When server response code is ***ok***, and parsing body fails. Includes a `response` property.

#### got.HTTPError

When the server response code is not ***ok***. Includes a `response` property.