### PR TITLE
Don't use instanceof stream.Readable, it's an interface

### DIFF
--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -1883,7 +1883,7 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 
 			if (
 				isBody &&
-				!(options.body instanceof Readable) &&
+				!is.nodeStream(options.body) &&
 				!is.string(options.body) &&
 				!is.buffer(options.body) &&
 				!isFormData(options.body)


### PR DESCRIPTION
`stream.Readable` doesn't need to be extended from, it's just an interface that readable streams implement. I replaced `body instanceof stream.Readable` with `is.nodeStream()` because that's the check that was used in other places of the code.

Specifically, I was trying to use [archiver](https://www.npmjs.com/package/archiver) with [chrome-webstore-upload](https://github.com/DrewML/chrome-webstore-upload/) which recently started using `got` (in version 4.0) which broke my publish CI script because of this. Archiver doesn't actually extend `stream.Readable`, it only implements it, which caused the issue.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [x] If it's a new feature, I have included documentation updates in both the README and the types.
