### PR TITLE
Fix `url` not being reused on retry in rare case

### DIFF
--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -1645,6 +1645,10 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 				delete options.port;
 			}
 
+			if ('protocol' in options) {
+				delete options.protocol;
+			}
+
 			// Make it possible to change `options.prefixUrl`
 			let {prefixUrl} = options;
 			Object.defineProperty(options, 'prefixUrl', {

--- a/test/hooks.ts
+++ b/test/hooks.ts
@@ -940,6 +940,7 @@ test('async afterResponse allows to retry with allowGetBody and json payload', w
 		retry: 0,
 		throwHttpErrors: false
 	});
+
 	t.is(statusCode, 200);
 });
 

--- a/test/hooks.ts
+++ b/test/hooks.ts
@@ -514,6 +514,38 @@ test('afterResponse allows to retry', withServer, async (t, server, got) => {
 	t.is(statusCode, 200);
 });
 
+test('afterResponse allows to retry without losing the port', withServer, async (t, server) => {
+	server.get('/', (request, response) => {
+		if (request.headers.token !== 'unicorn') {
+			response.statusCode = 401;
+		}
+
+		response.end();
+	});
+
+	const {statusCode} = await got({
+		protocol: 'http:',
+		hostname: server.hostname,
+		port: server.port,
+		hooks: {
+			afterResponse: [
+				(response, retryWithMergedOptions) => {
+					if (response.statusCode === 401) {
+						return retryWithMergedOptions({
+							headers: {
+								token: 'unicorn'
+							}
+						});
+					}
+
+					return response;
+				}
+			]
+		}
+	});
+	t.is(statusCode, 200);
+});
+
 test('cancelling the request after retrying in a afterResponse hook', withServer, async (t, server, got) => {
 	let requests = 0;
 	server.get('/', (_request, response) => {


### PR DESCRIPTION
#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] If it's a new feature, I have included documentation updates in both the README and the types.

Currently, when request URL is given in parts, `options.port` is removed from `options` after the initial request. Then `retryWithMergedOptions` attempts to connect to the default port.

This test fails after https://github.com/sindresorhus/got/commit/52de13bbdcd94db58ffcf39f87293af9249594c1