### PR TITLE
Add `response.ok`

### DIFF
--- a/documentation/3-streams.md
+++ b/documentation/3-streams.md
@@ -359,7 +359,7 @@ Whether the response comes from cache or not.
 **Type: `boolean`**
 
 **Note:**
-> - This property need not be checked if throwHttpErrors is true.
+> - Got throws automatically when `response.ok` is `false` and `throwHttpErrors` is `true`.
 
 Whether the response was successful (status code in the range 200-299).
 

--- a/documentation/3-streams.md
+++ b/documentation/3-streams.md
@@ -354,6 +354,15 @@ The server's IP address.
 
 Whether the response comes from cache or not.
 
+### `ok`
+
+**Type: `boolean`**
+
+**Note:**
+> - This property need not be checked if throwHttpErrors is true.
+
+Whether the response was successful (status code in the range 200-299).
+
 ### `statusCode`
 
 **Type: `number`**

--- a/documentation/3-streams.md
+++ b/documentation/3-streams.md
@@ -358,10 +358,13 @@ Whether the response comes from cache or not.
 
 **Type: `boolean`**
 
-**Note:**
-> - Got throws automatically when `response.ok` is `false` and `throwHttpErrors` is `true`.
+Whether the response was successful
 
-Whether the response was successful (status code in the range 200-299).
+**Note:**
+> - A request is successful when the status code of the final request is `2xx` or `3xx`.
+> - When [following redirects](2-options.md#followredirect), a request is successful **only** when the status code of the final request is `2xx`.
+> - `304` responses are always considered successful.
+> - Got throws automatically when `response.ok` is `false` and `throwHttpErrors` is `true`.
 
 ### `statusCode`
 

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -147,7 +147,6 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 	requestUrl?: URL;
 	redirectUrls: URL[];
 	retryCount: number;
-	ok?: boolean;
 
 	declare private _requestOptions: NativeRequestOptions;
 
@@ -633,7 +632,7 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 		typedResponse.isFromCache = (this._nativeResponse as any).fromCache ?? false;
 		typedResponse.ip = this.ip;
 		typedResponse.retryCount = this.retryCount;
-		typedResponse.ok = (statusCode >= 200 && statusCode <= 299);
+		typedResponse.ok = isResponseOk(typedResponse);
 
 		this._isFromCache = typedResponse.isFromCache;
 

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -147,6 +147,7 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 	requestUrl?: URL;
 	redirectUrls: URL[];
 	retryCount: number;
+	ok?: boolean;
 
 	declare private _requestOptions: NativeRequestOptions;
 
@@ -632,6 +633,7 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 		typedResponse.isFromCache = (this._nativeResponse as any).fromCache ?? false;
 		typedResponse.ip = this.ip;
 		typedResponse.retryCount = this.retryCount;
+		typedResponse.ok = (statusCode >= 200 && statusCode <= 299);
 
 		this._isFromCache = typedResponse.isFromCache;
 

--- a/source/core/response.ts
+++ b/source/core/response.ts
@@ -93,8 +93,9 @@ export interface PlainResponse extends IncomingMessageWithTimings {
 	body?: unknown;
 
 	/**
-	Whether the response was successful (status code in the range 200-299).
-	This property need not be checked if throwHttpErrors is true.
+	Whether the response was successful.
+
+	__Note__: Got throws automatically when `response.ok` is `false` and `throwHttpErrors` is `true`.
 	*/
 	ok: boolean;
 }

--- a/source/core/response.ts
+++ b/source/core/response.ts
@@ -91,6 +91,11 @@ export interface PlainResponse extends IncomingMessageWithTimings {
 	The result of the request.
 	*/
 	body?: unknown;
+
+	/**
+	Whether the response status code is 2xx.
+	*/
+	ok?: boolean;
 }
 
 // For Promise support

--- a/source/core/response.ts
+++ b/source/core/response.ts
@@ -93,9 +93,10 @@ export interface PlainResponse extends IncomingMessageWithTimings {
 	body?: unknown;
 
 	/**
-	Whether the response status code is 2xx.
+	Whether the response was successful (status code in the range 200-299).
+	This property need not be checked if throwHttpErrors is true.
 	*/
-	ok?: boolean;
+	ok: boolean;
 }
 
 // For Promise support

--- a/test/http.ts
+++ b/test/http.ts
@@ -385,7 +385,7 @@ test('status code 200 has response ok is true', withServer, async (t, server, go
 	const promise = got('');
 	await t.notThrowsAsync(promise);
 	const {statusCode, body, ok} = await promise;
-	t.is(ok, true);
+	t.true(ok);
 	t.is(statusCode, 200);
 	t.is(body, '');
 });

--- a/test/http.ts
+++ b/test/http.ts
@@ -375,3 +375,43 @@ test('ClientRequest can throw before promise resolves', async t => {
 		message: /EINVAL|EHOSTUNREACH|ETIMEDOUT/,
 	});
 });
+
+test('status code 200 has response ok is true', withServer, async (t, server, got) => {
+	server.get('/', (_request, response) => {
+		response.statusCode = 200;
+		response.end();
+	});
+
+	const promise = got('');
+	await t.notThrowsAsync(promise);
+	const {statusCode, body, ok} = await promise;
+	t.is(ok, true);
+	t.is(statusCode, 200);
+	t.is(body, '');
+});
+
+test('status code 404 has response ok is false if error is not thrown', withServer, async (t, server, got) => {
+	server.get('/', (_request, response) => {
+		response.statusCode = 404;
+		response.end();
+	});
+
+	const promise = got('', {throwHttpErrors: false});
+	await t.notThrowsAsync(promise);
+	const {statusCode, body, ok} = await promise;
+	t.is(ok, false);
+	t.is(statusCode, 404);
+	t.is(body, '');
+});
+
+test('status code 404 has error response ok is false if error is thrown', withServer, async (t, server, got) => {
+	server.get('/', (_request, response) => {
+		response.statusCode = 404;
+		response.end('not');
+	});
+
+	const error = await t.throwsAsync<HTTPError>(got(''), {instanceOf: HTTPError});
+	t.is(error.response.statusCode, 404);
+	t.is(error.response.ok, false);
+	t.is(error.response.body, 'not');
+});


### PR DESCRIPTION
Fixes #2036

Added a boolean ok to the response from got API to indicate whether status code is within 200 & 299 i.e. 2xx.

#### Checklist

- [X] I have read the documentation.
- [X] I have included a pull request description of my changes.
- [X] I have included some tests.
- [x] If it's a new feature, I have included documentation updates in both the README and the types.
