### PR TITLE
documentation: update proxy example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1720,8 +1720,9 @@ const tunnel = require('tunnel');
 
 got('https://sindresorhus.com', {
 	agent: {
-		http: tunnel.httpOverHttp({
+		https: tunnel.httpOverHttp({
 			proxy: {
+				rejectUnauthorized: false,
 				host: 'localhost'
 			}
 		})

--- a/readme.md
+++ b/readme.md
@@ -1720,7 +1720,7 @@ const tunnel = require('tunnel');
 
 got('https://sindresorhus.com', {
 	agent: {
-		https: tunnel.httpOverHttp({
+		http: tunnel.httpOverHttp({
 			proxy: {
 				host: 'localhost'
 			}


### PR DESCRIPTION
Feeling `http` is the most common use case there for proxying – normally you don't have access to proxy certificates (also the example is not reflecting that)