### PR TITLE
Add `enableUnixSockets` option

### DIFF
--- a/documentation/2-options.md
+++ b/documentation/2-options.md
@@ -926,8 +926,7 @@ For example, when sending a `POST` request and receiving a `302`, it will resend
 When it is enabled, requests can also be sent via [UNIX Domain Sockets](https://serverfault.com/questions/124517/what-is-the-difference-between-unix-sockets-and-tcp-ip-sockets).\
 Use the following URL scheme: `PROTOCOL://unix:SOCKET:PATH`
 
-Enable it with care if you accept untrusted user input for the URL.
-And make sure you do your own URL sanitizing.
+By default it is enabled, so make sure you do your own URL sanitizing if you accept untrusted user input for the URL.
 
 - `PROTOCOL` - `http` or `https`
 - `SOCKET` - Absolute path to a UNIX domain socket, for example: `/var/run/docker.sock`
@@ -936,12 +935,16 @@ And make sure you do your own URL sanitizing.
 ```js
 import got from 'got';
 
-const gotUnixSocketsEnabled = got.extend({enableUnixSockets: true});
-
-await gotUnixSocketsEnabled('http://unix:/var/run/docker.sock:/containers/json');
+await got('http://unix:/var/run/docker.sock:/containers/json');
 
 // Or without protocol (HTTP by default)
-await gotUnixSocketsEnabled('unix:/var/run/docker.sock:/containers/json');
+await got('unix:/var/run/docker.sock:/containers/json');
+
+// Disable Unix sockets
+const gotUnixSocketsDisabled = got.extend({enableUnixSockets: false});
+
+// Error!
+gotUnixSocketsDisabled('http://unix:/var/run/docker.sock:/containers/json')
 ```
 
 ## Methods

--- a/documentation/2-options.md
+++ b/documentation/2-options.md
@@ -921,15 +921,16 @@ For example, when sending a `POST` request and receiving a `302`, it will resend
 ### `enableUnixSockets`
 
 **Type: `boolean`**\
-**Default: `false`**
-
-Enable it with care if you accept untrusted user input for the URL.
+**Default: `true`**
 
 When it is enabled, requests can also be sent via [UNIX Domain Sockets](https://serverfault.com/questions/124517/what-is-the-difference-between-unix-sockets-and-tcp-ip-sockets).\
 Use the following URL scheme: `PROTOCOL://unix:SOCKET:PATH`
 
+Enable it with care if you accept untrusted user input for the URL.
+And make sure you do your own URL sanitizing.
+
 - `PROTOCOL` - `http` or `https`
-- `SOCKET` - Absolute path to a unix domain socket, for example: `/var/run/docker.sock`
+- `SOCKET` - Absolute path to a UNIX domain socket, for example: `/var/run/docker.sock`
 - `PATH` - Request path, for example: `/v2/keys`
 
 ```js

--- a/documentation/2-options.md
+++ b/documentation/2-options.md
@@ -919,10 +919,11 @@ By default, requests will not use [method rewriting](https://datatracker.ietf.or
 For example, when sending a `POST` request and receiving a `302`, it will resend the body to the new location using the same HTTP method (`POST` in this case). To rewrite the request as `GET`, set this option to `true`.
 
 ### `enableUnixSocket`
+
 **Type: `boolean`**\
 **Default: `false`**
 
-Set to `true` to enable unix socket domain.
+Enable it with care if you accept untrusted user input for the URL.
 
 When it is enabled, requests can also be sent via [UNIX Domain Sockets](https://serverfault.com/questions/124517/what-is-the-difference-between-unix-sockets-and-tcp-ip-sockets).\
 Use the following URL scheme: `PROTOCOL://unix:SOCKET:PATH`
@@ -934,10 +935,12 @@ Use the following URL scheme: `PROTOCOL://unix:SOCKET:PATH`
 ```js
 import got from 'got';
 
-await got('http://unix:/var/run/docker.sock:/containers/json');
+const gotUnixSocketEnabled = got.extend({enableUnixSocket: true});
+
+await gotUnixSocketEnabled('http://unix:/var/run/docker.sock:/containers/json');
 
 // Or without protocol (HTTP by default)
-await got('unix:/var/run/docker.sock:/containers/json');
+await gotUnixSocketEnabled('unix:/var/run/docker.sock:/containers/json');
 ```
 
 ## Methods

--- a/documentation/2-options.md
+++ b/documentation/2-options.md
@@ -918,6 +918,28 @@ By default, requests will not use [method rewriting](https://datatracker.ietf.or
 
 For example, when sending a `POST` request and receiving a `302`, it will resend the body to the new location using the same HTTP method (`POST` in this case). To rewrite the request as `GET`, set this option to `true`.
 
+### `enableUnixSocket`
+**Type: `boolean`**\
+**Default: `false`**
+
+Set to `true` to enable unix socket domain.
+
+When it is enabled, requests can also be sent via [UNIX Domain Sockets](https://serverfault.com/questions/124517/what-is-the-difference-between-unix-sockets-and-tcp-ip-sockets).\
+Use the following URL scheme: `PROTOCOL://unix:SOCKET:PATH`
+
+- `PROTOCOL` - `http` or `https`
+- `SOCKET` - Absolute path to a unix domain socket, for example: `/var/run/docker.sock`
+- `PATH` - Request path, for example: `/v2/keys`
+
+```js
+import got from 'got';
+
+await got('http://unix:/var/run/docker.sock:/containers/json');
+
+// Or without protocol (HTTP by default)
+await got('unix:/var/run/docker.sock:/containers/json');
+```
+
 ## Methods
 
 ### `options.merge(other: Options | OptionsInit)`

--- a/documentation/2-options.md
+++ b/documentation/2-options.md
@@ -926,8 +926,6 @@ For example, when sending a `POST` request and receiving a `302`, it will resend
 When it is enabled, requests can also be sent via [UNIX Domain Sockets](https://serverfault.com/questions/124517/what-is-the-difference-between-unix-sockets-and-tcp-ip-sockets).\
 Use the following URL scheme: `PROTOCOL://unix:SOCKET:PATH`
 
-By default it is enabled, so make sure you do your own URL sanitizing if you accept untrusted user input for the URL.
-
 - `PROTOCOL` - `http` or `https`
 - `SOCKET` - Absolute path to a UNIX domain socket, for example: `/var/run/docker.sock`
 - `PATH` - Request path, for example: `/v2/keys`
@@ -946,6 +944,10 @@ const gotUnixSocketsDisabled = got.extend({enableUnixSockets: false});
 // Error!
 gotUnixSocketsDisabled('http://unix:/var/run/docker.sock:/containers/json')
 ```
+
+#### **Note:**
+> - The option is enabled by default.
+> - Make sure you do your own URL sanitizing if you accept untrusted user input for the URL.
 
 ## Methods
 

--- a/documentation/2-options.md
+++ b/documentation/2-options.md
@@ -918,7 +918,7 @@ By default, requests will not use [method rewriting](https://datatracker.ietf.or
 
 For example, when sending a `POST` request and receiving a `302`, it will resend the body to the new location using the same HTTP method (`POST` in this case). To rewrite the request as `GET`, set this option to `true`.
 
-### `enableUnixSocket`
+### `enableUnixSockets`
 
 **Type: `boolean`**\
 **Default: `false`**
@@ -935,12 +935,12 @@ Use the following URL scheme: `PROTOCOL://unix:SOCKET:PATH`
 ```js
 import got from 'got';
 
-const gotUnixSocketEnabled = got.extend({enableUnixSocket: true});
+const gotUnixSocketsEnabled = got.extend({enableUnixSockets: true});
 
-await gotUnixSocketEnabled('http://unix:/var/run/docker.sock:/containers/json');
+await gotUnixSocketsEnabled('http://unix:/var/run/docker.sock:/containers/json');
 
 // Or without protocol (HTTP by default)
-await gotUnixSocketEnabled('unix:/var/run/docker.sock:/containers/json');
+await gotUnixSocketsEnabled('unix:/var/run/docker.sock:/containers/json');
 ```
 
 ## Methods

--- a/documentation/2-options.md
+++ b/documentation/2-options.md
@@ -923,7 +923,11 @@ For example, when sending a `POST` request and receiving a `302`, it will resend
 **Type: `boolean`**\
 **Default: `true`**
 
-When it is enabled, requests can also be sent via [UNIX Domain Sockets](https://serverfault.com/questions/124517/what-is-the-difference-between-unix-sockets-and-tcp-ip-sockets).\
+When enabled, requests can also be sent via [UNIX Domain Sockets](https://serverfault.com/questions/124517/what-is-the-difference-between-unix-sockets-and-tcp-ip-sockets).
+	
+> **Warning**
+> Make sure you do your own URL sanitizing if you accept untrusted user input for the URL.
+
 Use the following URL scheme: `PROTOCOL://unix:SOCKET:PATH`
 
 - `PROTOCOL` - `http` or `https`
@@ -944,10 +948,6 @@ const gotUnixSocketsDisabled = got.extend({enableUnixSockets: false});
 // Error!
 gotUnixSocketsDisabled('http://unix:/var/run/docker.sock:/containers/json')
 ```
-
-#### **Note:**
-> - The option is enabled by default.
-> - Make sure you do your own URL sanitizing if you accept untrusted user input for the URL.
 
 ## Methods
 

--- a/documentation/2-options.md
+++ b/documentation/2-options.md
@@ -923,8 +923,8 @@ For example, when sending a `POST` request and receiving a `302`, it will resend
 **Type: `boolean`**\
 **Default: `true`**
 
-When enabled, requests can also be sent via [UNIX Domain Sockets](https://serverfault.com/questions/124517/what-is-the-difference-between-unix-sockets-and-tcp-ip-sockets).
-	
+When enabled, requests can also be sent via [UNIX Domain Sockets](https://serverfault.com/questions/124517/what-is-the-difference-between-unix-sockets-and-tcp-ip-sockets). Please note that in the upcoming major release (Got v13) this default will be changed to `false` for security reasons.
+
 > **Warning**
 > Make sure you do your own URL sanitizing if you accept untrusted user input for the URL.
 
@@ -937,16 +937,16 @@ Use the following URL scheme: `PROTOCOL://unix:SOCKET:PATH`
 ```js
 import got from 'got';
 
-await got('http://unix:/var/run/docker.sock:/containers/json');
+await got('http://unix:/var/run/docker.sock:/containers/json', {enableUnixSockets: true});
 
 // Or without protocol (HTTP by default)
-await got('unix:/var/run/docker.sock:/containers/json');
+await got('unix:/var/run/docker.sock:/containers/json', {enableUnixSockets: true});
 
 // Disable Unix sockets
 const gotUnixSocketsDisabled = got.extend({enableUnixSockets: false});
 
-// Error!
-gotUnixSocketsDisabled('http://unix:/var/run/docker.sock:/containers/json')
+// RequestError: Using UNIX domain sockets but option `enableUnixSockets` is not enabled
+await gotUnixSocketsDisabled('http://unix:/var/run/docker.sock:/containers/json');
 ```
 
 ## Methods

--- a/documentation/migration-guides/axios.md
+++ b/documentation/migration-guides/axios.md
@@ -24,7 +24,7 @@ We deeply care about readability, so we renamed these options:
 
 - `httpAgent` → [`agent.http`](../2-options.md#agent)
 - `httpsAgent` → [`agent.https`](../2-options.md#agent)
-- `socketPath` → [`url`](../2-options.md#enableunixsocket)
+- `socketPath` → [`url`](../2-options.md#enableunixsockets)
 - `responseEncoding` → [`encoding`](../2-options.md#encoding)
 - `auth.username` → [`username`](../2-options.md#username)
 - `auth.password` → [`password`](../2-options.md#password)

--- a/documentation/migration-guides/axios.md
+++ b/documentation/migration-guides/axios.md
@@ -24,7 +24,7 @@ We deeply care about readability, so we renamed these options:
 
 - `httpAgent` → [`agent.http`](../2-options.md#agent)
 - `httpsAgent` → [`agent.https`](../2-options.md#agent)
-- `socketPath` → [`url`](../tips.md#unix)
+- `socketPath` → [`url`](../2-options.md#enableunixsocket)
 - `responseEncoding` → [`encoding`](../2-options.md#encoding)
 - `auth.username` → [`username`](../2-options.md#username)
 - `auth.password` → [`password`](../2-options.md#password)

--- a/documentation/migration-guides/request.md
+++ b/documentation/migration-guides/request.md
@@ -46,7 +46,7 @@ These Got options are the same as with Request:
 - [`localAddress`](../2-options.md#localaddress)
 - [`headers`](../2-options.md#headers)
 - [`createConnection`](../2-options.md#createconnection)
-- [UNIX sockets](../2-options.md#enableunixsocket): `http://unix:SOCKET:PATH`
+- [UNIX sockets](../2-options.md#enableunixsockets): `http://unix:SOCKET:PATH`
 
 The `time` option does not exist, assume [it's always true](../6-timeout.md).
 

--- a/documentation/migration-guides/request.md
+++ b/documentation/migration-guides/request.md
@@ -46,7 +46,7 @@ These Got options are the same as with Request:
 - [`localAddress`](../2-options.md#localaddress)
 - [`headers`](../2-options.md#headers)
 - [`createConnection`](../2-options.md#createconnection)
-- [UNIX sockets](../tips.md#unixsockets): `http://unix:SOCKET:PATH`
+- [UNIX sockets](../2-options.md#enableunixsocket): `http://unix:SOCKET:PATH`
 
 The `time` option does not exist, assume [it's always true](../6-timeout.md).
 

--- a/documentation/tips.md
+++ b/documentation/tips.md
@@ -89,6 +89,7 @@ for await (const commitData of pagination) {
 }
 ```
 
+<a name="unix"></a>
 ### UNIX Domain Sockets
 
 See the [`enableUnixSocket` option](./2-options.md#enableunixsocket).

--- a/documentation/tips.md
+++ b/documentation/tips.md
@@ -89,24 +89,9 @@ for await (const commitData of pagination) {
 }
 ```
 
-<a name="unix"></a>
 ### UNIX Domain Sockets
 
-Requests can also be sent via [UNIX Domain Sockets](https://serverfault.com/questions/124517/what-is-the-difference-between-unix-sockets-and-tcp-ip-sockets).\
-Use the following URL scheme: `PROTOCOL://unix:SOCKET:PATH`
-
-- `PROTOCOL` - `http` or `https`
-- `SOCKET` - Absolute path to a unix domain socket, for example: `/var/run/docker.sock`
-- `PATH` - Request path, for example: `/v2/keys`
-
-```js
-import got from 'got';
-
-await got('http://unix:/var/run/docker.sock:/containers/json');
-
-// Or without protocol (HTTP by default)
-await got('unix:/var/run/docker.sock:/containers/json');
-```
+See option [enableUnixSocket](./2-options.md#enableunixsocket) for more.
 
 ### Testing
 

--- a/documentation/tips.md
+++ b/documentation/tips.md
@@ -92,7 +92,7 @@ for await (const commitData of pagination) {
 <a name="unix"></a>
 ### UNIX Domain Sockets
 
-See the [`enableUnixSocket` option](./2-options.md#enableunixsocket).
+See the [`enableUnixSockets` option](./2-options.md#enableunixsockets).
 
 ### Testing
 

--- a/documentation/tips.md
+++ b/documentation/tips.md
@@ -91,7 +91,7 @@ for await (const commitData of pagination) {
 
 ### UNIX Domain Sockets
 
-See option [enableUnixSocket](./2-options.md#enableunixsocket) for more.
+See the [`enableUnixSocket` option](./2-options.md#enableunixsocket).
 
 ### Testing
 

--- a/readme.md
+++ b/readme.md
@@ -202,7 +202,7 @@ For advanced JSON usage, check out the [`parseJson`](documentation/2-options.md#
 
 - [x] [RFC compliant caching](documentation/cache.md)
 - [x] [Proxy support](documentation/tips.md#proxying)
-- [x] [Unix Domain Sockets](documentation/2-options.md#enableunixsocket)
+- [x] [Unix Domain Sockets](documentation/2-options.md#enableunixsockets)
 
 #### Integration
 

--- a/readme.md
+++ b/readme.md
@@ -202,7 +202,7 @@ For advanced JSON usage, check out the [`parseJson`](documentation/2-options.md#
 
 - [x] [RFC compliant caching](documentation/cache.md)
 - [x] [Proxy support](documentation/tips.md#proxying)
-- [x] [Unix Domain Sockets](documentation/tips.md#unix)
+- [x] [Unix Domain Sockets](documentation/2-options.md#enableunixsocket)
 
 #### Integration
 

--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -827,6 +827,7 @@ const defaultInternals: Options['_internals'] = {
 	},
 	setHost: true,
 	maxHeaderSize: undefined,
+	enableUnixSocket: false,
 };
 
 const cloneInternals = (internals: typeof defaultInternals) => {
@@ -1401,7 +1402,7 @@ export default class Options {
 		this._internals.url = url;
 		decodeURI(urlString);
 
-		if (url.protocol === 'unix:') {
+		if (this._internals.enableUnixSocket && url.protocol === 'unix:') {
 			url.href = `http://unix${url.pathname}${url.search}`;
 		}
 
@@ -1427,7 +1428,7 @@ export default class Options {
 			this._internals.searchParams = undefined;
 		}
 
-		if (url.hostname === 'unix') {
+		if (this._internals.enableUnixSocket && url.hostname === 'unix') {
 			const matches = /(?<socketPath>.+?):(?<path>.+)/.exec(`${url.pathname}${url.search}`);
 
 			if (matches?.groups) {
@@ -2343,6 +2344,16 @@ export default class Options {
 		assert.any([is.number, is.undefined], value);
 
 		this._internals.maxHeaderSize = value;
+	}
+
+	get enableUnixSocket() {
+		return this._internals.enableUnixSocket;
+	}
+
+	set enableUnixSocket(value: boolean) {
+		assert.boolean(value);
+
+		this._internals.enableUnixSocket = value;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/naming-convention

--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -827,7 +827,7 @@ const defaultInternals: Options['_internals'] = {
 	},
 	setHost: true,
 	maxHeaderSize: undefined,
-	enableUnixSocket: false,
+	enableUnixSockets: false,
 };
 
 const cloneInternals = (internals: typeof defaultInternals) => {
@@ -1402,7 +1402,7 @@ export default class Options {
 		this._internals.url = url;
 		decodeURI(urlString);
 
-		if (this._internals.enableUnixSocket && url.protocol === 'unix:') {
+		if (this._internals.enableUnixSockets && url.protocol === 'unix:') {
 			url.href = `http://unix${url.pathname}${url.search}`;
 		}
 
@@ -1428,7 +1428,7 @@ export default class Options {
 			this._internals.searchParams = undefined;
 		}
 
-		if (this._internals.enableUnixSocket && url.hostname === 'unix') {
+		if (this._internals.enableUnixSockets && url.hostname === 'unix') {
 			const matches = /(?<socketPath>.+?):(?<path>.+)/.exec(`${url.pathname}${url.search}`);
 
 			if (matches?.groups) {
@@ -2346,14 +2346,14 @@ export default class Options {
 		this._internals.maxHeaderSize = value;
 	}
 
-	get enableUnixSocket() {
-		return this._internals.enableUnixSocket;
+	get enableUnixSockets() {
+		return this._internals.enableUnixSockets;
 	}
 
-	set enableUnixSocket(value: boolean) {
+	set enableUnixSockets(value: boolean) {
 		assert.boolean(value);
 
-		this._internals.enableUnixSocket = value;
+		this._internals.enableUnixSockets = value;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/naming-convention

--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -1402,7 +1402,7 @@ export default class Options {
 		this._internals.url = url;
 		decodeURI(urlString);
 
-		if (this._internals.enableUnixSockets && url.protocol === 'unix:') {
+		if (url.protocol === 'unix:') {
 			url.href = `http://unix${url.pathname}${url.search}`;
 		}
 
@@ -1428,7 +1428,11 @@ export default class Options {
 			this._internals.searchParams = undefined;
 		}
 
-		if (this._internals.enableUnixSockets && url.hostname === 'unix') {
+		if (url.hostname === 'unix') {
+			if (!this._internals.enableUnixSockets) {
+				throw new Error('Using UNIX domain sockets but option `enableUnixSockets` is not enabled');
+			}
+
 			const matches = /(?<socketPath>.+?):(?<path>.+)/.exec(`${url.pathname}${url.search}`);
 
 			if (matches?.groups) {

--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -827,7 +827,7 @@ const defaultInternals: Options['_internals'] = {
 	},
 	setHost: true,
 	maxHeaderSize: undefined,
-	enableUnixSockets: false,
+	enableUnixSockets: true,
 };
 
 const cloneInternals = (internals: typeof defaultInternals) => {

--- a/test/redirects.ts
+++ b/test/redirects.ts
@@ -42,7 +42,7 @@ const unixHostname: Handler = (_request, response) => {
 	response.end();
 };
 
-test('cannot redirect to unix protocol when unix socket is enabled', withServer, async (t, server, got) => {
+test('cannot redirect to UNIX protocol when UNIX socket is enabled', withServer, async (t, server, got) => {
 	server.get('/protocol', unixProtocol);
 	server.get('/hostname', unixHostname);
 
@@ -61,7 +61,7 @@ test('cannot redirect to unix protocol when unix socket is enabled', withServer,
 	});
 });
 
-test('cannot redirect to unix protocol when unix socket is not enabled', withServer, async (t, server, got) => {
+test('cannot redirect to UNIX protocol when UNIX socket is not enabled', withServer, async (t, server, got) => {
 	server.get('/protocol', unixProtocol);
 	server.get('/hostname', unixHostname);
 

--- a/test/redirects.ts
+++ b/test/redirects.ts
@@ -42,30 +42,30 @@ const unixHostname: Handler = (_request, response) => {
 	response.end();
 };
 
-test('cannot redirect to UNIX protocol when UNIX socket is enabled', withServer, async (t, server, got) => {
+test('cannot redirect to UNIX protocol when UNIX sockets are enabled', withServer, async (t, server, got) => {
 	server.get('/protocol', unixProtocol);
 	server.get('/hostname', unixHostname);
 
-	const gotUnixSocketEnabled = got.extend({enableUnixSocket: true});
+	const gotUnixSocketsEnabled = got.extend({enableUnixSockets: true});
 
-	t.assert(gotUnixSocketEnabled.defaults.options.enableUnixSocket);
+	t.assert(gotUnixSocketsEnabled.defaults.options.enableUnixSockets);
 
-	await t.throwsAsync(gotUnixSocketEnabled('protocol'), {
+	await t.throwsAsync(gotUnixSocketsEnabled('protocol'), {
 		message: 'Cannot redirect to UNIX socket',
 		instanceOf: RequestError,
 	});
 
-	await t.throwsAsync(gotUnixSocketEnabled('hostname'), {
+	await t.throwsAsync(gotUnixSocketsEnabled('hostname'), {
 		message: 'Cannot redirect to UNIX socket',
 		instanceOf: RequestError,
 	});
 });
 
-test('cannot redirect to UNIX protocol when UNIX socket is not enabled', withServer, async (t, server, got) => {
+test('cannot redirect to UNIX protocol when UNIX sockets are not enabled', withServer, async (t, server, got) => {
 	server.get('/protocol', unixProtocol);
 	server.get('/hostname', unixHostname);
 
-	t.assert(!got.defaults.options.enableUnixSocket);
+	t.assert(!got.defaults.options.enableUnixSockets);
 
 	await t.throwsAsync(got('protocol'), {
 		message: 'Cannot redirect to UNIX socket',

--- a/test/redirects.ts
+++ b/test/redirects.ts
@@ -46,16 +46,14 @@ test('cannot redirect to UNIX protocol when UNIX sockets are enabled', withServe
 	server.get('/protocol', unixProtocol);
 	server.get('/hostname', unixHostname);
 
-	const gotUnixSocketsEnabled = got.extend({enableUnixSockets: true});
+	t.true(got.defaults.options.enableUnixSockets);
 
-	t.assert(gotUnixSocketsEnabled.defaults.options.enableUnixSockets);
-
-	await t.throwsAsync(gotUnixSocketsEnabled('protocol'), {
+	await t.throwsAsync(got('protocol'), {
 		message: 'Cannot redirect to UNIX socket',
 		instanceOf: RequestError,
 	});
 
-	await t.throwsAsync(gotUnixSocketsEnabled('hostname'), {
+	await t.throwsAsync(got('hostname'), {
 		message: 'Cannot redirect to UNIX socket',
 		instanceOf: RequestError,
 	});
@@ -65,14 +63,16 @@ test('cannot redirect to UNIX protocol when UNIX sockets are not enabled', withS
 	server.get('/protocol', unixProtocol);
 	server.get('/hostname', unixHostname);
 
-	t.assert(!got.defaults.options.enableUnixSockets);
+	const gotUnixSocketsDisabled = got.extend({enableUnixSockets: false});
 
-	await t.throwsAsync(got('protocol'), {
+	t.false(gotUnixSocketsDisabled.defaults.options.enableUnixSockets);
+
+	await t.throwsAsync(gotUnixSocketsDisabled('protocol'), {
 		message: 'Cannot redirect to UNIX socket',
 		instanceOf: RequestError,
 	});
 
-	await t.throwsAsync(got('hostname'), {
+	await t.throwsAsync(gotUnixSocketsDisabled('hostname'), {
 		message: 'Cannot redirect to UNIX socket',
 		instanceOf: RequestError,
 	});

--- a/test/redirects.ts
+++ b/test/redirects.ts
@@ -42,9 +42,30 @@ const unixHostname: Handler = (_request, response) => {
 	response.end();
 };
 
-test('cannot redirect to unix protocol', withServer, async (t, server, got) => {
+test('cannot redirect to unix protocol when unix socket is enabled', withServer, async (t, server, got) => {
 	server.get('/protocol', unixProtocol);
 	server.get('/hostname', unixHostname);
+
+	const gotUnixSocketEnabled = got.extend({enableUnixSocket: true});
+
+	t.assert(gotUnixSocketEnabled.defaults.options.enableUnixSocket);
+
+	await t.throwsAsync(gotUnixSocketEnabled('protocol'), {
+		message: 'Cannot redirect to UNIX socket',
+		instanceOf: RequestError,
+	});
+
+	await t.throwsAsync(gotUnixSocketEnabled('hostname'), {
+		message: 'Cannot redirect to UNIX socket',
+		instanceOf: RequestError,
+	});
+});
+
+test('cannot redirect to unix protocol when unix socket is not enabled', withServer, async (t, server, got) => {
+	server.get('/protocol', unixProtocol);
+	server.get('/hostname', unixHostname);
+
+	t.assert(!got.defaults.options.enableUnixSocket);
 
 	await t.throwsAsync(got('protocol'), {
 		message: 'Cannot redirect to UNIX socket',

--- a/test/unix-socket.ts
+++ b/test/unix-socket.ts
@@ -5,7 +5,7 @@ import {Handler} from 'express';
 import got from '../source/index.js';
 import {withSocketServer} from './helpers/with-server.js';
 
-const gotUnixSocketEnabled = got.extend({enableUnixSocket: true});
+const gotUnixSocketsEnabled = got.extend({enableUnixSockets: true});
 
 const okHandler: Handler = (_request, response) => {
 	response.end('ok');
@@ -23,26 +23,26 @@ if (process.platform !== 'win32') {
 		server.on('/', okHandler);
 
 		const url = format('http://unix:%s:%s', server.socketPath, '/');
-		t.is((await gotUnixSocketEnabled(url)).body, 'ok');
+		t.is((await gotUnixSocketsEnabled(url)).body, 'ok');
 	});
 
 	test('protocol-less works', withSocketServer, async (t, server) => {
 		server.on('/', okHandler);
 
 		const url = format('unix:%s:%s', server.socketPath, '/');
-		t.is((await gotUnixSocketEnabled(url)).body, 'ok');
+		t.is((await gotUnixSocketsEnabled(url)).body, 'ok');
 	});
 
 	test('address with : works', withSocketServer, async (t, server) => {
 		server.on('/foo:bar', okHandler);
 
 		const url = format('unix:%s:%s', server.socketPath, '/foo:bar');
-		t.is((await gotUnixSocketEnabled(url)).body, 'ok');
+		t.is((await gotUnixSocketsEnabled(url)).body, 'ok');
 	});
 
 	test('throws on invalid URL', async t => {
 		try {
-			await gotUnixSocketEnabled('unix:', {retry: {limit: 0}});
+			await gotUnixSocketsEnabled('unix:', {retry: {limit: 0}});
 		} catch (error: any) {
 			t.regex(error.code, /ENOTFOUND|EAI_AGAIN/);
 		}
@@ -52,7 +52,7 @@ if (process.platform !== 'win32') {
 		server.on('/', okHandler);
 
 		const url = format('unix:%s:%s', server.socketPath, '/');
-		const instance = gotUnixSocketEnabled.extend({prefixUrl: url});
+		const instance = gotUnixSocketsEnabled.extend({prefixUrl: url});
 		t.is((await instance('')).body, 'ok');
 	});
 
@@ -60,7 +60,7 @@ if (process.platform !== 'win32') {
 		server.on('/?a=1', okHandler);
 
 		const url = format('http://unix:%s:%s', server.socketPath, '/?a=1');
-		t.is((await gotUnixSocketEnabled(url)).body, 'ok');
+		t.is((await gotUnixSocketsEnabled(url)).body, 'ok');
 	});
 
 	test('redirects work', withSocketServer, async (t, server) => {
@@ -68,10 +68,10 @@ if (process.platform !== 'win32') {
 		server.on('/foo', okHandler);
 
 		const url = format('http://unix:%s:%s', server.socketPath, '/');
-		t.is((await gotUnixSocketEnabled(url)).body, 'ok');
+		t.is((await gotUnixSocketsEnabled(url)).body, 'ok');
 	});
 
-	test('unix: fails when unix socket is not enabled', async t => {
+	test('unix: fails when unix sockets are not enabled', async t => {
 		try {
 			await got('unix:');
 		} catch (error: any) {
@@ -83,7 +83,7 @@ if (process.platform !== 'win32') {
 		t.fail();
 	});
 
-	test('http://unix:/ fails when unix socket is not enabled', async t => {
+	test('http://unix:/ fails when unix sockets are not enabled', async t => {
 		try {
 			await got('http://unix:');
 		} catch (error: any) {

--- a/test/unix-socket.ts
+++ b/test/unix-socket.ts
@@ -87,6 +87,7 @@ if (process.platform !== 'win32') {
 		try {
 			await got('http://unix:');
 		} catch (error: any) {
+			t.log(error);
 			t.assert(error.code === 'ENOTFOUND');
 			return;
 		}

--- a/test/unix-socket.ts
+++ b/test/unix-socket.ts
@@ -87,8 +87,7 @@ if (process.platform !== 'win32') {
 		try {
 			await got('http://unix:');
 		} catch (error: any) {
-			t.log(error);
-			t.assert(error.code === 'ENOTFOUND');
+			t.regex(error.code, /ENOTFOUND|EAI_AGAIN/);
 			return;
 		}
 

--- a/test/unix-socket.ts
+++ b/test/unix-socket.ts
@@ -73,6 +73,7 @@ if (process.platform !== 'win32') {
 
 	test('unix: fails when unix sockets are not enabled', async t => {
 		try {
+			t.assert(!got.defaults.options.enableUnixSockets);
 			await got('unix:');
 		} catch (error: any) {
 			t.assert(error.code === 'ERR_UNSUPPORTED_PROTOCOL');
@@ -85,6 +86,7 @@ if (process.platform !== 'win32') {
 
 	test('http://unix:/ fails when unix sockets are not enabled', async t => {
 		try {
+			t.assert(!got.defaults.options.enableUnixSockets);
 			await got('http://unix:');
 		} catch (error: any) {
 			t.regex(error.code, /ENOTFOUND|EAI_AGAIN/);

--- a/test/unix-socket.ts
+++ b/test/unix-socket.ts
@@ -76,7 +76,7 @@ if (process.platform !== 'win32') {
 		await t.throwsAsync(
 			gotUnixSocketsDisabled('unix:'),
 			{
-				code: 'ERR_UNSUPPORTED_PROTOCOL',
+				message: 'Using UNIX domain sockets but option `enableUnixSockets` is not enabled',
 			},
 		);
 	});
@@ -86,7 +86,11 @@ if (process.platform !== 'win32') {
 
 		t.false(gotUnixSocketsDisabled.defaults.options.enableUnixSockets);
 
-		const error = await t.throwsAsync<Error & {code: string}>(got('http://unix:'));
-		t.regex(error.code, /ENOTFOUND|EAI_AGAIN/);
+		await t.throwsAsync(
+			gotUnixSocketsDisabled('http://unix:'),
+			{
+				message: 'Using UNIX domain sockets but option `enableUnixSockets` is not enabled',
+			},
+		);
 	});
 }

--- a/test/unix-socket.ts
+++ b/test/unix-socket.ts
@@ -86,14 +86,7 @@ if (process.platform !== 'win32') {
 
 		t.false(gotUnixSocketsDisabled.defaults.options.enableUnixSockets);
 
-		try {
-			await got('http://unix:');
-		} catch (error: any) {
-			t.regex(error.code, /ENOTFOUND|EAI_AGAIN/);
-			return;
-		}
-
-		// Fail if no error is thrown
-		t.fail();
+		const error = await t.throwsAsync<Error & {code: string}>(got('http://unix:'));
+		t.regex(error.code, /ENOTFOUND|EAI_AGAIN/);
 	});
 }

--- a/test/unix-socket.ts
+++ b/test/unix-socket.ts
@@ -5,8 +5,6 @@ import {Handler} from 'express';
 import got from '../source/index.js';
 import {withSocketServer} from './helpers/with-server.js';
 
-const gotUnixSocketsEnabled = got.extend({enableUnixSockets: true});
-
 const okHandler: Handler = (_request, response) => {
 	response.end('ok');
 };
@@ -23,26 +21,26 @@ if (process.platform !== 'win32') {
 		server.on('/', okHandler);
 
 		const url = format('http://unix:%s:%s', server.socketPath, '/');
-		t.is((await gotUnixSocketsEnabled(url)).body, 'ok');
+		t.is((await got(url)).body, 'ok');
 	});
 
 	test('protocol-less works', withSocketServer, async (t, server) => {
 		server.on('/', okHandler);
 
 		const url = format('unix:%s:%s', server.socketPath, '/');
-		t.is((await gotUnixSocketsEnabled(url)).body, 'ok');
+		t.is((await got(url)).body, 'ok');
 	});
 
 	test('address with : works', withSocketServer, async (t, server) => {
 		server.on('/foo:bar', okHandler);
 
 		const url = format('unix:%s:%s', server.socketPath, '/foo:bar');
-		t.is((await gotUnixSocketsEnabled(url)).body, 'ok');
+		t.is((await got(url)).body, 'ok');
 	});
 
 	test('throws on invalid URL', async t => {
 		try {
-			await gotUnixSocketsEnabled('unix:', {retry: {limit: 0}});
+			await got('unix:', {retry: {limit: 0}});
 		} catch (error: any) {
 			t.regex(error.code, /ENOTFOUND|EAI_AGAIN/);
 		}
@@ -52,7 +50,7 @@ if (process.platform !== 'win32') {
 		server.on('/', okHandler);
 
 		const url = format('unix:%s:%s', server.socketPath, '/');
-		const instance = gotUnixSocketsEnabled.extend({prefixUrl: url});
+		const instance = got.extend({prefixUrl: url});
 		t.is((await instance('')).body, 'ok');
 	});
 
@@ -60,7 +58,7 @@ if (process.platform !== 'win32') {
 		server.on('/?a=1', okHandler);
 
 		const url = format('http://unix:%s:%s', server.socketPath, '/?a=1');
-		t.is((await gotUnixSocketsEnabled(url)).body, 'ok');
+		t.is((await got(url)).body, 'ok');
 	});
 
 	test('redirects work', withSocketServer, async (t, server) => {
@@ -68,25 +66,27 @@ if (process.platform !== 'win32') {
 		server.on('/foo', okHandler);
 
 		const url = format('http://unix:%s:%s', server.socketPath, '/');
-		t.is((await gotUnixSocketsEnabled(url)).body, 'ok');
+		t.is((await got(url)).body, 'ok');
 	});
 
-	test('unix: fails when unix sockets are not enabled', async t => {
-		try {
-			t.assert(!got.defaults.options.enableUnixSockets);
-			await got('unix:');
-		} catch (error: any) {
-			t.assert(error.code === 'ERR_UNSUPPORTED_PROTOCOL');
-			return;
-		}
+	test('`unix:` fails when UNIX sockets are not enabled', async t => {
+		const gotUnixSocketsDisabled = got.extend({enableUnixSockets: false});
 
-		// Fail if no error is thrown
-		t.fail();
+		t.false(gotUnixSocketsDisabled.defaults.options.enableUnixSockets);
+		await t.throwsAsync(
+			gotUnixSocketsDisabled('unix:'),
+			{
+				code: 'ERR_UNSUPPORTED_PROTOCOL',
+			},
+		);
 	});
 
-	test('http://unix:/ fails when unix sockets are not enabled', async t => {
+	test('`http://unix:/` fails when UNIX sockets are not enabled', async t => {
+		const gotUnixSocketsDisabled = got.extend({enableUnixSockets: false});
+
+		t.false(gotUnixSocketsDisabled.defaults.options.enableUnixSockets);
+
 		try {
-			t.assert(!got.defaults.options.enableUnixSockets);
 			await got('http://unix:');
 		} catch (error: any) {
 			t.regex(error.code, /ENOTFOUND|EAI_AGAIN/);


### PR DESCRIPTION
### What is the PR for?

For issue #2046, we add an option to control if unix domain socket is supported:

```js
// enableUnixSocket is default to false before Got v13
const gotUnixSocketEnabled = got.extend({enableUnixSocket: true});
```

### How is the PR tested?

Unit tests.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] If it's a new feature, I have included documentation updates in both the README and the types.
