### PR TITLE
Initialize globalResponse in case of ignored HTTPError

### DIFF
--- a/source/as-promise/index.ts
+++ b/source/as-promise/index.ts
@@ -124,12 +124,12 @@ export default function asPromise<T>(normalizedOptions: NormalizedOptions): Canc
 					return;
 				}
 
+				globalResponse = response;
+
 				if (!isResponseOk(response)) {
 					request._beforeError(new HTTPError(response));
 					return;
 				}
-
-				globalResponse = response;
 
 				resolve(request.options.resolveBodyOnly ? response.body as T : response as unknown as T);
 			});

--- a/test/promise.ts
+++ b/test/promise.ts
@@ -80,7 +80,7 @@ test('promise.json() can be called before a file stream body is open', withServe
 	await Promise.all(checks);
 });
 
-test.failing('promise.json() does not fail when server returns an error', withServer, async (t, server, got) => {
+test('promise.json() does not fail when server returns an error', withServer, async (t, server, got) => {
 	server.get('/', (_request, response) => {
 		response.statusCode = 400;
 		response.end('{}');


### PR DESCRIPTION
This should fix #1540 

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] If it's a new feature, I have included documentation updates in both the README and the types.
