### PR TITLE
fix: allow other json values

### DIFF
--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -1349,13 +1349,11 @@ export default class Options {
 
 	__Note #2__: This option is not enumerable and will not be merged with the instance defaults.
 	*/
-	get json(): Record<string, any> | undefined {
+	get json(): any {
 		return this._internals.json;
 	}
 
-	set json(value: Record<string, any> | undefined) {
-		assert.any([is.object, is.undefined], value);
-
+	set json(value: any) {
 		if (value !== undefined) {
 			assert.undefined(this._internals.body);
 			assert.undefined(this._internals.form);


### PR DESCRIPTION
related to https://github.com/sindresorhus/got/issues/2013

@szmarczak proposed to use `any` for the json value type.

it works and passes all current tests on my machine.

if you prefer to avoid `any` and use types then the following also works and passes tests:

```
	get json(): Record<string, any> | string | number | boolean | undefined {
		return this._internals.json;
	}

	set json(value: Record<string, any> | string | number | boolean | undefined) {
		assert.any([is.object, is.string, is.number, is.boolean, is.null_, is.undefined], value);
		...
```