### PR TITLE
drop `nyc` devDep & conf

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
 		"nock": "^13.1.3",
 		"node-fetch": "^2.6.1",
 		"np": "^7.5.0",
-		"nyc": "^15.1.0",
 		"p-event": "^4.2.0",
 		"pem": "^1.14.4",
 		"pify": "^5.0.0",
@@ -119,19 +118,6 @@
 		},
 		"nodeArguments": [
 			"--loader=ts-node/esm"
-		]
-	},
-	"nyc": {
-		"reporter": [
-			"text",
-			"html",
-			"lcov"
-		],
-		"extension": [
-			".ts"
-		],
-		"exclude": [
-			"**/test/**"
 		]
 	},
 	"xo": {


### PR DESCRIPTION
I notice that `nyc` is declared but no longer used... Feel free to ignore and close this PR if irrelevant.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates in both the README and the types.
