### PR TITLE
Allow `url` to start with a slash when `prefixUrl` is specified

### DIFF
--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -1188,7 +1188,7 @@ export default class Options {
 		}
 
 		if (is.string(value) && value.startsWith('/')) {
-			throw new Error('`url` must not start with a slash');
+			value = value.replace(/\/+/, '');
 		}
 
 		const urlString = `${this.prefixUrl as string}${value.toString()}`;

--- a/test/arguments.ts
+++ b/test/arguments.ts
@@ -404,12 +404,6 @@ test('throws a helpful error when passing `auth`', async t => {
 	});
 });
 
-test('throws on leading slashes', async t => {
-	await t.throwsAsync(got('/asdf', {prefixUrl: 'https://example.com'}), {
-		message: '`url` must not start with a slash',
-	});
-});
-
 test('throws on invalid `dnsCache` option', async t => {
 	await t.throwsAsync(got('https://example.com', {
 		// @ts-expect-error Error tests
@@ -456,6 +450,15 @@ test('does not throw on frozen options', withServer, async (t, server, got) => {
 	const {body} = await got(options);
 
 	t.is(body, '/');
+});
+
+test('removes leading slashes in url when prefixUrl is specified', t => {
+	const {url} = new Options({
+		prefixUrl: 'https://example.com/',
+		url: '/asdf',
+	});
+
+	t.is(url!.toString(), 'https://example.com/asdf');
 });
 
 test('encodes query string included in input', t => {


### PR DESCRIPTION
#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [ ] ~~If it's a new feature, I have included documentation updates in both the README and the types.~~
    Not a new feature. I could not find any documentation stating that a leading slash is not allowed in `url` when `prefixUrl` is specified, so I did not change anything.
