### PR TITLE
Add `forceHeaderKeysLowercase` option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -213,6 +213,15 @@ Request headers.
 
 Existing headers will be overwritten. Headers set to `undefined` will be omitted.
 
+###### forceHeaderKeysLowercase
+
+Type: `boolean`\
+Default: `true`
+
+Force header keys to be lowercase.
+
+Set to `false` to keep the case as is.
+
 ###### isStream
 
 Type: `boolean`\

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -152,6 +152,7 @@ export interface Options extends URLOptions {
 	allowGetBody?: boolean;
 	lookup?: CacheableLookup['lookup'];
 	headers?: Headers;
+	forceHeaderKeysLowercase?: boolean;
 	methodRewriting?: boolean;
 	dnsLookupIpVersion?: DnsLookupIpVersion;
 	parseJson?: ParseJsonFunction;
@@ -193,6 +194,7 @@ export interface NormalizedOptions extends Options {
 	searchParams?: URLSearchParams;
 	cookieJar?: PromiseCookieJar;
 	headers: Headers;
+	forceHeaderKeysLowercase: boolean;
 	context: object;
 	hooks: Required<Hooks>;
 	followRedirect: boolean;
@@ -223,6 +225,7 @@ export interface Defaults {
 	cookieJar?: PromiseCookieJar | ToughCookieJar;
 	dnsCache?: CacheableLookup;
 	headers: Headers;
+	forceHeaderKeysLowercase: boolean;
 	hooks: Required<Hooks>;
 	followRedirect: boolean;
 	maxRedirects: number;
@@ -686,7 +689,8 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 		if (options.headers === defaults?.headers) {
 			options.headers = {...options.headers};
 		} else {
-			options.headers = lowercaseKeys({...(defaults?.headers), ...options.headers});
+			const mergedHeaders = {...(defaults?.headers), ...options.headers}
+			options.headers = options.forceHeaderKeysLowercase ? lowercaseKeys(mergedHeaders) : mergedHeaders;
 		}
 
 		// Disallow legacy `url.Url`

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -689,7 +689,7 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 		if (options.headers === defaults?.headers) {
 			options.headers = {...options.headers};
 		} else {
-			const mergedHeaders = {...(defaults?.headers), ...options.headers}
+			const mergedHeaders = {...(defaults?.headers), ...options.headers};
 			options.headers = options.forceHeaderKeysLowercase ? lowercaseKeys(mergedHeaders) : mergedHeaders;
 		}
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -44,6 +44,7 @@ const defaults: InstanceDefaults = {
 		headers: {
 			'user-agent': 'got (https://github.com/sindresorhus/got)'
 		},
+		forceHeaderKeysLowercase: true,
 		hooks: {
 			init: [],
 			beforeRequest: [],

--- a/test/headers.ts
+++ b/test/headers.ts
@@ -87,7 +87,7 @@ test('`host` header', withServer, async (t, server, got) => {
 	t.is(headers.host, `localhost:${server.port}`);
 });
 
-test('transforms names to lowercase', withServer, async (t, server, got) => {
+test('transforms names to lowercase by default', withServer, async (t, server, got) => {
 	server.get('/', echoHeaders);
 
 	const headers = (await got<Headers>({
@@ -97,6 +97,19 @@ test('transforms names to lowercase', withServer, async (t, server, got) => {
 		responseType: 'json'
 	})).body;
 	t.is(headers['accept-encoding'], 'identity');
+});
+
+test('does not transforms names to lowercase with option', withServer, async (t, server, got) => {
+	server.get('/', echoHeaders);
+
+	const headers = (await got<Headers>({
+		headers: {
+			'ACCEPT-ENCODING': 'identity'
+		},
+		forceHeaderKeysLowercase: false,
+		responseType: 'json'
+	})).body;
+	t.is(headers['ACCEPT-ENCODING'], 'identity');
 });
 
 test('setting `content-length` to 0', withServer, async (t, server, got) => {


### PR DESCRIPTION
#### Checklist

- [X] I have read the documentation.
- [X] I have included a pull request description of my changes.
- [X] I have included some tests.
- [X] If it's a new feature, I have included documentation updates.

Allows the user to chose if the case of the headers should stay as-is.

As per the [RFC 2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2) for HTTP1, and [RFC 7540](https://tools.ietf.org/html/rfc7540#section-8.1.2) for HTTP2, the field names are case-insensitive, that should be a valid reason not to force the user to lowercase them.

Thanks

Fixes #1335