### PR TITLE
Add generic argument to `AfterResponseHook` TypeScript type

### DIFF
--- a/source/as-promise/types.ts
+++ b/source/as-promise/types.ts
@@ -121,7 +121,7 @@ export interface PaginationOptions<T, R> {
 	};
 }
 
-export type AfterResponseHook<TResp = unknown> = (response: Response<TResp>, retryWithMergedOptions: (options: Options) => CancelableRequest<Response>) => Response | CancelableRequest<Response> | Promise<Response | CancelableRequest<Response>>;
+export type AfterResponseHook<ResponseType = unknown> = (response: Response<ResponseType>, retryWithMergedOptions: (options: Options) => CancelableRequest<Response>) => Response | CancelableRequest<Response> | Promise<Response | CancelableRequest<Response>>;
 
 // These should be merged into Options in core/index.ts
 export namespace PromiseOnly {

--- a/source/as-promise/types.ts
+++ b/source/as-promise/types.ts
@@ -121,7 +121,7 @@ export interface PaginationOptions<T, R> {
 	};
 }
 
-export type AfterResponseHook = (response: Response, retryWithMergedOptions: (options: Options) => CancelableRequest<Response>) => Response | CancelableRequest<Response> | Promise<Response | CancelableRequest<Response>>;
+export type AfterResponseHook<TResp = unknown> = (response: Response<TResp>, retryWithMergedOptions: (options: Options) => CancelableRequest<Response>) => Response | CancelableRequest<Response> | Promise<Response | CancelableRequest<Response>>;
 
 // These should be merged into Options in core/index.ts
 export namespace PromiseOnly {


### PR DESCRIPTION
Adding a generic parameter to the AfterResponseHook type allows us to type the response and avoid an unknown if the user knows the response type.

#### Checklist

- [ ] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates in both the README and the types.
