### PR TITLE
Meta tweak

### DIFF
--- a/documentation/tips.md
+++ b/documentation/tips.md
@@ -43,14 +43,12 @@ Got supports cookies out of box. There is no need to parse them manually.\
 In order to use cookies, pass a `CookieJar` instance from the [`tough-cookie`](https://github.com/salesforce/tough-cookie) package.
 
 ```js
-import {promisify} from 'node:util';
 import got from 'got';
 import {CookieJar} from 'tough-cookie';
 
 const cookieJar = new CookieJar();
-const setCookie = promisify(cookieJar.setCookie.bind(cookieJar));
 
-await setCookie('foo=bar', 'https://httpbin.org');
+await cookieJar.setCookie('foo=bar', 'https://httpbin.org');
 await got('https://httpbin.org/anything', {cookieJar});
 ```
 


### PR DESCRIPTION
Since at least [v4](https://github.com/salesforce/tough-cookie/blob/30246e6c039f91ca33fab2046ffdf7a2d3d8c33c/CHANGELOG.md#breaking-changes-major-version), `tough-cookie` [returns promises](https://github.com/salesforce/tough-cookie/blob/2921fbdfe11e310b1b0835b4d050575578b4b2c3/lib/cookie.js#L1705) if a callback is not provided.