### PR TITLE
Set default value for an options object

### DIFF
--- a/source/create.ts
+++ b/source/create.ts
@@ -125,7 +125,7 @@ const create = (defaults: InstanceDefaults): Got => {
 	}));
 
 	// Got interface
-	const got: Got = ((url: string | URL, options?: Options, _defaults?: Defaults): GotReturn => {
+	const got: Got = ((url: string | URL, options: Options = {}, _defaults?: Defaults): GotReturn => {
 		let iteration = 0;
 		const iterateHandlers = (newOptions: NormalizedOptions): GotReturn => {
 			return defaults.handlers[iteration++](
@@ -152,7 +152,7 @@ const create = (defaults: InstanceDefaults): Got => {
 			let initHookError: Error | undefined;
 			try {
 				callInitHooks(defaults.options.hooks.init, options);
-				callInitHooks(options?.hooks?.init, options);
+				callInitHooks(options.hooks?.init, options);
 			} catch (error) {
 				initHookError = error;
 			}
@@ -167,10 +167,10 @@ const create = (defaults: InstanceDefaults): Got => {
 
 			return iterateHandlers(normalizedOptions);
 		} catch (error) {
-			if (options?.isStream) {
+			if (options.isStream) {
 				throw error;
 			} else {
-				return createRejection(error, defaults.options.hooks.beforeError, options?.hooks?.beforeError);
+				return createRejection(error, defaults.options.hooks.beforeError, options.hooks?.beforeError);
 			}
 		}
 	}) as Got;

--- a/test/create.ts
+++ b/test/create.ts
@@ -231,6 +231,24 @@ test('does not include the `request` option in normalized `http` options', withS
 	t.true(isCalled);
 });
 
+test('should pass an options object into an initialization hook after .extend', withServer, async (t, server, got) => {
+	t.plan(1);
+
+	server.get('/', echoHeaders);
+
+	const instance = got.extend({
+		hooks: {
+			init: [
+				options => {
+					t.deepEqual(options, {});
+				}
+			]
+		}
+	});
+
+	await instance('');
+});
+
 test('hooks aren\'t overriden when merging options', withServer, async (t, server, got) => {
 	server.get('/', echoHeaders);
 


### PR DESCRIPTION
Hello,

I ran into a problem that after the client extension by the `.extend` method, the `init` hook gets an `undefined` instead of an object as options.

The following example illustrates the problem.

```js
const got = require('got').default;

const client = got.extend({
	hooks: {
		init: [
			(options) => {
				console.dir({ options }, { colors: true });
			}
		]
	}
});

(async () => {
	await client('https://google.com'); // { options: undefined }
	await client('https://google.com', {}); // { options: {} }
	await client({ url: 'https://google.com' }); // { options: { url: <value> }}
})();
```

Looks like a bug, because I see that the `init` hook should get an `Options` object according to the signature in the types.

https://github.com/sindresorhus/got/blob/87dadd53bdef4184ecba1b263a726bba4674c23c/source/core/index.ts#L103

So, this PR fixes the problem. If you accept this change, I can make a backport to the `v11` branch.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates in both the README and the types.
