### PR TITLE
Provide an overload for unknown `responseType`

### DIFF
--- a/source/types.ts
+++ b/source/types.ts
@@ -44,7 +44,7 @@ export interface ExtendOptions extends Options {
 export type OptionsOfTextResponseBody = Merge<Options, {isStream?: false; resolveBodyOnly?: false; responseType?: 'text'}>;
 export type OptionsOfJSONResponseBody = Merge<Options, {isStream?: false; resolveBodyOnly?: false; responseType?: 'json'}>;
 export type OptionsOfBufferResponseBody = Merge<Options, {isStream?: false; resolveBodyOnly?: false; responseType: 'buffer'}>;
-export type OptionsOfResponseBody = Merge<Options, {isStream?: false; resolveBodyOnly?: false}>;
+export type OptionsOfUnknownResponseBody = Merge<Options, {isStream?: false; resolveBodyOnly?: false}>;
 export type StrictOptions = Except<Options, 'isStream' | 'responseType' | 'resolveBodyOnly'>;
 export type StreamOptions = Merge<Options, {isStream?: true}>;
 type ResponseBodyOnly = {resolveBodyOnly: true};
@@ -67,12 +67,12 @@ export interface GotRequestFunction {
 	(url: string | URL, options?: OptionsOfTextResponseBody): CancelableRequest<Response<string>>;
 	<T>(url: string | URL, options?: OptionsOfJSONResponseBody): CancelableRequest<Response<T>>;
 	(url: string | URL, options?: OptionsOfBufferResponseBody): CancelableRequest<Response<Buffer>>;
-	(url: string | URL, options?: OptionsOfResponseBody): CancelableRequest<Response>;
+	(url: string | URL, options?: OptionsOfUnknownResponseBody): CancelableRequest<Response>;
 
 	(options: OptionsOfTextResponseBody): CancelableRequest<Response<string>>;
 	<T>(options: OptionsOfJSONResponseBody): CancelableRequest<Response<T>>;
 	(options: OptionsOfBufferResponseBody): CancelableRequest<Response<Buffer>>;
-	(options: OptionsOfResponseBody): CancelableRequest<Response>;
+	(options: OptionsOfUnknownResponseBody): CancelableRequest<Response>;
 
 	// `resolveBodyOnly` usage
 	(url: string | URL, options?: (Merge<OptionsOfTextResponseBody, ResponseBodyOnly>)): CancelableRequest<string>;

--- a/source/types.ts
+++ b/source/types.ts
@@ -44,6 +44,7 @@ export interface ExtendOptions extends Options {
 export type OptionsOfTextResponseBody = Merge<Options, {isStream?: false; resolveBodyOnly?: false; responseType?: 'text'}>;
 export type OptionsOfJSONResponseBody = Merge<Options, {isStream?: false; resolveBodyOnly?: false; responseType?: 'json'}>;
 export type OptionsOfBufferResponseBody = Merge<Options, {isStream?: false; resolveBodyOnly?: false; responseType: 'buffer'}>;
+export type OptionsOfResponseBody = Merge<Options, {isStream?: false; resolveBodyOnly?: false}>;
 export type StrictOptions = Except<Options, 'isStream' | 'responseType' | 'resolveBodyOnly'>;
 export type StreamOptions = Merge<Options, {isStream?: true}>;
 type ResponseBodyOnly = {resolveBodyOnly: true};
@@ -66,10 +67,12 @@ export interface GotRequestFunction {
 	(url: string | URL, options?: OptionsOfTextResponseBody): CancelableRequest<Response<string>>;
 	<T>(url: string | URL, options?: OptionsOfJSONResponseBody): CancelableRequest<Response<T>>;
 	(url: string | URL, options?: OptionsOfBufferResponseBody): CancelableRequest<Response<Buffer>>;
+	(url: string | URL, options?: OptionsOfResponseBody): CancelableRequest<Response>;
 
 	(options: OptionsOfTextResponseBody): CancelableRequest<Response<string>>;
 	<T>(options: OptionsOfJSONResponseBody): CancelableRequest<Response<T>>;
 	(options: OptionsOfBufferResponseBody): CancelableRequest<Response<Buffer>>;
+	(options: OptionsOfResponseBody): CancelableRequest<Response>;
 
 	// `resolveBodyOnly` usage
 	(url: string | URL, options?: (Merge<OptionsOfTextResponseBody, ResponseBodyOnly>)): CancelableRequest<string>;


### PR DESCRIPTION
#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests (more on why this is unchecked below).

Wrapping `got` is difficult with the current function overloads. The changes made in #1051 made things much better, but given a `responseType` of `'text' | 'buffer' | 'json'` in the following call:

```ts
const responseType = 'text' as 'text' | 'buffer' | 'json';
const result = await got({
  url: 'github.com',
  responseType,
});
```

`got` will return `CancelableRequest<unknown> | Request` (or just `unknown` when `await`ed) instead of `CancelableRequest<Response<unknown>>`. This change adds an overload that catches the case where `responseType` isn't statically known, but we do know that a `Response` object will be returned.

I haven't added any tests for this PR since this is a type update and I didn't see any tests for types. Given the complexity of the types used by `got`, though, I'm happy to add some if desired. I've had good luck using [conditional-type-checks](https://github.com/dsherret/conditional-type-checks) for testing types in the past.

Related issues:
#954 
#1122 