### PR TITLE
Add failing test for retries with POST requests

### DIFF
--- a/test/retry.ts
+++ b/test/retry.ts
@@ -293,6 +293,19 @@ test('retries on 503 without Retry-After header', withServer, async (t, server, 
 	t.is(retryCount, 1);
 });
 
+test('retries on POST request (returns 502 status code)', withServer, async (t, server, got) => {
+	server.post('/', (_request, response) => {
+		response.statusCode = 502;
+		response.end();
+	});
+
+	const {retryCount} = await got({
+		throwHttpErrors: false,
+		retry: 3
+	});
+	t.is(retryCount, 3);
+});
+
 test('doesn\'t retry on streams', withServer, async (t, server, got) => {
 	server.get('/', () => {});
 


### PR DESCRIPTION
Adds test a test that proves retries aren't respected with POST requests.

Ref https://github.com/sindresorhus/got/issues/1672

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] If it's a new feature, I have included documentation updates in both the README and the types.
