### PR TITLE
Some `beforeRequest` edited options are discarded

### DIFF
--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -1254,7 +1254,7 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 
 	async _makeRequest(): Promise<void> {
 		const {options} = this;
-		const {url, headers, request, agent, timeout} = options;
+		const {headers, request, timeout} = options;
 
 		for (const key in headers) {
 			if (is.undefined(headers[key])) {
@@ -1288,6 +1288,8 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 				break;
 			}
 		}
+
+		const {agent, url} = options;
 
 		if (options.dnsCache && !('lookup' in options)) {
 			options.lookup = options.dnsCache.lookup;

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -1254,7 +1254,8 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 
 	async _makeRequest(): Promise<void> {
 		const {options} = this;
-		const {headers, request, timeout} = options;
+
+		const {headers} = options;
 
 		for (const key in headers) {
 			if (is.undefined(headers[key])) {
@@ -1289,7 +1290,7 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 			}
 		}
 
-		const {agent, url} = options;
+		const {agent, request, timeout, url} = options;
 
 		if (options.dnsCache && !('lookup' in options)) {
 			options.lookup = options.dnsCache.lookup;

--- a/test/hooks.ts
+++ b/test/hooks.ts
@@ -933,7 +933,6 @@ test('beforeRequest hook respect `agent` option', withServer, async (t, server, 
 	agent.destroy();
 });
 
-
 test('beforeRequest hook respect `url` option', withServer, async (t, server, got) => {
 	server.get('/', (_request, response) => {
 		response.end('ko');
@@ -947,7 +946,7 @@ test('beforeRequest hook respect `url` option', withServer, async (t, server, go
 		hooks: {
 			beforeRequest: [
 				options => {
-					options.url = new URL(server.url + '/changed')
+					options.url = new URL(server.url + '/changed');
 				}
 			]
 		}

--- a/test/hooks.ts
+++ b/test/hooks.ts
@@ -1,7 +1,9 @@
 import {URL} from 'url';
-import test from 'ava';
+import {Agent as HttpAgent} from 'http';
+import test, {Constructor} from 'ava';
 import nock = require('nock');
 import getStream from 'get-stream';
+import sinon = require('sinon');
 import delay = require('delay');
 import {Handler} from 'express';
 import Responselike = require('responselike');
@@ -34,6 +36,13 @@ const redirectEndpoint: Handler = (_request, response) => {
 	response.statusCode = 302;
 	response.setHeader('location', '/');
 	response.end();
+};
+
+const createAgentSpy = <T extends HttpAgent>(AgentClass: Constructor): {agent: T; spy: sinon.SinonSpy} => {
+	const agent: T = new AgentClass({keepAlive: true});
+	// @ts-ignore This IS correct
+	const spy = sinon.spy(agent, 'addRequest');
+	return {agent, spy};
 };
 
 test('async hooks', withServer, async (t, server, got) => {
@@ -898,4 +907,49 @@ test('async afterResponse allows to retry with allowGetBody and json payload', w
 		throwHttpErrors: false
 	});
 	t.is(statusCode, 200);
+});
+
+test('beforeRequest hook respect `agent` option', withServer, async (t, server, got) => {
+	server.get('/', (_request, response) => {
+		response.end('ok');
+	});
+
+	const {agent, spy} = createAgentSpy(HttpAgent);
+
+	t.truthy((await got({
+		hooks: {
+			beforeRequest: [
+				options => {
+					options.agent = {
+						http: agent
+					};
+				}
+			]
+		}
+	})).body);
+	t.true(spy.calledOnce);
+
+	// Make sure to close all open sockets
+	agent.destroy();
+});
+
+
+test('beforeRequest hook respect `url` option', withServer, async (t, server, got) => {
+	server.get('/', (_request, response) => {
+		response.end('ko');
+	});
+
+	server.get('/changed', (_request, response) => {
+		response.end('ok');
+	});
+
+	t.is((await got(server.sslHostname, {
+		hooks: {
+			beforeRequest: [
+				options => {
+					options.url = new URL(server.url + '/changed')
+				}
+			]
+		}
+	})).body, 'ok');
 });


### PR DESCRIPTION
Currently he edits of `options.agent` and `options.url` made in `beforeRequest` are discarded.

This PR simply read `agent` and `url` after `beforeRequest` hooks.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.

Fixes #1292 