### PR TITLE
Fix Got on Node.js 14.10.0 (v2)

### DIFF
--- a/source/as-promise/index.ts
+++ b/source/as-promise/index.ts
@@ -80,7 +80,7 @@ export default function asPromise<T>(normalizedOptions: NormalizedOptions): Canc
 						response.body = rawBody.toString();
 
 						if (isResponseOk(response)) {
-							request._beforeError(error);
+							request._beforeError(error, onError);
 							return;
 						}
 					}
@@ -120,12 +120,12 @@ export default function asPromise<T>(normalizedOptions: NormalizedOptions): Canc
 						});
 					}
 				} catch (error) {
-					request._beforeError(new RequestError(error.message, error, request));
+					request._beforeError(new RequestError(error.message, error, request), onError);
 					return;
 				}
 
 				if (!isResponseOk(response)) {
-					request._beforeError(new HTTPError(response));
+					request._beforeError(new HTTPError(response), onError);
 					return;
 				}
 

--- a/source/core/utils/timed-out.ts
+++ b/source/core/utils/timed-out.ts
@@ -68,6 +68,12 @@ export default (request: ClientRequest, delays: Delays, options: TimedOutOptions
 	const {host, hostname} = options;
 
 	const timeoutHandler = (delay: number, event: string): void => {
+		// Some weird fix. Reading hangs after request.destroy(error)?
+		const {res} = (request as ClientRequest & {res?: IncomingMessage});
+		if (res) {
+			res.destroyed = true;
+		}
+
 		request.destroy(new TimeoutError(delay, event));
 	};
 


### PR DESCRIPTION
```
  ✖ Exiting due to SIGINT

  6 tests were pending in test/hooks.ts

  ◌ hooks.ts › catches beforeRetry thrown errors
  ◌ hooks.ts › catches beforeRetry promise rejections
  ◌ hooks.ts › beforeRetry is called with options
  ◌ hooks.ts › beforeRetry allows modifications
  ◌ hooks.ts › throws on afterResponse retry failure
  ◌ hooks.ts › doesn't throw on afterResponse retry HTTP failure if throwHttpErrors is false

  1 tests were pending in test/http.ts

  ◌ http.ts › throws an error if the server aborted the request

  1 tests were pending in test/promise.ts

  ◌ promise.ts › no unhandled `The server aborted pending request` rejection

  11 tests were pending in test/retry.ts

  ◌ retry.ts › retry function gets iteration count
  ◌ retry.ts › custom retries
  ◌ retry.ts › custom retries async
  ◌ retry.ts › respects 413 Retry-After
  ◌ retry.ts › respects 413 Retry-After with RFC-1123 timestamp
  ◌ retry.ts › retries on 503 without Retry-After header
  ◌ retry.ts › works when defaults.options.retry is a number
  ◌ retry.ts › retry function can throw
  ◌ retry.ts › does not break on redirect
  ◌ retry.ts › does not destroy the socket on HTTP error
  ◌ retry.ts › promise does not retry when body is a stream

  ─

  cancel.ts › does not retry after cancelation

  Makes a new try after cancelation

  › Object.calculateDelay (dist/test/cancel.js:49:19)
  › dist/source/core/index.js:1220:51
  › Request._beforeError (dist/source/core/index.js:1262:11)
  › ClientRequest.<anonymous> (dist/source/core/index.js:943:18)
  › ClientRequest.origin.emit (node_modules/@szmarczak/http-timer/dist/source/index.js:39:20)

  ─
```

there has to be a way to emit `retry` errors somehow...