### PR TITLE
Add hpagent to proxy section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1750,6 +1750,26 @@ got('https://sindresorhus.com', {
 });
 ```
 
+Otherwise, you can use the [`hpagent`](https://github.com/delvedor/hpagent) package, which keeps the internal sockets alive to be reused.
+
+```js
+const got = require('got');
+const {HttpsProxyAgent} = require('hpagent');
+
+got('https://sindresorhus.com', {
+	agent: {
+		https: new HttpsProxyAgent({
+			keepAlive: true,
+			keepAliveMsecs: 1000,
+			maxSockets: 256,
+			maxFreeSockets: 256,
+			scheduling: 'lifo',
+			proxy: 'https://localhost:8080'
+		})
+	}
+});
+```
+
 Alternatively, use [`global-agent`](https://github.com/gajus/global-agent) to configure a global proxy for all HTTP/HTTPS traffic in your program.
 
 Read the [`http2-wrapper`](https://github.com/szmarczak/http2-wrapper/#proxy-support) docs to learn about proxying for HTTP/2.


### PR DESCRIPTION
Hello!
I've spent the past days working on a [HTTP agent](https://github.com/delvedor/hpagent) for working with proxies that also keeps sockets alive. Since I wasn't able to find one, I built it.
I love got and I'm using it in many projects, so I'm testing that the agent works with got in my testing suite (https://github.com/delvedor/hpagent/pull/2).
If you would like to mention the package in your README, this pr does that :)

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates.
