### PR TITLE
Parse JSON without conversion to string

### DIFF
--- a/source/as-promise/parse-body.ts
+++ b/source/as-promise/parse-body.ts
@@ -14,7 +14,7 @@ const parseBody = (response: Response, responseType: ResponseType, parseJson: Pa
 		}
 
 		if (responseType === 'json') {
-			return rawBody.length === 0 ? '' : parseJson(rawBody.toString());
+			return rawBody.length === 0 ? '' : parseJson(rawBody);
 		}
 
 		if (responseType === 'buffer') {


### PR DESCRIPTION
Node.js and V8 allows to parse JSON from buffer, so an intermediate conversion to string is not required.

Though typescript doesn't have correct typing due to historic issues. I would like do extend JSON interface with a method that allows Buffer as its first argument. Will it be ok for you?
