### PR TITLE
Improve type inference

### DIFF
--- a/source/as-promise/types.ts
+++ b/source/as-promise/types.ts
@@ -286,7 +286,7 @@ export class CancelError extends RequestError {
 	}
 }
 
-export interface CancelableRequest<T extends Response | Response['body'] = Response['body']> extends PCancelable<T>, RequestEvents<CancelableRequest<T>> {
+export interface CancelableRequest<T extends Response | Response['body'] = Response['body']> extends PCancelable<T>, Promise<T>, RequestEvents<CancelableRequest<T>> {
 	json: <ReturnType>() => CancelableRequest<ReturnType>;
 	buffer: () => CancelableRequest<Buffer>;
 	text: () => CancelableRequest<string>;


### PR DESCRIPTION
`PCancelable<T>` extends `Promise<T>`, but due to the default import `p-cancelable` this fact is erased.
As a result `await got.get(...).json<E>()` returns `any`. After the fix Webstorm IDE returns `E`.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
