### PR TITLE
Don't force query string normalization

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -139,6 +139,13 @@ Properties from `options` will override properties in the parsed `url`.
 
 If no protocol is specified, it will throw a `TypeError`.
 
+**Note:** The query string is **not** parsed as search params. Example:
+
+```
+got('https://example.com/?query=a b'); //=> https://example.com/?query=a%20b
+got('https://example.com/', {searchParams: {query: 'a b'}}); //=> https://example.com/?query=a+b
+```
+
 ##### options
 
 Type: `object`

--- a/readme.md
+++ b/readme.md
@@ -144,6 +144,9 @@ If no protocol is specified, it will throw a `TypeError`.
 ```
 got('https://example.com/?query=a b'); //=> https://example.com/?query=a%20b
 got('https://example.com/', {searchParams: {query: 'a b'}}); //=> https://example.com/?query=a+b
+
+// The query string is overridden by `searchParams`
+got('https://example.com/?query=a b', {searchParams: {query: 'a b'}}); //=> https://example.com/?query=a+b
 ```
 
 ##### options

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -726,11 +726,6 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 				options.url.search = options.searchParams.toString();
 			}
 
-			// Trigger search params normalization
-			if (options.url.search) {
-				options.url.search = decodeURIComponent(options.url.search.toString());
-			}
-
 			// Protocol check
 			if (protocol !== 'http:' && protocol !== 'https:') {
 				throw new UnsupportedProtocolError(options as NormalizedOptions);
@@ -1069,9 +1064,8 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 				const redirectBuffer = Buffer.from(response.headers.location, 'binary').toString();
 
 				// Handles invalid URLs. See https://github.com/sindresorhus/got/issues/604
-				const redirectUrl = new URL(redirectBuffer, url);
+				const redirectUrl = new URL(decodeURI(redirectBuffer), url);
 				const redirectString = redirectUrl.toString();
-				decodeURI(redirectString);
 
 				// Redirecting to a different site, clear sensitive data.
 				if (redirectUrl.hostname !== url.hostname) {

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -1067,7 +1067,7 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 				const redirectUrl = new URL(redirectBuffer, url);
 				const redirectString = redirectUrl.toString();
 				decodeURI(redirectString);
-				
+
 				// Redirecting to a different site, clear sensitive data.
 				if (redirectUrl.hostname !== url.hostname) {
 					if ('host' in options.headers) {

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -728,10 +728,7 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 
 			// Trigger search params normalization
 			if (options.url.search) {
-				const triggerSearchParameters = '_GOT_INTERNAL_TRIGGER_NORMALIZATION';
-
-				options.url.searchParams.append(triggerSearchParameters, '');
-				options.url.searchParams.delete(triggerSearchParameters);
+				options.url.search = decodeURIComponent(options.url.search.toString());
 			}
 
 			// Protocol check
@@ -1068,8 +1065,10 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 			}
 
 			try {
-				// Handles invalid URLs. See https://github.com/sindresorhus/got/issues/604
+				// Do not remove. See https://github.com/sindresorhus/got/pull/214
 				const redirectBuffer = Buffer.from(response.headers.location, 'binary').toString();
+
+				// Handles invalid URLs. See https://github.com/sindresorhus/got/issues/604
 				const redirectUrl = new URL(redirectBuffer, url);
 				const redirectString = redirectUrl.toString();
 				decodeURI(redirectString);

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -1064,9 +1064,10 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 				const redirectBuffer = Buffer.from(response.headers.location, 'binary').toString();
 
 				// Handles invalid URLs. See https://github.com/sindresorhus/got/issues/604
-				const redirectUrl = new URL(decodeURI(redirectBuffer), url);
+				const redirectUrl = new URL(redirectBuffer, url);
 				const redirectString = redirectUrl.toString();
-
+				decodeURI(redirectString);
+				
 				// Redirecting to a different site, clear sensitive data.
 				if (redirectUrl.hostname !== url.hostname) {
 					if ('host' in options.headers) {

--- a/test/arguments.ts
+++ b/test/arguments.ts
@@ -55,7 +55,7 @@ test('throws an error if the protocol is not specified', async t => {
 	});
 });
 
-test('properly encodes search params', withServer, async (t, server, got) => {
+test('properly encodes query string', withServer, async (t, server, got) => {
 	server.get('/', echoUrl);
 
 	const path = '?test=http://example.com?foo=bar';

--- a/test/arguments.ts
+++ b/test/arguments.ts
@@ -55,12 +55,12 @@ test('throws an error if the protocol is not specified', async t => {
 	});
 });
 
-test('string url with searchParams is preserved', withServer, async (t, server, got) => {
+test('properly encodes search params', withServer, async (t, server, got) => {
 	server.get('/', echoUrl);
 
 	const path = '?test=http://example.com?foo=bar';
 	const {body} = await got(path);
-	t.is(body, '/?test=http%3A%2F%2Fexample.com%3Ffoo%3Dbar');
+	t.is(body, '/?test=http://example.com?foo=bar');
 });
 
 test('options are optional', withServer, async (t, server, got) => {
@@ -474,7 +474,7 @@ test('normalizes search params included in input', t => {
 		url: new URL('https://example.com/?a=b c')
 	});
 
-	t.is(url.search, '?a=b+c');
+	t.is(url.search, '?a=b%20c');
 });
 
 test('normalizes search params included in options', t => {

--- a/test/arguments.ts
+++ b/test/arguments.ts
@@ -469,7 +469,7 @@ test('does not throw on frozen options', withServer, async (t, server, got) => {
 	t.is(body, '/');
 });
 
-test('normalizes search params included in input', t => {
+test('encodes query string included in input', t => {
 	const {url} = got.mergeOptions({
 		url: new URL('https://example.com/?a=b c')
 	});


### PR DESCRIPTION
It assumes that the query speicified in the input is not `URLSearchParams` unless the `searchParams` option is present.

~The search params are correctly normalized via `decodeURIComponent` (I spent 30 mins reading stackoverflow and exeprimenting by myself, I'm pretty sure that's the correct one).~ The WHATWG URL handles it, what I need is just `decodeURI` before parsing the `location` header.

Fixes #1234

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates.
