### PR TITLE
fix link to Promise on MDN

### DIFF
--- a/documentation/1-promise.md
+++ b/documentation/1-promise.md
@@ -4,7 +4,7 @@
 
 Source code: [`source/as-promise/index.ts`](../source/as-promise/index.ts)
 
-The main Got function returns a [`Promise`](https://developer.mozilla.org/pl/docs/Web/JavaScript/Reference/Global_Objects/Promise).\
+The main Got function returns a [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise).\
 Although in order to support cancelation, [`PCancelable`](https://github.com/sindresorhus/p-cancelable) is used instead of pure `Promise`.
 
 ### <code>got(url: string | URL, options?: [OptionsInit](typescript.md#optionsinit), defaults?: [Options](2-options.md))</code>


### PR DESCRIPTION
The link for "Promise" goes to [the Polish translation on MDN](https://developer.mozilla.org/pl/docs/Web/JavaScript/Reference/Global_Objects/Promise).  It should be without language so people get MDN in their desired language instead. 

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates in both the README and the types.
