### PR TITLE
Fix `nock` compatibility

### DIFF
--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -3,8 +3,8 @@ import {Buffer} from 'node:buffer';
 import {promisify, inspect} from 'node:util';
 import {URL, URLSearchParams} from 'node:url';
 import {checkServerIdentity} from 'node:tls';
-import {request as httpRequest} from 'node:http';
-import {request as httpsRequest} from 'node:https';
+import http from 'node:http';
+import https from 'node:https';
 import type {Readable} from 'node:stream';
 import type {Socket} from 'node:net';
 import type {SecureContextOptions, DetailedPeerCertificate} from 'node:tls';
@@ -2447,10 +2447,10 @@ export default class Options {
 				return http2wrapper.auto as RequestFunction;
 			}
 
-			return httpsRequest;
+			return https.request;
 		}
 
-		return httpRequest;
+		return http.request;
 	}
 
 	freeze() {

--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -3,8 +3,7 @@ import {Buffer} from 'node:buffer';
 import {promisify, inspect} from 'node:util';
 import {URL, URLSearchParams} from 'node:url';
 import {checkServerIdentity} from 'node:tls';
-// The way of destructuring is not compatible with `nock`.
-// DO NOT use destructuring assignment for https.request and http.request.
+// DO NOT use destructuring for `https.request` and `http.request` as it's not compatible with `nock`.
 import http from 'node:http';
 import https from 'node:https';
 import type {Readable} from 'node:stream';

--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -3,6 +3,8 @@ import {Buffer} from 'node:buffer';
 import {promisify, inspect} from 'node:util';
 import {URL, URLSearchParams} from 'node:url';
 import {checkServerIdentity} from 'node:tls';
+// The way of destructuring is not compatible with `nock`.
+// DO NOT use destructuring assignment for https.request and http.request.
 import http from 'node:http';
 import https from 'node:https';
 import type {Readable} from 'node:stream';


### PR DESCRIPTION
It seems that `got` does not compatible with `nock` as of version 12.

This PR makes `got` be compatible with `nock`.

**Version before 12:**
![got2](https://user-images.githubusercontent.com/5173298/148678607-d59bec6e-f6c1-4328-9592-c12b8a41b76d.jpg)

**As of version 12:**
![got1](https://user-images.githubusercontent.com/5173298/148678610-ac3a8fad-8345-4e8d-a16f-7ee900a7e29e.jpg)

**Cause:**
`nock`  implements mocking by hacking native http.request/https.request object.
The way of destructuring is not compatible with `nock`.



---

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates in both the README and the types.
