### PR TITLE
Document `response` event in stream docs

### DIFF
--- a/documentation/3-streams.md
+++ b/documentation/3-streams.md
@@ -174,7 +174,7 @@ This is emitted when a HTTP response is received.
 
 ```js
 import got from 'got';
-import { pipeline } from 'pipeline';
+import { pipeline } from 'node:stream/promises';
 import { createWriteStream } from 'node:fs';
 
 const readStream = got.stream('http://example.com/image.png', { throwHttpErrors: false });

--- a/documentation/3-streams.md
+++ b/documentation/3-streams.md
@@ -164,6 +164,38 @@ Whether the socket was used for other previous requests.
 
 ## Events
 
+### `stream.on('response', ...)`
+
+#### `response`
+
+**Type: [`PlainResponse`](typescript.md#plainresponse)**
+
+This is emitted when a HTTP response is received.
+
+```js
+import got from 'got';
+import { pipeline } from 'pipeline';
+import { createWriteStream } from 'node:fs';
+
+const readStream = got.stream('http://example.com/image.png', { throwHttpErrors: false });
+
+readStream.on('response', async (response) => {
+	if (response.statusCode !== 200) {
+		console.log('failed');
+		readStream.destroy(); // destroy the stream to prevent hanging resources
+
+		return;
+	}
+
+	await pipeline(
+		readStream,
+		createWriteStream('image.png')
+	);
+
+	console.log('success');
+})
+```
+
 ### `stream.on('downloadProgress', …)`
 
 #### `progress`

--- a/documentation/3-streams.md
+++ b/documentation/3-streams.md
@@ -179,18 +179,18 @@ import got from 'got';
 
 const readStream = got.stream('http://example.com/image.png', {throwHttpErrors: false});
 
-const onError = (error) => {
+const onError = error => {
 	// Do something with it.
 };
 
 readStream.on('response', async response => {
 	if (response.headers.age > 3600) {
 		console.log('Failure - response too old');
-		readStream.destroy(); // Destroy the stream to prevent hanging resources
+		readStream.destroy(); // Destroy the stream to prevent hanging resources.
 		return;
 	}
 
-	// Prevent onError being called twice
+	// Prevent `onError` being called twice.
 	readStream.off('error', onError);
 
 	try {

--- a/documentation/3-streams.md
+++ b/documentation/3-streams.md
@@ -164,7 +164,7 @@ Whether the socket was used for other previous requests.
 
 ## Events
 
-### `stream.on('response', ...)`
+### `stream.on('response', …)`
 
 #### `response`
 

--- a/documentation/3-streams.md
+++ b/documentation/3-streams.md
@@ -173,17 +173,16 @@ Whether the socket was used for other previous requests.
 This is emitted when a HTTP response is received.
 
 ```js
+import {pipeline} from 'node:stream/promises';
+import {createWriteStream} from 'node:fs';
 import got from 'got';
-import { pipeline } from 'node:stream/promises';
-import { createWriteStream } from 'node:fs';
 
-const readStream = got.stream('http://example.com/image.png', { throwHttpErrors: false });
+const readStream = got.stream('http://example.com/image.png', {throwHttpErrors: false});
 
-readStream.on('response', async (response) => {
+readStream.on('response', async response => {
 	if (response.statusCode !== 200) {
-		console.log('failed');
-		readStream.destroy(); // destroy the stream to prevent hanging resources
-
+		console.log('Failure');
+		readStream.destroy(); // Destroy the stream to prevent hanging resources
 		return;
 	}
 
@@ -192,7 +191,7 @@ readStream.on('response', async (response) => {
 		createWriteStream('image.png')
 	);
 
-	console.log('success');
+	console.log('Success');
 })
 ```
 


### PR DESCRIPTION
I've added documentation in the form of an example around the got.stream response event.

Fixes #1955
 
#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] If it's a new feature, I have included documentation updates in both the README and the types.
