### PR TITLE
Allow cancelation of shortcuted promises

### DIFF
--- a/source/as-promise/index.ts
+++ b/source/as-promise/index.ts
@@ -185,6 +185,7 @@ export default function asPromise<T>(normalizedOptions: NormalizedOptions): Canc
 		})();
 
 		Object.defineProperties(newPromise, Object.getOwnPropertyDescriptors(promise));
+		Object.setPrototypeOf(newPromise, Object.getPrototypeOf(promise));
 
 		return newPromise as CancelableRequest<T>;
 	};


### PR DESCRIPTION
Fixes #1417. Briefly, `got.get(...).buffer().cancel()` throws `TypeError { message: 'p.cancel is not a function' }`