### PR TITLE
Migrate from `lolex` to `@sinonjs/fake-timers`

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
 	"devDependencies": {
 		"@ava/typescript": "^1.1.1",
 		"@sindresorhus/tsconfig": "^0.7.0",
+		"@sinonjs/fake-timers": "^6.0.1",
 		"@types/benchmark": "^1.0.31",
 		"@types/express": "^4.17.6",
-		"@types/lolex": "^5.1.0",
 		"@types/node": "^13.13.4",
 		"@types/node-fetch": "^2.5.5",
 		"@types/request": "^2.48.4",
@@ -76,7 +76,6 @@
 		"delay": "^4.3.0",
 		"express": "^4.17.1",
 		"form-data": "^3.0.0",
-		"lolex": "^6.0.0",
 		"nock": "^12.0.0",
 		"node-fetch": "^2.6.0",
 		"np": "^6.0.0",

--- a/test/cancel.ts
+++ b/test/cancel.ts
@@ -9,7 +9,7 @@ import {Handler} from 'express';
 import got, {CancelError} from '../source';
 import slowDataStream from './helpers/slow-data-stream';
 import {ExtendedTestServer, GlobalClock} from './helpers/types';
-import withServer, {withServerAndLolex} from './helpers/with-server';
+import withServer, {withServerAndFakeTimers} from './helpers/with-server';
 
 const prepareServer = (server: ExtendedTestServer, clock: GlobalClock): {emitter: EventEmitter; promise: Promise<unknown>} => {
 	const emitter = new EventEmitter();
@@ -56,7 +56,7 @@ const downloadHandler = (clock: GlobalClock): Handler => (_request, response) =>
 	);
 };
 
-test.serial('does not retry after cancelation', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('does not retry after cancelation', withServerAndFakeTimers, async (t, server, got, clock) => {
 	const {emitter, promise} = prepareServer(server, clock);
 
 	const gotPromise = got('redirect', {
@@ -101,7 +101,7 @@ test.serial('cleans up request timeouts', withServer, async (t, server, got) => 
 	await delay(40);
 });
 
-test.serial('cancels in-progress request', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('cancels in-progress request', withServerAndFakeTimers, async (t, server, got, clock) => {
 	const {emitter, promise} = prepareServer(server, clock);
 
 	const body = new ReadableStream({
@@ -121,7 +121,7 @@ test.serial('cancels in-progress request', withServerAndLolex, async (t, server,
 	await t.notThrowsAsync(promise, 'Request finished instead of aborting.');
 });
 
-test.serial('cancels in-progress request with timeout', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('cancels in-progress request with timeout', withServerAndFakeTimers, async (t, server, got, clock) => {
 	const {emitter, promise} = prepareServer(server, clock);
 
 	const body = new ReadableStream({
@@ -141,7 +141,7 @@ test.serial('cancels in-progress request with timeout', withServerAndLolex, asyn
 	await t.notThrowsAsync(promise, 'Request finished instead of aborting.');
 });
 
-test.serial('cancel immediately', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('cancel immediately', withServerAndFakeTimers, async (t, server, got, clock) => {
 	const promise = new Promise((resolve, reject) => {
 		// We won't get an abort or even a connection
 		// We assume no request within 1000ms equals a (client side) aborted request
@@ -193,7 +193,7 @@ test('recover from cancellation using error instance', async t => {
 	await t.notThrowsAsync(recover);
 });
 
-test.serial('throws on incomplete (canceled) response - promise', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('throws on incomplete (canceled) response - promise', withServerAndFakeTimers, async (t, server, got, clock) => {
 	server.get('/', downloadHandler(clock));
 
 	await t.throwsAsync(
@@ -205,7 +205,7 @@ test.serial('throws on incomplete (canceled) response - promise', withServerAndL
 	);
 });
 
-test.serial('throws on incomplete (canceled) response - promise #2', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('throws on incomplete (canceled) response - promise #2', withServerAndFakeTimers, async (t, server, got, clock) => {
 	server.get('/', downloadHandler(clock));
 
 	const promise = got('').on('response', () => {
@@ -216,7 +216,7 @@ test.serial('throws on incomplete (canceled) response - promise #2', withServerA
 	await t.throwsAsync(promise, {instanceOf: got.CancelError});
 });
 
-test.serial('throws on incomplete (canceled) response - stream', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('throws on incomplete (canceled) response - stream', withServerAndFakeTimers, async (t, server, got, clock) => {
 	server.get('/', downloadHandler(clock));
 
 	const errorString = 'Foobar';

--- a/test/helpers/slow-data-stream.ts
+++ b/test/helpers/slow-data-stream.ts
@@ -1,5 +1,5 @@
 import {Readable} from 'stream';
-import {Clock} from 'lolex';
+import {Clock} from '@sinonjs/fake-timers';
 
 export default (clock: Clock): Readable => {
 	let i = 0;

--- a/test/helpers/types.ts
+++ b/test/helpers/types.ts
@@ -1,6 +1,6 @@
 import {Server} from 'http';
 import {TestServer} from 'create-test-server';
-import * as lolex from 'lolex';
+import * as FakeTimers from '@sinonjs/fake-timers';
 import {Got} from '../../source';
 
 export interface ExtendedGot extends Got {
@@ -16,5 +16,5 @@ export interface ExtendedTestServer extends TestServer {
 	sslHostname: string;
 }
 
-export type InstalledClock = ReturnType<typeof lolex.install>;
-export type GlobalClock = InstalledClock | lolex.NodeClock;
+export type InstalledClock = ReturnType<typeof FakeTimers.install>;
+export type GlobalClock = InstalledClock | FakeTimers.NodeClock;

--- a/test/helpers/with-server.ts
+++ b/test/helpers/with-server.ts
@@ -4,7 +4,7 @@ import is from '@sindresorhus/is';
 import http = require('http');
 import tempy = require('tempy');
 import createTestServer = require('create-test-server');
-import lolex = require('lolex');
+import FakeTimers = require('@sinonjs/fake-timers');
 import got, {InstanceDefaults} from '../../source';
 import {ExtendedGot, ExtendedHttpServer, ExtendedTestServer, GlobalClock, InstalledClock} from './types';
 
@@ -12,7 +12,7 @@ export type RunTestWithServer = (t: test.ExecutionContext, server: ExtendedTestS
 export type RunTestWithSocket = (t: test.ExecutionContext, server: ExtendedHttpServer) => Promise<void> | void;
 
 const generateHook = ({install, options: testServerOptions}: {install?: boolean; options?: unknown}): test.Macro<[RunTestWithServer]> => async (t, run) => {
-	const clock: GlobalClock = install ? lolex.install() : lolex.createClock();
+	const clock = install ? FakeTimers.install() : FakeTimers.createClock() as GlobalClock;
 
 	// Re-enable body parsing to investigate https://github.com/sindresorhus/got/issues/1186
 	const server = await createTestServer(is.plainObject(testServerOptions) ? testServerOptions : {
@@ -60,7 +60,7 @@ const generateHook = ({install, options: testServerOptions}: {install?: boolean;
 export const withBodyParsingServer = generateHook({install: false, options: {}});
 export default generateHook({install: false});
 
-export const withServerAndLolex = generateHook({install: true});
+export const withServerAndFakeTimers = generateHook({install: true});
 
 // TODO: remove this when `create-test-server` supports custom listen
 export const withSocketServer: test.Macro<[RunTestWithSocket]> = async (t, run) => {

--- a/test/timeout.ts
+++ b/test/timeout.ts
@@ -14,7 +14,7 @@ import got, {TimeoutError} from '../source';
 import timedOut from '../source/core/utils/timed-out';
 import slowDataStream from './helpers/slow-data-stream';
 import {GlobalClock} from './helpers/types';
-import withServer, {withServerAndLolex} from './helpers/with-server';
+import withServer, {withServerAndFakeTimers} from './helpers/with-server';
 
 const pStreamPipeline = promisify(stream.pipeline);
 
@@ -48,7 +48,7 @@ const downloadHandler = (clock: GlobalClock): Handler => (_request, response) =>
 	});
 };
 
-test.serial('timeout option', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('timeout option', withServerAndFakeTimers, async (t, server, got, clock) => {
 	server.get('/', defaultHandler(clock));
 
 	await t.throwsAsync(
@@ -63,7 +63,7 @@ test.serial('timeout option', withServerAndLolex, async (t, server, got, clock) 
 	);
 });
 
-test.serial('timeout option as object', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('timeout option as object', withServerAndFakeTimers, async (t, server, got, clock) => {
 	server.get('/', defaultHandler(clock));
 
 	await t.throwsAsync(
@@ -105,7 +105,7 @@ test.serial('socket timeout', async t => {
 	);
 });
 
-test.serial('send timeout', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('send timeout', withServerAndFakeTimers, async (t, server, got, clock) => {
 	server.post('/', defaultHandler(clock));
 
 	await t.throwsAsync(
@@ -127,7 +127,7 @@ test.serial('send timeout', withServerAndLolex, async (t, server, got, clock) =>
 	);
 });
 
-test.serial('send timeout (keepalive)', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('send timeout (keepalive)', withServerAndFakeTimers, async (t, server, got, clock) => {
 	server.post('/', defaultHandler(clock));
 	server.get('/prime', (_request, response) => {
 		response.end('ok');
@@ -159,7 +159,7 @@ test.serial('send timeout (keepalive)', withServerAndLolex, async (t, server, go
 	);
 });
 
-test.serial('response timeout', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('response timeout', withServerAndFakeTimers, async (t, server, got, clock) => {
 	server.get('/', defaultHandler(clock));
 
 	await t.throwsAsync(
@@ -174,7 +174,7 @@ test.serial('response timeout', withServerAndLolex, async (t, server, got, clock
 	);
 });
 
-test.serial('response timeout unaffected by slow upload', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('response timeout unaffected by slow upload', withServerAndFakeTimers, async (t, server, got, clock) => {
 	server.post('/', defaultHandler(clock));
 
 	await t.notThrowsAsync(got.post({
@@ -183,7 +183,7 @@ test.serial('response timeout unaffected by slow upload', withServerAndLolex, as
 	}));
 });
 
-test.serial('response timeout unaffected by slow download', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('response timeout unaffected by slow download', withServerAndFakeTimers, async (t, server, got, clock) => {
 	server.get('/', downloadHandler(clock));
 
 	await t.notThrowsAsync(got({
@@ -194,7 +194,7 @@ test.serial('response timeout unaffected by slow download', withServerAndLolex, 
 	clock.tick(100);
 });
 
-test.serial('response timeout (keepalive)', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('response timeout (keepalive)', withServerAndFakeTimers, async (t, server, got, clock) => {
 	server.get('/', defaultHandler(clock));
 	server.get('/prime', (_request, response) => {
 		response.end('ok');
@@ -223,7 +223,7 @@ test.serial('response timeout (keepalive)', withServerAndLolex, async (t, server
 	});
 });
 
-test.serial('connect timeout', withServerAndLolex, async (t, _server, got, clock) => {
+test.serial('connect timeout', withServerAndFakeTimers, async (t, _server, got, clock) => {
 	await t.throwsAsync(
 		got({
 			createConnection: options => {
@@ -249,7 +249,7 @@ test.serial('connect timeout', withServerAndLolex, async (t, _server, got, clock
 	);
 });
 
-test.serial('connect timeout (ip address)', withServerAndLolex, async (t, _server, got, clock) => {
+test.serial('connect timeout (ip address)', withServerAndFakeTimers, async (t, _server, got, clock) => {
 	await t.throwsAsync(
 		got({
 			url: 'http://127.0.0.1',
@@ -274,7 +274,7 @@ test.serial('connect timeout (ip address)', withServerAndLolex, async (t, _serve
 	);
 });
 
-test.serial('secureConnect timeout', withServerAndLolex, async (t, _server, got, clock) => {
+test.serial('secureConnect timeout', withServerAndFakeTimers, async (t, _server, got, clock) => {
 	await t.throwsAsync(
 		got.secure({
 			createConnection: options => {
@@ -316,7 +316,7 @@ test('secureConnect timeout not breached', withServer, async (t, server, got) =>
 	}));
 });
 
-test.serial('lookup timeout', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('lookup timeout', withServerAndFakeTimers, async (t, server, got, clock) => {
 	server.get('/', defaultHandler(clock));
 
 	await t.throwsAsync(
@@ -337,7 +337,7 @@ test.serial('lookup timeout', withServerAndLolex, async (t, server, got, clock) 
 	);
 });
 
-test.serial('lookup timeout no error (ip address)', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('lookup timeout no error (ip address)', withServerAndFakeTimers, async (t, server, got, clock) => {
 	server.get('/', defaultHandler(clock));
 
 	await t.notThrowsAsync(got({
@@ -348,7 +348,7 @@ test.serial('lookup timeout no error (ip address)', withServerAndLolex, async (t
 	}));
 });
 
-test.serial('lookup timeout no error (keepalive)', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('lookup timeout no error (keepalive)', withServerAndFakeTimers, async (t, server, got, clock) => {
 	server.get('/', defaultHandler(clock));
 	server.get('/prime', (_request, response) => {
 		response.end('ok');
@@ -392,7 +392,7 @@ test.serial('retries on timeout', withServer, async (t, server, got) => {
 	t.true(hasTried);
 });
 
-test.serial('timeout with streams', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('timeout with streams', withServerAndFakeTimers, async (t, server, got, clock) => {
 	server.get('/', defaultHandler(clock));
 
 	const stream = got.stream({
@@ -402,7 +402,7 @@ test.serial('timeout with streams', withServerAndLolex, async (t, server, got, c
 	await t.throwsAsync(pEvent(stream, 'response'), {code: 'ETIMEDOUT'});
 });
 
-test.serial('no error emitted when timeout is not breached (stream)', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('no error emitted when timeout is not breached (stream)', withServerAndFakeTimers, async (t, server, got, clock) => {
 	server.get('/', defaultHandler(clock));
 
 	const stream = got.stream({
@@ -415,7 +415,7 @@ test.serial('no error emitted when timeout is not breached (stream)', withServer
 	await t.notThrowsAsync(getStream(stream));
 });
 
-test.serial('no error emitted when timeout is not breached (promise)', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('no error emitted when timeout is not breached (promise)', withServerAndFakeTimers, async (t, server, got, clock) => {
 	server.get('/', defaultHandler(clock));
 
 	await t.notThrowsAsync(got({
@@ -426,7 +426,7 @@ test.serial('no error emitted when timeout is not breached (promise)', withServe
 	}));
 });
 
-test.serial('no unhandled `socket hung up` errors', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('no unhandled `socket hung up` errors', withServerAndFakeTimers, async (t, server, got, clock) => {
 	server.get('/', defaultHandler(clock));
 
 	await t.throwsAsync(
@@ -435,7 +435,7 @@ test.serial('no unhandled `socket hung up` errors', withServerAndLolex, async (t
 	);
 });
 
-// TODO: use lolex here
+// TODO: use fakeTimers here
 test.serial('no unhandled timeout errors', withServer, async (t, _server, got) => {
 	await t.throwsAsync(got({
 		retry: 0,
@@ -455,7 +455,7 @@ test.serial('no unhandled timeout errors', withServer, async (t, _server, got) =
 	await delay(200);
 });
 
-// TODO: use lolex here
+// TODO: use fakeTimers here
 test.serial('no unhandled timeout errors #2', withServer, async (t, server, got) => {
 	server.get('/', (_request, response) => {
 		response.write('Hello world!');
@@ -528,7 +528,7 @@ test.serial('no more timeouts after an error', withServer, async (t, _server, go
 	global.clearTimeout = clearTimeout;
 });
 
-test.serial('socket timeout is canceled on error', withServerAndLolex, async (t, _server, got, clock) => {
+test.serial('socket timeout is canceled on error', withServerAndFakeTimers, async (t, _server, got, clock) => {
 	const message = 'oh, snap!';
 
 	const promise = got({
@@ -544,7 +544,7 @@ test.serial('socket timeout is canceled on error', withServerAndLolex, async (t,
 	clock.tick(100);
 });
 
-test.serial('no memory leak when using socket timeout and keepalive agent', withServerAndLolex, async (t, server, got, clock) => {
+test.serial('no memory leak when using socket timeout and keepalive agent', withServerAndFakeTimers, async (t, server, got, clock) => {
 	server.get('/', defaultHandler(clock));
 
 	let request: any;
@@ -592,7 +592,7 @@ test('double calling timedOut has no effect', t => {
 	t.is(emitter.listenerCount('socket'), 1);
 });
 
-test.serial('doesn\'t throw on early lookup', withServerAndLolex, async (t, server, got) => {
+test.serial('doesn\'t throw on early lookup', withServerAndFakeTimers, async (t, server, got) => {
 	server.get('/', (_request, response) => {
 		response.end('ok');
 	});
@@ -614,7 +614,7 @@ test.serial('doesn\'t throw on early lookup', withServerAndLolex, async (t, serv
 	}));
 });
 
-// TODO: use lolex here
+// TODO: use fakeTimers here
 test.serial('no unhandled `Premature close` error', withServer, async (t, server, got) => {
 	server.get('/', async (_request, response) => {
 		response.write('hello');
@@ -628,7 +628,7 @@ test.serial('no unhandled `Premature close` error', withServer, async (t, server
 	await delay(20);
 });
 
-// TODO: use lolex here
+// TODO: use fakeTimers here
 test.serial('cancelling the request removes timeouts', withServer, async (t, server, got) => {
 	server.get('/', (_request, response) => {
 		response.write('hello');


### PR DESCRIPTION
As stated by the NPM page of lolex

> lolex has been renamed to @sinonjs/fake-timers. No API changes made. Please use the new package instead

Note: the `lolex` package is no longer updated (stuck at v6.0.0).

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
