### PR TITLE
Add `got-ssrf` to plugins section in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -162,6 +162,7 @@ For advanced JSON usage, check out the [`parseJson`](documentation/2-options.md#
 - [`gotql`](https://github.com/khaosdoctor/gotql) - Got convenience wrapper to interact with GraphQL using JSON-parsed queries instead of strings
 - [`got-fetch`](https://github.com/alexghr/got-fetch) - Got with a [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) interface
 - [`got-scraping`](https://github.com/apify/got-scraping) - Got wrapper specifically designed for web scraping purposes
+- [`got-ssrf`](https://github.com/JaneJeon/got-ssrf) - Got wrapper to protect server-side requests against SSRF attacks
 
 ### Legacy
 


### PR DESCRIPTION
I maintain got-ssrf, and I use it to protect got requests (from nodejs) from hitting internal services, for stuff like webhooks. I wanted to add it to the plugin list as SSRFs can be escalated to “essentially RCEs” under certain circumstances.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] If it's a new feature, I have included documentation updates in both the README and the types.