### PR TITLE
Fix links in Errors documentation

### DIFF
--- a/documentation/8-errors.md
+++ b/documentation/8-errors.md
@@ -3,9 +3,9 @@
 ## Errors
 
 Source code:
-- [`source/core/errors.ts`](source/core/errors.ts)
-- [`source/as-promise/types.ts`](source/as-promise/types.ts)
-- [`source/core/response.ts`](source/core/response.ts)
+- [`source/core/errors.ts`](../source/core/errors.ts)
+- [`source/as-promise/types.ts`](../source/as-promise/types.ts)
+- [`source/core/response.ts`](../source/core/response.ts)
 
 All Got errors contain various metadata, such as:
 


### PR DESCRIPTION
Links lead to the relative location like this https://github.com/sindresorhus/got/blob/main/documentation/source/core/errors.ts, which leads to 404 error.

#### Checklist

- [ ] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates in both the README and the types.
