### PR TITLE
Add tips on stream behavior for new users

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1183,13 +1183,13 @@ The number of times the request was retried.
 
 Sets `options.isStream` to `true`.
 
-Returns a [duplex stream](https://nodejs.org/api/stream.html#stream_class_stream_duplex) with additional events:
+Returns a [duplex stream](https://nodejs.org/api/stream.html#stream_class_stream_duplex) with additional events. This stream can be read from (e.g. listening to the `data` and `end` events) for retrieving the response body, and can be written to (e.g. calling `write(data)` and `end`). If the stream is not read from then the response body will not be downloaded. The additional events expose request and response metadata:
 
 ##### .on('request', request)
 
 `request` event to get the request object of the request.
 
-**Tip:** You can use `request` event to abort request:
+**Tip:** You can use `request` event to abort request (you can also call `destroy` on the stream to abort):
 
 ```js
 got.stream('https://github.com')
@@ -1199,6 +1199,8 @@ got.stream('https://github.com')
 ##### .on('response', response)
 
 The `response` event to get the response object of the final request.
+
+**Note:** This will not include the response body. If you want to download the response body you will need to listen to the `on('data')` and `.on('end')` events.
 
 ##### .on('redirect', response, nextOptions)
 


### PR DESCRIPTION
First off, thank you so much for creating this library! It's been a huge time saver while working with HTTP requests in Node.js.

I was recently working with the stream variant of the API and experienced some confusion around when events were triggered and how to access the response body. I was under the impression that the `response` event returned a response object just like the promise methods and therefore `rawBody` would be populated (which is not the case).

I thought that some slight tweaks to the readme might clarify this for new users. Hopefully these changes will ease onboarding.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] ~~I have included some tests.~~ N/A 
- [x] ~~If it's a new feature, I have included documentation updates.~~ N/A
