### PR TITLE
Don't allocate buffer twice

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -319,6 +319,8 @@ const body = await got(url).json();
 const body = await got(url, {responseType: 'json', resolveBodyOnly: true});
 ```
 
+**Note:** `buffer` will return the raw body buffer. Modifying it will also alter the result of `promise.text()` and `promise.json()`. Before overwritting the buffer, please copy it first via `Buffer.from(buffer)`. See https://github.com/nodejs/node/issues/27080
+
 ###### parseJson
 
 Type: `(text: string) => unknown`\

--- a/source/as-promise/parse-body.ts
+++ b/source/as-promise/parse-body.ts
@@ -18,7 +18,7 @@ const parseBody = (response: Response, responseType: ResponseType, parseJson: Pa
 		}
 
 		if (responseType === 'buffer') {
-			return Buffer.from(rawBody.buffer);
+			return rawBody;
 		}
 
 		throw new ParseError({

--- a/source/as-promise/parse-body.ts
+++ b/source/as-promise/parse-body.ts
@@ -18,7 +18,7 @@ const parseBody = (response: Response, responseType: ResponseType, parseJson: Pa
 		}
 
 		if (responseType === 'buffer') {
-			return Buffer.from(rawBody);
+			return Buffer.from(rawBody.buffer);
 		}
 
 		throw new ParseError({


### PR DESCRIPTION
* `getBuffer` returns a buffer of concatenated response chunks.
* Its result is stored in `rawBody` and passed to `parseBody`.
* Then it meets `Buffer.from(rawBody)` and triggers a new buffer allocation:
   https://nodejs.org/api/buffer.html#buffer_class_method_buffer_from_buffer

Now a new Buffer created without copying the underlying memory.
https://nodejs.org/api/buffer.html#buffer_class_method_buffer_from_arraybuffer_byteoffset_length

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates.
