### PR TITLE
Fix encoding with json `responseType`

### DIFF
--- a/source/core/response.ts
+++ b/source/core/response.ts
@@ -138,7 +138,7 @@ export const parseBody = (response: Response, responseType: ResponseType, parseJ
 		}
 
 		if (responseType === 'json') {
-			return rawBody.length === 0 ? '' : parseJson(rawBody.toString());
+			return rawBody.length === 0 ? '' : parseJson(rawBody.toString(encoding));
 		}
 
 		if (responseType === 'buffer') {

--- a/test/encoding.ts
+++ b/test/encoding.ts
@@ -1,0 +1,19 @@
+import {Buffer} from 'buffer';
+import test from 'ava';
+import withServer from './helpers/with-server.js';
+
+test('encoding works with json', withServer, async (t, server, got) => {
+	const json = {data: 'é'};
+
+	server.get('/', (_request, response) => {
+		response.set('Content-Type', 'application-json');
+		response.send(Buffer.from(JSON.stringify(json), 'latin1'));
+	});
+
+	const response = await got('', {
+		encoding: 'latin1',
+		responseType: 'json',
+	});
+
+	t.deepEqual(response.body, json);
+});

--- a/test/retry.ts
+++ b/test/retry.ts
@@ -171,7 +171,9 @@ test('custom error codes', async t => {
 		request: () => {
 			const emitter = new EventEmitter() as http.ClientRequest;
 			emitter.abort = () => {};
+			// @ts-expect-error Imitating a stream
 			emitter.end = () => {};
+			// @ts-expect-error Imitating a stream
 			emitter.destroy = () => {};
 			// @ts-expect-error Imitating a stream
 			emitter.writable = true;


### PR DESCRIPTION
All the details are in the issue.

Fixes #1988
