### PR TITLE
Update docs on how to disable the retry feature with Got 12

### DIFF
--- a/documentation/2-options.md
+++ b/documentation/2-options.md
@@ -7,7 +7,7 @@ Source code: [`source/core/options.ts`](../source/core/options.ts)
 Like `fetch` stores the options in a `Request` instance, Got does so in `Options`.\
 It is made of getters and setters that provide fast option normalization and validation.
 
-**By default, Got will retry on failure. To disable this option, set [`options.retry`](7-retry.md) to `0`.**
+**By default, Got will retry on failure. To disable this option, set [`options.retry`](7-retry.md) to `{limit: 0}`.**
 
 #### Merge behavior explained
 


### PR DESCRIPTION
Passing a number to the `retry` option is not supported anymore with got@12

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates in both the README and the types.
