### PR TITLE
Fix misspelling of `Primitive` in documentation

### DIFF
--- a/documentation/2-options.md
+++ b/documentation/2-options.md
@@ -341,7 +341,7 @@ console.log(data);
 
 ### `form`
 
-**Type: <code>object&lt;string, [Primitve](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html)&gt;</code>**
+**Type: <code>object&lt;string, [Primitive](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html)&gt;</code>**
 
 The form body is converted to a query string using `(new URLSearchParams(form)).toString()`.
 


### PR DESCRIPTION
In the type documentation for the `form` field of the `Options`, `Primitive` was misspelled as `Primitve`. I have corrected this.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] If it's a new feature, I have included documentation updates in both the README and the types.
