### PR TITLE
`paginate` has 3 arguments

### DIFF
--- a/documentation/4-pagination.md
+++ b/documentation/4-pagination.md
@@ -77,7 +77,7 @@ console.log(results);
 
 		return JSON.parse(response.body as string);
 	},
-	paginate: ({response}) => {
+	paginate: (response) => {
 		const rawLinkHeader = response.headers.link;
 		if (typeof rawLinkHeader !== 'string' || rawLinkHeader.trim() === '') {
 			return false;
@@ -201,7 +201,7 @@ const max = Date.now() - 1000 * 86400 * 7;
 
 const iterator = got.paginate('https://api.github.com/repos/sindresorhus/got/commits', {
 	pagination: {
-		paginate: ({response, currentItems}) => {
+		paginate: (response, currentItems) => {
 			// If there are no more data, finish.
 			if (currentItems.length === 0) {
 				return false;


### PR DESCRIPTION
The example destructures, but I'm seeing the `response` on the first argument.

#### Checklist

- [ ] I have read the documentation.
- [x ] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates in both the README and the types.
