### PR TITLE
Add missing `method` option example

### DIFF
--- a/documentation/2-options.md
+++ b/documentation/2-options.md
@@ -220,7 +220,9 @@ The most common methods are: `GET`, `HEAD`, `POST`, `PUT`, `DELETE`.
 ```js
 import got from 'got';
 
-const {method} = await got.post('https://httpbin.org/anything').json();
+const {method} = await got('https://httpbin.org/anything', {
+	method: 'POST'
+}).json();
 
 console.log(method);
 // => 'POST'


### PR DESCRIPTION
#### Checklist

- [X] I have read the documentation.
- [X] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates in both the README and the types.

#### Description

An example of how to use the `method` option was missing in the docs section relating to options and how to use them.