### PR TITLE
Disable a test as the built-in `openssl` on macOS does not support negative days

### DIFF
--- a/test/https.ts
+++ b/test/https.ts
@@ -115,14 +115,16 @@ test('https request with `checkServerIdentity` NOT OK', withHttpsServer(), async
 	);
 });
 
-test('https request with expired certificate', withHttpsServer({days: -1}), async (t, _server, got) => {
-	await t.throwsAsync(
-		got({}),
-		{
-			code: 'CERT_HAS_EXPIRED'
-		}
-	);
-});
+if (process.platform !== 'darwin') {
+	test('https request with expired certificate', withHttpsServer({days: -1}), async (t, _server, got) => {
+		await t.throwsAsync(
+			got({}),
+			{
+				code: 'CERT_HAS_EXPIRED'
+			}
+		);
+	});
+}
 
 test('https request with wrong host', withHttpsServer({commonName: 'not-localhost.com'}), async (t, _server, got) => {
 	await t.throwsAsync(

--- a/test/https.ts
+++ b/test/https.ts
@@ -115,6 +115,7 @@ test('https request with `checkServerIdentity` NOT OK', withHttpsServer(), async
 	);
 });
 
+// Default openssl on MacOS does not support negative days
 if (process.platform !== 'darwin') {
 	test('https request with expired certificate', withHttpsServer({days: -1}), async (t, _server, got) => {
 		await t.throwsAsync(

--- a/test/https.ts
+++ b/test/https.ts
@@ -115,7 +115,7 @@ test('https request with `checkServerIdentity` NOT OK', withHttpsServer(), async
 	);
 });
 
-// Default openssl on MacOS does not support negative days
+// The built-in `openssl` on macOS does not support negative days.
 if (process.platform !== 'darwin') {
 	test('https request with expired certificate', withHttpsServer({days: -1}), async (t, _server, got) => {
 		await t.throwsAsync(


### PR DESCRIPTION
Title self-explanatory.

Reference: https://ci.nodejs.org/job/citgm-smoker-nobuild/nodes=osx1015/935/testReport/junit/(root)/citgm/got_v11_6_1/

The test has been disabled, I'm looking for some kind of replacement. We cannot play with timers because the TLS logic related to the certificate expiration is done by openssl.