### PR TITLE
Fix `deflate` responses not being decompressed

### DIFF
--- a/source/as-promise/index.ts
+++ b/source/as-promise/index.ts
@@ -53,7 +53,7 @@ export default function asPromise<T>(firstRequest?: Request): CancelableRequest<
 			request.once('response', async (response: Response) => {
 				// Parse body
 				const contentEncoding = (response.headers['content-encoding'] ?? '').toLowerCase();
-				const isCompressed = contentEncoding === 'gzip' || contentEncoding === 'defalte' || contentEncoding === 'br';
+				const isCompressed = contentEncoding === 'gzip' || contentEncoding === 'deflate' || contentEncoding === 'br';
 
 				const {options} = request;
 


### PR DESCRIPTION
I think this should be deflate.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates in both the README and the types.
