### PR TITLE
Add `got-scraping` to Got plugins in Readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -150,6 +150,7 @@ For advanced JSON usage, check out the [`parseJson`](documentation/2-options.md#
 - [`gl-got`](https://github.com/singapore/gl-got) - Got convenience wrapper to interact with the GitLab API
 - [`gotql`](https://github.com/khaosdoctor/gotql) - Got convenience wrapper to interact with GraphQL using JSON-parsed queries instead of strings
 - [`got-fetch`](https://github.com/alexghr/got-fetch) - Got with a [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) interface
+- [`got-scraping`](https://github.com/apify/got-scraping) - Got wrapper specifically designed for web scraping purposes
 
 ### Legacy
 


### PR DESCRIPTION
Thank you for this great library. We built a special-purpose wrapper that extends `got` with automatically generated browser-like headers, auto-detection of HTTP(2) proxy agents, proper browser-like ciphers and a few more goodies targeted specifically at large scale web scraping. It would be amazing if it could be featured here among the other Got plugins.

Thanks for the consideration!

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates in both the README and the types.