### PR TITLE
Export `Request` type

### DIFF
--- a/documentation/typescript.md
+++ b/documentation/typescript.md
@@ -40,6 +40,8 @@ Here's a list of types that Got exports:
 
 ### [`Response<T = unknown>`](https://github.com/sindresorhus/got/blob/ae04c0e36cf3f5b2e356df7d48a5b19988f935a2/source/core/response.ts#L95)
 
+### [`Request`](https://github.com/sindresorhus/got/blob/ae04c0e36cf3f5b2e356df7d48a5b19988f935a2/source/core/index.ts#L139)
+
 ### [`RequestEvents<T>`](https://github.com/sindresorhus/got/blob/ae04c0e36cf3f5b2e356df7d48a5b19988f935a2/source/core/index.ts#L108)
 
 ### [`InstanceDefaults`](https://github.com/sindresorhus/got/blob/ae04c0e36cf3f5b2e356df7d48a5b19988f935a2/source/types.ts#L17)

--- a/documentation/typescript.md
+++ b/documentation/typescript.md
@@ -40,7 +40,7 @@ Here's a list of types that Got exports:
 
 ### [`Response<T = unknown>`](https://github.com/sindresorhus/got/blob/ae04c0e36cf3f5b2e356df7d48a5b19988f935a2/source/core/response.ts#L95)
 
-### [`Request`](https://github.com/sindresorhus/got/blob/ae04c0e36cf3f5b2e356df7d48a5b19988f935a2/source/core/index.ts#L139)
+### [`Request`](https://github.com/sindresorhus/got/blob/ecb05343dea3bd35933585a1ec5bcea01348d109/source/core/index.ts#L139)
 
 ### [`RequestEvents<T>`](https://github.com/sindresorhus/got/blob/ae04c0e36cf3f5b2e356df7d48a5b19988f935a2/source/core/index.ts#L108)
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -16,6 +16,7 @@ export {got};
 export {default as Options} from './core/options.js';
 export * from './core/options.js';
 export * from './core/response.js';
+export {default as Request} from './core/index.js';
 export * from './core/index.js';
 export * from './core/errors.js';
 export {Delays} from './core/timed-out.js';

--- a/source/index.ts
+++ b/source/index.ts
@@ -16,7 +16,7 @@ export {got};
 export {default as Options} from './core/options.js';
 export * from './core/options.js';
 export * from './core/response.js';
-export {default as Request} from './core/index.js';
+export type {default as Request} from './core/index.js';
 export * from './core/index.js';
 export * from './core/errors.js';
 export {Delays} from './core/timed-out.js';


### PR DESCRIPTION
This PR exports the `Request` class, and update the typescript documentation accordingly.

I didn't found any export related tests, but if provided some pointers where they live, I would be happy to write one.

Fixes #1939

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates in both the README and the types.
