### PR TITLE
Allow leading slashes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -173,7 +173,7 @@ A trailing slash `/` is optional - one will be added automatically.
 
 **Note:** `prefixUrl` will be ignored if the `url` argument is a URL instance.
 
-**Note:** Leading slashes in `input` are disallowed when using this option to enforce consistency and avoid confusion. For example, when the prefix URL is `https://example.com/foo` and the input is `/bar`, there's ambiguity whether the resulting URL would become `https://example.com/foo/bar` or `https://example.com/bar`. The latter is used by browsers.
+**Note:** Leading slashes in `input` are disallowed when using this option unless `allowLeadingSlash` is `true`. This is the default behavior to enforce consistency and avoid confusion. For example, when the prefix URL is `https://example.com/foo` and the input is `/bar`, there's ambiguity whether the resulting URL would become `https://example.com/foo/bar` or `https://example.com/bar`. The latter is used by browsers.
 
 **Tip:** Useful when used with [`got.extend()`](#custom-endpoints) to create niche-specific Got instances.
 
@@ -200,6 +200,31 @@ const got = require('got');
 		}
 	});
 	//=> 'https://cats.com/unicorn'
+})();
+```
+
+###### allowLeadingSlash
+
+Type: `boolean`
+
+When specified, leading slashes are allowed when a `prefixUrl` is given. Its behavior is the same as if you omitted the leading slash and it is implemented by removing the leading slash from the input.
+
+```js
+const got = require('got');
+
+(async () => {
+	await got('/unicorn', {prefixUrl: 'https://cats.com'});
+	//=> throws Error: `input` must not start with a slash when using `prefixUrl`
+
+	await got('/unicorn', {prefixUrl: 'https://cats.com', allowLeadingSlash: true});
+	//=> https://cats.com/unicorn
+
+	const instance = got.extend({
+		prefixUrl: 'https://cats.com/foo/'
+	});
+
+	await instance('/bar');
+	//=> 'https://cats.com/foo/bar'
 })();
 ```
 

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -122,6 +122,7 @@ export interface Options extends URLOptions, SecureContextOptions {
 	decompress?: boolean;
 	timeout?: Delays | number;
 	prefixUrl?: string | URL;
+	allowLeadingSlash?: boolean;
 	body?: string | Buffer | Readable;
 	form?: {[key: string]: any};
 	json?: {[key: string]: any};
@@ -157,6 +158,7 @@ export interface NormalizedOptions extends Options {
 	url: URL;
 	timeout: Delays;
 	prefixUrl: string;
+	allowLeadingSlash: boolean;
 	ignoreInvalidCookies: boolean;
 	decompress: boolean;
 	searchParams?: URLSearchParams;
@@ -183,6 +185,7 @@ export interface NormalizedOptions extends Options {
 export interface Defaults {
 	timeout: Delays;
 	prefixUrl: string;
+	allowLeadingSlash: boolean;
 	method: Method;
 	ignoreInvalidCookies: boolean;
 	decompress: boolean;
@@ -688,7 +691,11 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 
 		if (is.string(options.url)) {
 			if (options.url.startsWith('/')) {
-				throw new Error('`input` must not start with a slash when using `prefixUrl`');
+				if (options.allowLeadingSlash) {
+					options.url = options.url.slice(1);
+				} else {
+					throw new Error('`input` must not start with a slash when using `prefixUrl`');
+				}
 			}
 
 			options.url = optionsToUrl(options.prefixUrl + options.url, options as Options & {searchParams?: URLSearchParams});

--- a/source/index.ts
+++ b/source/index.ts
@@ -62,6 +62,7 @@ const defaults: InstanceDefaults = {
 		resolveBodyOnly: false,
 		maxRedirects: 10,
 		prefixUrl: '',
+		allowLeadingSlash: false,
 		methodRewriting: true,
 		ignoreInvalidCookies: false,
 		context: {},

--- a/test/arguments.ts
+++ b/test/arguments.ts
@@ -423,6 +423,22 @@ test('throws on leading slashes', async t => {
 	});
 });
 
+test('leading slashes work with `allowLeadingSlash: true`', withServer, async (t, server, got) => {
+	server.get('/test/foobar', echoUrl);
+
+	const instanceA = got.extend({prefixUrl: `${server.url}`, allowLeadingSlash: true});
+	const {body} = await instanceA('/test/foobar');
+	t.is(body, '/test/foobar');
+});
+
+test('leading slash does not overwrite path with `allowLeadingSlash: true`', withServer, async (t, server, got) => {
+	server.get('/test/foobar', echoUrl);
+
+	const instanceA = got.extend({prefixUrl: `${server.url}/test/`, allowLeadingSlash: true});
+	const {body} = await instanceA('/foobar');
+	t.is(body, '/test/foobar');
+});
+
 test('throws on invalid `dnsCache` option', async t => {
 	await t.throwsAsync(got('https://example.com', {
 		// @ts-ignore Error tests


### PR DESCRIPTION
This PR adds an `allowLeadingSlash` option which allows users to opt-in to leading slashes in the `input` if a `prefixUrl` is given. It is implemented by removing the leading slash if this option is `true`.

I'm open for suggestions and changes, especially since this hasn't been discussed in the issue yet if this option in desired or not by the maintainers.

Fixes #1283. 

#### Checklist

- [X] I have read the documentation.
- [X] I have included a pull request description of my changes.
- [X] I have included some tests.
- [X] If it's a new feature, I have included documentation updates.
