### PR TITLE
Link to the correct 'Response' heading

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -149,7 +149,7 @@ By default, Got will retry on failure. To disable this option, set [`options.ret
 - [x] [Pagination API](documentation/4-pagination.md)
 - [x] [Advanced HTTPS API](documentation/5-https.md)
 - [x] [HTTP/2 support](documentation/2-options.md#http2)
-- [x] [`Response` class](documentation/3-streams.md#response-1)
+- [x] [`Response` class](documentation/3-streams.md#response-2)
 
 #### Timeouts and retries
 


### PR DESCRIPTION
#### Description

It looks like the `streams` page has three responses headings now. This updates the link to go to the the right one.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [x] If it's a new feature, I have included documentation updates in both the README and the types.
