### PR TITLE
Add HTTP/1 and HTTP/2 timings tests

### DIFF
--- a/test/timings.ts
+++ b/test/timings.ts
@@ -1,14 +1,18 @@
 import test from 'ava';
 import got from '../source/index.js';
+import withServer from './helpers/with-server.js';
 
-test('http/1 timings', async t => {
-	const {timings} = await got('https://httpbin.org/anything');
+test('http/1 timings', withServer, async (t, server, got) => {
+	server.get('/', (_request, response) => {
+		response.end('ok');
+	});
+
+	const {timings} = await got('');
 
 	t.true(timings.start >= 0);
 	t.true(timings.socket! >= 0);
 	t.true(timings.lookup! >= 0);
 	t.true(timings.connect! >= 0);
-	t.true(timings.secureConnect! >= 0);
 	t.true(timings.upload! >= 0);
 	t.true(timings.response! >= 0);
 	t.true(timings.end! >= 0);
@@ -18,7 +22,6 @@ test('http/1 timings', async t => {
 	t.true(phases.wait! >= 0);
 	t.true(phases.dns! >= 0);
 	t.true(phases.tcp! >= 0);
-	t.true(phases.tls! >= 0);
 	t.true(phases.request! >= 0);
 	t.true(phases.firstByte! >= 0);
 	t.true(phases.download! >= 0);

--- a/test/timings.ts
+++ b/test/timings.ts
@@ -2,9 +2,7 @@ import test from 'ava';
 import got from '../source/index.js';
 
 test('http/1 timings', async t => {
-	const request = await got('https://httpbin.org/anything');
-
-	const {timings} = request;
+	const {timings} = await got('https://httpbin.org/anything');
 
 	t.true(timings.start >= 0);
 	t.true(timings.socket! >= 0);
@@ -25,14 +23,10 @@ test('http/1 timings', async t => {
 	t.true(phases.firstByte! >= 0);
 	t.true(phases.download! >= 0);
 	t.true(phases.total! >= 0);
-
-	t.pass();
 });
 
-test('http/2 timings', async t => {
-	const request = await got('https://httpbin.org/anything', {http2: true});
-
-	const {timings} = request;
+test.failing('http/2 timings', async t => {
+	const {timings} = await got('https://httpbin.org/anything', {http2: true});
 
 	t.true(timings.start >= 0);
 	t.true(timings.socket! >= 0);
@@ -53,6 +47,4 @@ test('http/2 timings', async t => {
 	t.true(phases.firstByte! >= 0);
 	t.true(phases.download! >= 0);
 	t.true(phases.total! >= 0);
-
-	t.pass();
 });

--- a/test/timings.ts
+++ b/test/timings.ts
@@ -1,0 +1,58 @@
+import test from 'ava';
+import got from '../source/index.js';
+
+test('http/1 timings', async t => {
+	const request = await got('https://httpbin.org/anything');
+
+	const {timings} = request;
+
+	t.true(timings.start >= 0);
+	t.true(timings.socket! >= 0);
+	t.true(timings.lookup! >= 0);
+	t.true(timings.connect! >= 0);
+	t.true(timings.secureConnect! >= 0);
+	t.true(timings.upload! >= 0);
+	t.true(timings.response! >= 0);
+	t.true(timings.end! >= 0);
+
+	const {phases} = timings;
+
+	t.true(phases.wait! >= 0);
+	t.true(phases.dns! >= 0);
+	t.true(phases.tcp! >= 0);
+	t.true(phases.tls! >= 0);
+	t.true(phases.request! >= 0);
+	t.true(phases.firstByte! >= 0);
+	t.true(phases.download! >= 0);
+	t.true(phases.total! >= 0);
+
+	t.pass();
+});
+
+test('http/2 timings', async t => {
+	const request = await got('https://httpbin.org/anything', {http2: true});
+
+	const {timings} = request;
+
+	t.true(timings.start >= 0);
+	t.true(timings.socket! >= 0);
+	t.true(timings.lookup! >= 0);
+	t.true(timings.connect! >= 0);
+	t.true(timings.secureConnect! >= 0);
+	t.true(timings.upload! >= 0);
+	t.true(timings.response! >= 0);
+	t.true(timings.end! >= 0);
+
+	const {phases} = timings;
+
+	t.true(phases.wait! >= 0);
+	t.true(phases.dns! >= 0);
+	t.true(phases.tcp! >= 0);
+	t.true(phases.tls! >= 0);
+	t.true(phases.request! >= 0);
+	t.true(phases.firstByte! >= 0);
+	t.true(phases.download! >= 0);
+	t.true(phases.total! >= 0);
+
+	t.pass();
+});


### PR DESCRIPTION
This PR implements tests to make sure the `timings` and `timings.phases` values are not missing in both http/1 and http/2.
It is currently failing for an http/2 request.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates in both the README and the types.
