### PR TITLE
Add a test for #1438

### DIFF
--- a/test/promise.ts
+++ b/test/promise.ts
@@ -78,9 +78,13 @@ test.only('promise.json() can be called before a file stream body is open', with
 	// @ts-ignore
 	promise.asdf = 123;
 	p = promise;
-	t.notThrows(() => promise.json());
+	let jsonPromise: any;
+	t.notThrows(() => {
+		jsonPromise = promise.json()
+	});
 
 	promise.cancel();
 
 	await t.throwsAsync(promise, {instanceOf: CancelError});;
+	await t.throwsAsync(jsonPromise, {instanceOf: CancelError});;
 });

--- a/test/promise.ts
+++ b/test/promise.ts
@@ -60,7 +60,7 @@ test('promise.json() can be called before a file stream body is open', withServe
 		});
 	});
 
-	// @ts-ignore @types/node has wrong types.
+	// @ts-expect-error @types/node has wrong types.
 	const body = new ReadStream('', {
 		fs: {
 			open: () => {},


### PR DESCRIPTION
```
szm@solus ~/Desktop/got $ npm run build && ava test/promise.ts -v

> got@11.6.2 build /home/szm/Desktop/got
> del-cli dist && tsc


  ✔ promise.json() can be called before a file stream body is open
false PCancelable [Promise] {
  _cancelHandlers: [ [Function (anonymous)], [Function (anonymous)] ],
  _isPending: false,
  _isCanceled: true,
  _rejectOnCancel: false,
  _reject: [Function (anonymous)],
  _promise: Promise {
    <rejected> CancelError: Promise was canceled
        at /home/szm/Desktop/got/dist/source/as-promise/index.js:40:35
        at PCancelable.cancel (/home/szm/Desktop/got/node_modules/p-cancelable/index.js:86:6)
        at /home/szm/Desktop/got/dist/test/promise.js:71:13
        at /home/szm/Desktop/got/dist/test/helpers/with-server.js:37:15
        at processTicksAndRejections (internal/process/task_queues.js:93:5) {
      code: undefined,
      timings: undefined
    }
  },
  on: [Function (anonymous)],
  json: [Function (anonymous)],
  buffer: [Function (anonymous)],
  text: [Function (anonymous)],
  asdf: 123
} Promise {
  <rejected> CancelError: Promise was canceled
      at /home/szm/Desktop/got/dist/source/as-promise/index.js:40:35
      at PCancelable.cancel (/home/szm/Desktop/got/node_modules/p-cancelable/index.js:86:6)
      at /home/szm/Desktop/got/dist/test/promise.js:71:13
      at /home/szm/Desktop/got/dist/test/helpers/with-server.js:37:15
      at processTicksAndRejections (internal/process/task_queues.js:93:5) {
    code: undefined,
    timings: undefined
  },
  _cancelHandlers: [ [Function (anonymous)], [Function (anonymous)] ],
  _isPending: true,
  _isCanceled: false,
  _rejectOnCancel: false,
  _reject: [Function (anonymous)],
  _promise: Promise {
    <rejected> CancelError: Promise was canceled
        at /home/szm/Desktop/got/dist/source/as-promise/index.js:40:35
        at PCancelable.cancel (/home/szm/Desktop/got/node_modules/p-cancelable/index.js:86:6)
        at /home/szm/Desktop/got/dist/test/promise.js:71:13
        at /home/szm/Desktop/got/dist/test/helpers/with-server.js:37:15
        at processTicksAndRejections (internal/process/task_queues.js:93:5) {
      code: undefined,
      timings: undefined
    }
  },
  on: [Function (anonymous)],
  json: [Function (anonymous)],
  buffer: [Function (anonymous)],
  text: [Function (anonymous)],
  asdf: 123
}

  Unhandled rejection in test/promise.ts

  CancelError: Promise was canceled

  › dist/source/as-promise/index.js:40:35
  › PCancelable.cancel (node_modules/p-cancelable/index.js:86:6)
  › dist/test/promise.js:71:13
  › dist/test/helpers/with-server.js:37:15

  ─

  1 test passed
  1 unhandled rejection
```