### PR TITLE
Fix a typo in a test name

### DIFF
--- a/test/normalize-arguments.ts
+++ b/test/normalize-arguments.ts
@@ -105,7 +105,7 @@ test('prefixUrl alone does not set url', t => {
 	t.is(options.url, undefined);
 });
 
-test('maxRetryAfter is calculated seperately from request timeout', t => {
+test('maxRetryAfter is calculated separately from request timeout', t => {
 	const options = new Options({
 		timeout: {
 			request: 1000


### PR DESCRIPTION
This merely changes the spelling of `separately` in the unit test name. Thank you for maintaining `got`!

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
