### PR TITLE
Rename `httpsOptions` to `https`

### DIFF
--- a/documentation/2-options.md
+++ b/documentation/2-options.md
@@ -79,7 +79,7 @@ instance(…, {responseType: undefined}});
 instance(…, {prefixUrl: ''});
 instance(…, {agent: {http: undefined, https: undefined, http2: undefined}});
 instance(…, {context: {token: undefined, …}});
-instance(…, {httpsOptions: {rejectUnauthorized: undefined, …}});
+instance(…, {https: {rejectUnauthorized: undefined, …}});
 instance(…, {cacheOptions: {immutableMinTimeToLive: undefined, …}});
 instance(…, {headers: {'user-agent': undefined, …}});
 instance(…, {timeout: {request: undefined, …}});
@@ -863,7 +863,7 @@ The local IP address used to make the request.
 
 The function used to retrieve a `net.Socket` instance when the `agent` option is not used.
 
-### `httpsOptions`
+### `https`
 
 **Type: `object`**
 

--- a/documentation/5-https.md
+++ b/documentation/5-https.md
@@ -2,7 +2,7 @@
 
 ## Advanced HTTPS API
 
-### `httpsOptions`
+### `https`
 
 **Type: `object`**
 
@@ -70,7 +70,7 @@ Private keys in [PEM format](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail
 Multiple keys with different passphrases can be provided as an array of `{pem: <string | Buffer>, passphrase: <string>}`.
 
 **Note:**
-> - Encrypted keys will be decrypted with `httpsOptions.passphrase`.
+> - Encrypted keys will be decrypted with `https.passphrase`.
 
 #### `passphrase`
 
@@ -89,13 +89,13 @@ Shared passphrase used for a single private key and/or a PFX.
 
 One certificate chain should be provided per private key.
 
-When providing multiple certificate chains, they do not have to be in the same order as their private keys in `httpsOptions.key`.
+When providing multiple certificate chains, they do not have to be in the same order as their private keys in `https.key`.
 
 #### `pfx`
 
 **Type: `string | Buffer | string[] | Buffer[] | object[]`**
 
-[PFX or PKCS12](https://en.wikipedia.org/wiki/PKCS_12) encoded private key and certificate chain. Using `httpsOptions.pfx` is an alternative to providing `httpsOptions.key` and `httpsOptions.certificate` individually. A PFX is usually encrypted, then `httpsOptions.passphrase` will be used to decrypt it.
+[PFX or PKCS12](https://en.wikipedia.org/wiki/PKCS_12) encoded private key and certificate chain. Using `https.pfx` is an alternative to providing `https.key` and `https.certificate` individually. A PFX is usually encrypted, then `https.passphrase` will be used to decrypt it.
 
 Multiple PFX can be be provided as an array of unencrypted buffers or an array of objects like:
 

--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -714,7 +714,7 @@ const cloneInternals = (internals: typeof defaultInternals): typeof defaultInter
 		...internals,
 		context: {...internals.context},
 		cacheOptions: {...internals.cacheOptions},
-		httpsOptions: {...internals.https},
+		https: {...internals.https},
 		agent: {...internals.agent},
 		headers: {...internals.headers},
 		retry: {

--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -649,7 +649,7 @@ const defaultInternals: Options['_internals'] = {
 		immutableMinTimeToLive: undefined,
 		ignoreCargoCult: undefined,
 	},
-	httpsOptions: {
+	https: {
 		alpnProtocols: undefined,
 		rejectUnauthorized: undefined,
 		checkServerIdentity: undefined,
@@ -714,7 +714,7 @@ const cloneInternals = (internals: typeof defaultInternals): typeof defaultInter
 		...internals,
 		context: {...internals.context},
 		cacheOptions: {...internals.cacheOptions},
-		httpsOptions: {...internals.httpsOptions},
+		httpsOptions: {...internals.https},
 		agent: {...internals.agent},
 		headers: {...internals.headers},
 		retry: {
@@ -841,7 +841,7 @@ export default class Options {
 		// This is way much faster than cloning ^_^
 		Object.freeze(options);
 		Object.freeze(options.hooks);
-		Object.freeze(options.httpsOptions);
+		Object.freeze(options.https);
 		Object.freeze(options.cacheOptions);
 		Object.freeze(options.agent);
 		Object.freeze(options.headers);
@@ -1950,11 +1950,11 @@ export default class Options {
 	/**
 	Options for the advanced HTTPS API.
 	*/
-	get httpsOptions(): HttpsOptions {
-		return this._internals.httpsOptions;
+	get https(): HttpsOptions {
+		return this._internals.https;
 	}
 
-	set httpsOptions(value: HttpsOptions) {
+	set https(value: HttpsOptions) {
 		assert.plainObject(value);
 
 		assert.any([is.boolean, is.undefined], value.rejectUnauthorized);
@@ -1976,15 +1976,15 @@ export default class Options {
 		assert.any([is.string, is.buffer, is.array, is.undefined], value.certificateRevocationLists);
 
 		for (const key in value) {
-			if (!(key in this._internals.httpsOptions)) {
+			if (!(key in this._internals.https)) {
 				throw new Error(`HTTPS option \`${key}\` does not exist`);
 			}
 		}
 
 		if (this._merging) {
-			Object.assign(this._internals.httpsOptions, value);
+			Object.assign(this._internals.https, value);
 		} else {
-			this._internals.httpsOptions = {...value};
+			this._internals.https = {...value};
 		}
 	}
 
@@ -2151,8 +2151,8 @@ export default class Options {
 			agent = internals.agent.http;
 		}
 
-		const {httpsOptions} = internals;
-		let {pfx} = httpsOptions;
+		const {https} = internals;
+		let {pfx} = https;
 
 		if (is.array(pfx) && is.plainObject(pfx[0])) {
 			pfx = (pfx as PfxObject[]).map(object => ({
@@ -2166,22 +2166,22 @@ export default class Options {
 			...this._unixOptions,
 
 			// HTTPS options
-			ca: httpsOptions.certificateAuthority,
-			cert: httpsOptions.certificate,
-			key: httpsOptions.key,
-			passphrase: httpsOptions.passphrase,
-			pfx: httpsOptions.pfx,
-			rejectUnauthorized: httpsOptions.rejectUnauthorized,
-			checkServerIdentity: httpsOptions.checkServerIdentity ?? checkServerIdentity,
-			ciphers: httpsOptions.ciphers,
-			honorCipherOrder: httpsOptions.honorCipherOrder,
-			minVersion: httpsOptions.minVersion,
-			maxVersion: httpsOptions.maxVersion,
-			sigalgs: httpsOptions.signatureAlgorithms,
-			sessionTimeout: httpsOptions.tlsSessionLifetime,
-			dhparam: httpsOptions.dhparam,
-			ecdhCurve: httpsOptions.ecdhCurve,
-			crl: httpsOptions.certificateRevocationLists,
+			ca: https.certificateAuthority,
+			cert: https.certificate,
+			key: https.key,
+			passphrase: https.passphrase,
+			pfx: https.pfx,
+			rejectUnauthorized: https.rejectUnauthorized,
+			checkServerIdentity: https.checkServerIdentity ?? checkServerIdentity,
+			ciphers: https.ciphers,
+			honorCipherOrder: https.honorCipherOrder,
+			minVersion: https.minVersion,
+			maxVersion: https.maxVersion,
+			sigalgs: https.signatureAlgorithms,
+			sessionTimeout: https.tlsSessionLifetime,
+			dhparam: https.dhparam,
+			ecdhCurve: https.ecdhCurve,
+			crl: https.certificateRevocationLists,
 
 			// HTTP options
 			lookup: internals.dnsLookup ?? (internals.dnsCache as CacheableLookup | undefined)?.lookup,
@@ -2237,7 +2237,7 @@ export default class Options {
 
 		Object.freeze(options);
 		Object.freeze(options.hooks);
-		Object.freeze(options.httpsOptions);
+		Object.freeze(options.https);
 		Object.freeze(options.cacheOptions);
 		Object.freeze(options.agent);
 		Object.freeze(options.headers);

--- a/test/agent.ts
+++ b/test/agent.ts
@@ -19,7 +19,7 @@ test('non-object agent option works with http', withServer, async (t, server, go
 	const {agent, spy} = createAgentSpy(HttpAgent);
 
 	t.truthy((await got({
-		httpsOptions: {
+		https: {
 			rejectUnauthorized: false,
 		},
 		agent: {
@@ -40,7 +40,7 @@ test('non-object agent option works with https', withHttpsServer(), async (t, se
 	const {agent, spy} = createAgentSpy(HttpsAgent);
 
 	t.truthy((await got({
-		httpsOptions: {
+		https: {
 			rejectUnauthorized: false,
 		},
 		agent: {

--- a/test/helpers/with-server.ts
+++ b/test/helpers/with-server.ts
@@ -85,7 +85,7 @@ const generateHttpsHook = (options?: HttpsServerOptions, installFakeTimer = fals
 			},
 		],
 		prefixUrl: server.url,
-		httpsOptions: {
+		https: {
 			certificateAuthority: (server as any).caCert,
 			rejectUnauthorized: true,
 		},

--- a/test/https.ts
+++ b/test/https.ts
@@ -17,7 +17,7 @@ test('https request without ca', withHttpsServer(), async (t, server, got) => {
 	});
 
 	t.truthy((await got({
-		httpsOptions: {
+		https: {
 			certificateAuthority: [],
 			rejectUnauthorized: false,
 		},
@@ -78,7 +78,7 @@ test('https request with `checkServerIdentity` OK', withHttpsServer(), async (t,
 	});
 
 	const {body} = await got({
-		httpsOptions: {
+		https: {
 			checkServerIdentity: (hostname: string, certificate: DetailedPeerCertificate) => {
 				t.is(hostname, 'localhost');
 				t.is(certificate.subject.CN, 'localhost');
@@ -96,7 +96,7 @@ test('https request with `checkServerIdentity` NOT OK', withHttpsServer(), async
 	});
 
 	const promise = got({
-		httpsOptions: {
+		https: {
 			checkServerIdentity: (hostname: string, certificate: DetailedPeerCertificate) => {
 				t.is(hostname, 'localhost');
 				t.is(certificate.subject.CN, 'localhost');
@@ -186,7 +186,7 @@ test.serial('non-deprecated `rejectUnauthorized` option', withHttpsServer(), asy
 	})();
 
 	await got({
-		httpsOptions: {
+		https: {
 			rejectUnauthorized: false,
 		},
 	});
@@ -217,7 +217,7 @@ test('client certificate', withHttpsServer(), async (t, server, got) => {
 	const clientCert = clientResult.certificate;
 
 	const response = await got({
-		httpsOptions: {
+		https: {
 			key: clientKey,
 			certificate: clientCert,
 		},
@@ -256,7 +256,7 @@ test('invalid client certificate (self-signed)', withHttpsServer(), async (t, se
 	const clientCert = clientResult.certificate;
 
 	const response = await got({
-		httpsOptions: {
+		https: {
 			key: clientKey,
 			certificate: clientCert,
 		},
@@ -298,7 +298,7 @@ test('invalid client certificate (other CA)', withHttpsServer(), async (t, serve
 	const clientCert = clientResult.certificate;
 
 	const response = await got({
-		httpsOptions: {
+		https: {
 			key: clientKey,
 			certificate: clientCert,
 		},
@@ -352,7 +352,7 @@ test('key passphrase', withHttpsServer(), async (t, server, got) => {
 	const clientCert = clientResult.certificate;
 
 	const response = await got({
-		httpsOptions: {
+		https: {
 			key: clientKey,
 			passphrase: 'randomPassword',
 			certificate: clientCert,
@@ -407,7 +407,7 @@ test('invalid key passphrase', withHttpsServer(), async (t, server, got) => {
 	const clientCert = clientResult.certificate;
 
 	const request = got({
-		httpsOptions: {
+		https: {
 			key: clientKey,
 			passphrase: 'wrongPassword',
 			certificate: clientCert,
@@ -444,7 +444,7 @@ test('client certificate PFX', withHttpsServer(), async (t, server, got) => {
 	const {pkcs12} = await createPkcs12(clientKey, clientCert, 'randomPassword');
 
 	const response = await got({
-		httpsOptions: {
+		https: {
 			pfx: pkcs12,
 			passphrase: 'randomPassword',
 		},
@@ -471,7 +471,7 @@ test('https request with `ciphers` option', withHttpsServer({ciphers: `${ciphers
 	});
 
 	const response = await got({
-		httpsOptions: {
+		https: {
 			ciphers: ciphers[0],
 		},
 	}).json<{cipher: string}>();
@@ -487,7 +487,7 @@ test('https request with `honorCipherOrder` option', withHttpsServer({ciphers: `
 	});
 
 	const response = await got({
-		httpsOptions: {
+		https: {
 			ciphers: `${ciphers[1]!}:${ciphers[0]!}`,
 			honorCipherOrder: true,
 		},
@@ -504,7 +504,7 @@ test('https request with `minVersion` option', withHttpsServer({maxVersion: 'TLS
 	});
 
 	const request = got({
-		httpsOptions: {
+		https: {
 			minVersion: 'TLSv1.3',
 		},
 	});

--- a/test/merge-instances.ts
+++ b/test/merge-instances.ts
@@ -118,33 +118,33 @@ test('URL is not polluted', withServer, async (t, server, got) => {
 });
 
 test('merging instances with HTTPS options', t => {
-	const instanceA = got.extend({httpsOptions: {
+	const instanceA = got.extend({https: {
 		rejectUnauthorized: true,
 		certificate: 'FIRST',
 	}});
-	const instanceB = got.extend({httpsOptions: {
+	const instanceB = got.extend({https: {
 		certificate: 'SECOND',
 	}});
 
 	const merged = instanceA.extend(instanceB);
 
-	t.true(merged.defaults.options.httpsOptions.rejectUnauthorized);
-	t.is(merged.defaults.options.httpsOptions.certificate, 'SECOND');
+	t.true(merged.defaults.options.https.rejectUnauthorized);
+	t.is(merged.defaults.options.https.certificate, 'SECOND');
 });
 
 test('merging instances with HTTPS options undefined', t => {
-	const instanceA = got.extend({httpsOptions: {
+	const instanceA = got.extend({https: {
 		rejectUnauthorized: true,
 		certificate: 'FIRST',
 	}});
-	const instanceB = got.extend({httpsOptions: {
+	const instanceB = got.extend({https: {
 		certificate: undefined,
 	}});
 
 	const merged = instanceA.extend(instanceB);
 
-	t.true(merged.defaults.options.httpsOptions.rejectUnauthorized);
-	t.is(merged.defaults.options.httpsOptions.certificate, undefined);
+	t.true(merged.defaults.options.https.rejectUnauthorized);
+	t.is(merged.defaults.options.https.certificate, undefined);
 });
 
 test('accepts options for promise API', t => {

--- a/test/timeout.ts
+++ b/test/timeout.ts
@@ -338,7 +338,7 @@ test('secureConnect timeout not breached', withServer, async (t, server, got) =>
 		retry: {
 			limit: 0,
 		},
-		httpsOptions: {
+		https: {
 			rejectUnauthorized: false,
 		},
 	}));


### PR DESCRIPTION
@sindresorhus TBH I'd prefer if we named this `httpsOptions` because there is `cacheOptions`. But I leave this up to you :)