### PR TITLE
Do not wait for `ready` event if the file descriptor is already opened

### DIFF
--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -262,6 +262,8 @@ const waitForOpenFile = async (file: ReadStream): Promise<void> => new Promise((
 		reject(error);
 	};
 
+	if (!file.pending) resolve();
+
 	file.once('error', onError);
 	file.once('open', () => {
 		file.off('error', onError);

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -267,7 +267,7 @@ const waitForOpenFile = async (file: ReadStream): Promise<void> => new Promise((
 	}
 
 	file.once('error', onError);
-	file.once('open', () => {
+	file.once('ready', () => {
 		file.off('error', onError);
 		resolve();
 	});

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -262,7 +262,9 @@ const waitForOpenFile = async (file: ReadStream): Promise<void> => new Promise((
 		reject(error);
 	};
 
-	if (!file.pending) resolve();
+	if (!file.pending) {
+		resolve();
+	}
 
 	file.once('error', onError);
 	file.once('open', () => {

--- a/test/post.ts
+++ b/test/post.ts
@@ -4,6 +4,7 @@ import fs = require('fs');
 import path = require('path');
 import test from 'ava';
 import delay = require('delay');
+import pEvent = require('p-event');
 import {Handler} from 'express';
 import getStream = require('get-stream');
 import toReadableStream = require('to-readable-stream');
@@ -325,17 +326,13 @@ test('body - file read stream, wait for `ready` event', withServer, async (t, se
 	const toSend = await getStream(fs.createReadStream(fullPath));
 	const ifStream = fs.createReadStream(fullPath);
 
-	await new Promise(resolve => ifStream.on('ready', () => {
-		(async () => {
-			const body = await got.post({
-				body: ifStream
-			}).text();
+	await pEvent(ifStream, 'ready');
 
-			t.is(toSend, body);
+	const body = await got.post({
+		body: ifStream
+	}).text();
 
-			resolve();
-		})();
-	}));
+	t.is(toSend, body);
 });
 
 test('throws on upload error', withServer, async (t, server, got) => {

--- a/test/post.ts
+++ b/test/post.ts
@@ -318,6 +318,26 @@ test('body - file read stream', withServer, async (t, server, got) => {
 	t.is(toSend, body);
 });
 
+test('body - file read stream, wait for `open` event', withServer, async (t, server, got) => {
+	server.post('/', defaultEndpoint);
+
+	const fullPath = path.resolve('test/fixtures/ok');
+	const toSend = await getStream(fs.createReadStream(fullPath));
+	const ifStream = fs.createReadStream(fullPath);
+
+	await new Promise(resolve => ifStream.on('open', () => {
+		(async () => {
+			const body = await got.post({
+				body: ifStream
+			}).text();
+
+			t.is(toSend, body);
+
+			resolve();
+		})();
+	}));
+});
+
 test('throws on upload error', withServer, async (t, server, got) => {
 	server.post('/', defaultEndpoint);
 

--- a/test/post.ts
+++ b/test/post.ts
@@ -318,14 +318,14 @@ test('body - file read stream', withServer, async (t, server, got) => {
 	t.is(toSend, body);
 });
 
-test('body - file read stream, wait for `open` event', withServer, async (t, server, got) => {
+test('body - file read stream, wait for `ready` event', withServer, async (t, server, got) => {
 	server.post('/', defaultEndpoint);
 
 	const fullPath = path.resolve('test/fixtures/ok');
 	const toSend = await getStream(fs.createReadStream(fullPath));
 	const ifStream = fs.createReadStream(fullPath);
 
-	await new Promise(resolve => ifStream.on('open', () => {
+	await new Promise(resolve => ifStream.on('ready', () => {
 		(async () => {
 			const body = await got.post({
 				body: ifStream


### PR DESCRIPTION
got waits for the `open` event if the body is an `fs.ReadStream` even if the fd is already opened.

With this PR I added a check `ReadStream.pending` in order to immediately resolve `waitForOpenFile` if the fd is already opened.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.

Fixes #1280 