### PR TITLE
Fix `response` event not being emitted on cache verify request

### DIFF
--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -1318,7 +1318,7 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 			cacheRequest.once('error', reject);
 			cacheRequest.once('request', r => {
 				request = r;
-				resolve();
+				resolve(r);
 			});
 		});
 	}

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -1318,7 +1318,7 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 			cacheRequest.once('error', reject);
 			cacheRequest.once('request', r => {
 				request = r;
-				resolve(r);
+				r.end();
 			});
 		});
 	}

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -1318,7 +1318,7 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 			cacheRequest.once('error', reject);
 			cacheRequest.once('request', r => {
 				request = r;
-				r.end();
+				resolve(r);
 			});
 		});
 	}

--- a/test/cache.ts
+++ b/test/cache.ts
@@ -317,7 +317,7 @@ test('cached response ETag', withServer, async (t, server, got) => {
 
 	server.get('/', (request, response) => {
 		if (request.headers['if-none-match'] === etag) {
-			response.writeHead(304, {ETag: 'asdf'});
+			response.writeHead(304);
 			response.end();
 		} else {
 			response.writeHead(200, {ETag: etag});

--- a/test/cache.ts
+++ b/test/cache.ts
@@ -244,7 +244,7 @@ test('decompresses cached responses', withServer, async (t, server, got) => {
 		} else {
 			response.setHeader('content-encoding', 'gzip');
 			response.setHeader('cache-control', 'public, max-age=60');
-			response.setHeader('etag', 'foobar');
+			response.setHeader('etag', etag);
 			response.end(compressed);
 		}
 	});
@@ -309,4 +309,32 @@ test('does not hang on huge response', withServer, async (t, server, got) => {
 	}).buffer();
 
 	t.is(body.length, bufferSize * times);
+});
+
+test('cached response ETag', withServer, async (t, server, got) => {
+	const etag = 'foobar';
+	const body = 'responseBody';
+
+	server.get('/', (request, response) => {
+		if (request.headers['if-none-match'] === etag) {
+			response.writeHead(304, {ETag: 'asdf'});
+			response.end();
+		} else {
+			response.writeHead(200, {ETag: etag});
+			response.end(body);
+		}
+	});
+
+	const cache = new Map();
+
+	const originalResponse = await got({cache});
+
+	t.false(originalResponse.isFromCache);
+	t.is(originalResponse.body, body);
+	t.is(cache.size, 1);
+
+	const cachedResponse = await got({cache});
+
+	t.true(cachedResponse.isFromCache);
+	t.is(cachedResponse.body, body);
 });

--- a/test/cache.ts
+++ b/test/cache.ts
@@ -331,6 +331,9 @@ test('cached response ETag', withServer, async (t, server, got) => {
 
 	t.false(originalResponse.isFromCache);
 	t.is(originalResponse.body, body);
+
+	await delay(100); // Added small delay in order to wait the cache to be populated
+
 	t.is(cache.size, 1);
 
 	const cachedResponse = await got({cache});


### PR DESCRIPTION
~~That's only a workaround, a real solution is still WIP (this PR will be updated).~~

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.

Fixes #1287 