### PR TITLE
Add fixes for Node.js 14.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "got",
-	"version": "11.6.0",
+	"version": "11.6.1",
 	"description": "Human-friendly and powerful HTTP request library for Node.js",
 	"license": "MIT",
 	"repository": "sindresorhus/got",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "got",
-	"version": "11.6.1",
+	"version": "11.6.0",
 	"description": "Human-friendly and powerful HTTP request library for Node.js",
 	"license": "MIT",
 	"repository": "sindresorhus/got",

--- a/source/as-promise/index.ts
+++ b/source/as-promise/index.ts
@@ -80,7 +80,7 @@ export default function asPromise<T>(normalizedOptions: NormalizedOptions): Canc
 						response.body = rawBody.toString();
 
 						if (isResponseOk(response)) {
-							request._beforeError(error);
+							request._beforeError(error, onError);
 							return;
 						}
 					}
@@ -120,12 +120,12 @@ export default function asPromise<T>(normalizedOptions: NormalizedOptions): Canc
 						});
 					}
 				} catch (error) {
-					request._beforeError(new RequestError(error.message, error, request));
+					request._beforeError(new RequestError(error.message, error, request), onError);
 					return;
 				}
 
 				if (!isResponseOk(response)) {
-					request._beforeError(new HTTPError(response));
+					request._beforeError(new HTTPError(response), onError);
 					return;
 				}
 

--- a/test/hooks.ts
+++ b/test/hooks.ts
@@ -214,7 +214,7 @@ test('catches beforeRedirect promise rejections', withServer, async (t, server, 
 	});
 });
 
-test('catches beforeRetry promise rejections', withServer, async (t, server, got) => {
+test.only('catches beforeRetry promise rejections', withServer, async (t, server, got) => {
 	server.get('/retry', retryEndpoint);
 
 	await t.throwsAsync(got('retry', {


### PR DESCRIPTION
```
szm@solus ~/Desktop/got $ npm run build && ava test/hooks.ts -v

> got@11.6.0 build /home/szm/Desktop/got
> del-cli dist && tsc


catches beforeRetry promise rejections
RequestError: oops
    at Timeout.retry [as _onTimeout] (/home/szm/Desktop/got/dist/source/core/index.js:1245:46)
    at Request.<anonymous> (/home/szm/Desktop/got/dist/source/as-promise/index.js:117:42)
    at processTicksAndRejections (internal/process/task_queues.js:93:5) {
  code: undefined,
  timings: {
    start: 1599686790514,
    socket: 1599686790515,
    lookup: 1599686790516,
    connect: 1599686790516,
    secureConnect: undefined,
    upload: 1599686790516,
    response: 1599686790519,
    end: 1599686790520,
    error: undefined,
    abort: 1599686790521,
    phases: {
      wait: 1,
      dns: 1,
      tcp: 0,
      tls: undefined,
      request: 0,
      firstByte: 3,
      download: 1,
      total: 7
    }
  }
}
Error: To error after destroy, pass a callback.
    at Request._error (/home/szm/Desktop/got/dist/source/core/index.js:1177:27)
    at Timeout.retry [as _onTimeout] (/home/szm/Desktop/got/dist/source/core/index.js:1245:39)
  ✖ test/hooks.ts exited with a non-zero exit code: 1
```