### PR TITLE
Minor tweak

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
 		"http2-wrapper": "^2.0.0",
 		"lowercase-keys": "^2.0.0",
 		"p-cancelable": "^2.0.0",
-		"responselike": "^2.0.0"
+		"responselike": "^2.0.0",
+		"yoctodelay": "^1.2.0"
 	},
 	"devDependencies": {
 		"@ava/typescript": "^1.1.1",

--- a/source/create.ts
+++ b/source/create.ts
@@ -1,5 +1,6 @@
 import {URL} from 'url';
 import is from '@sindresorhus/is';
+import delay = require('yoctodelay');
 import asPromise, {
 	// Response
 	Response,
@@ -52,11 +53,6 @@ const errors = {
 	UnsupportedProtocolError,
 	UploadError
 };
-
-// The `delay` package weighs 10KB (!)
-const delay = async (ms: number) => new Promise(resolve => {
-	setTimeout(resolve, ms);
-});
 
 const {normalizeArguments} = Request;
 


### PR DESCRIPTION
`yoctodelay` can be used instead of `delay` to retain space while being modular.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [x] If it's a new feature, I have included documentation updates in both the README and the types.
