### PR TITLE
Fix a broken link in docs

### DIFF
--- a/documentation/8-errors.md
+++ b/documentation/8-errors.md
@@ -10,7 +10,7 @@ Source code:
 All Got errors contain various metadata, such as:
 
 - `code` - A string like `ERR_NON_2XX_3XX_RESPONSE`,
-- `options` - An instance of [`Options`](`2-options.md`),
+- `options` - An instance of [`Options`](2-options.md),
 - `request` - An instance of Got Stream,
 - `response` (optional) - An instance of Got Response,
 - `timings` (optional) - Points to `response.timings`.


### PR DESCRIPTION
A link of documentation (8 → 2) is improperly formatted by the inline code syntax. Remove it.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
→ I tested the link in the preview.
- [ ] ~~If it's a new feature, I have included documentation updates in both the README and the types.~~
