### PR TITLE
fix: add Number as accepted header type

### DIFF
--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -52,7 +52,7 @@ export interface Agents {
 	http2?: unknown | false;
 }
 
-export type Headers = Record<string, string | string[] | undefined>;
+export type Headers = Record<string, string | Number | string[] | undefined>;
 
 export interface ToughCookieJar {
 	getCookieString: ((currentUrl: string, options: Record<string, unknown>, cb: (error: Error | null, cookies: string) => void) => void)


### PR DESCRIPTION
I recently wanted to add `"content-length": a-number` to the headers of a request with `got`. However, Typescript complained about this. Is there a reason for this? If so, I'd like to know why. In the meantime this PR will allow for numbers in the future.

PS: first open source contribution ever.