### PR TITLE
Don't freeze signal when freezing Options

### DIFF
--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -2521,6 +2521,5 @@ export default class Options {
 		Object.freeze(options.retry.methods);
 		Object.freeze(options.retry.statusCodes);
 		Object.freeze(options.context);
-		Object.freeze(options.signal);
 	}
 }

--- a/test/abort.ts
+++ b/test/abort.ts
@@ -271,4 +271,17 @@ if (globalThis.AbortController !== undefined) {
 			message: 'This operation was aborted.',
 		});
 	});
+
+	test('support setting the signal as a default option', async t => {
+		const controller = new AbortController();
+
+		const got2 = got.extend({signal: controller.signal});
+		const p = got2('http://example.com', {signal: controller.signal});
+		controller.abort();
+
+		await t.throwsAsync(p, {
+			code: 'ERR_ABORTED',
+			message: 'This operation was aborted.',
+		});
+	});
 }

--- a/test/normalize-arguments.ts
+++ b/test/normalize-arguments.ts
@@ -1,5 +1,4 @@
 import {URL, URLSearchParams} from 'url';
-import {EventEmitter} from 'events';
 import test from 'ava';
 import got, {Options} from '../source/index.js';
 

--- a/test/normalize-arguments.ts
+++ b/test/normalize-arguments.ts
@@ -1,4 +1,5 @@
 import {URL, URLSearchParams} from 'url';
+import {EventEmitter} from 'events';
 import test from 'ava';
 import got, {Options} from '../source/index.js';
 
@@ -167,3 +168,18 @@ test('searchParams - multiple values for one key', t => {
 		['100', '200', '300'],
 	);
 });
+
+if (globalThis.AbortSignal !== undefined) {
+	test('signal does not get frozen', t => {
+		const controller = new AbortController();
+		const {signal} = controller;
+
+		const options = new Options({
+			url: new URL('http://localhost'),
+			signal,
+		});
+		options.freeze();
+
+		t.is(Object.isFrozen(options.signal), false);
+	});
+}


### PR DESCRIPTION
Freezing the abort signal object breaks its functionality under Node.

Fixes #2099