### PR TITLE
Backport #1543: Initialize globalResponse in case of ignored HTTPError

### DIFF
--- a/source/as-promise/index.ts
+++ b/source/as-promise/index.ts
@@ -124,12 +124,12 @@ export default function asPromise<T>(normalizedOptions: NormalizedOptions): Canc
 					return;
 				}
 
+				globalResponse = response;
+				
 				if (!isResponseOk(response)) {
 					request._beforeError(new HTTPError(response));
 					return;
 				}
-
-				globalResponse = response;
 
 				resolve(request.options.resolveBodyOnly ? response.body as T : response as unknown as T);
 			});

--- a/test/promise.ts
+++ b/test/promise.ts
@@ -85,3 +85,13 @@ test('promise.json() can be called before a file stream body is open', withServe
 
 	await Promise.all(checks);
 });
+
+test('promise.json() does not fail when server returns an error and throwHttpErrors is disabled', withServer, async (t, server, got) => {
+	server.get('/', (_request, response) => {
+		response.statusCode = 400;
+		response.end('{}');
+	});
+
+	const promise = got('', {throwHttpErrors: false});
+	await t.notThrowsAsync(promise.json());
+});


### PR DESCRIPTION
Backports #1543 to `v11`

Fixes #1540 :

> When the server returns an error code with JSON body, and I try to parse it using .json() and {throwHttpErrors: false}, I get the following error:
> ```js
> TypeError: Cannot read property 'request' of undefined
>     at /path/to/my/project/node_modules/got/dist/source/as-promise/index.js:157:48
>     at processTicksAndRejections (internal/process/task_queues.js:93:5)
> ```
> 

#### Checklist

- [ ] I have read the documentation.
- [X] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates in both the README and the types.
