### PR TITLE
Add `proxy` option

### DIFF
--- a/source/core/proxy/agents.ts
+++ b/source/core/proxy/agents.ts
@@ -6,175 +6,175 @@ import https from 'https';
 import { proxies } from 'http2-wrapper';
 
 export const {
-    HttpOverHttp2,
-    HttpsOverHttp2,
-    Http2OverHttp2,
-    Http2OverHttps,
-    Http2OverHttp,
+	HttpOverHttp2,
+	HttpsOverHttp2,
+	Http2OverHttp2,
+	Http2OverHttps,
+	Http2OverHttp,
 } = proxies;
 
 interface AgentOptions extends http.AgentOptions {
-    proxy: string | URL;
-    disableConnect?: boolean;
+	proxy: string | URL;
+	disableConnect?: boolean;
 }
 
 const initialize = (self: http.Agent & { proxy: URL }, options: AgentOptions) => {
-    self.proxy = typeof options.proxy === 'string' ? new URL(options.proxy) : options.proxy;
+	self.proxy = typeof options.proxy === 'string' ? new URL(options.proxy) : options.proxy;
 };
 
 const getPort = (url: URL): number => {
-    if (url.port !== '') {
-        return Number(url.port);
-    }
+	if (url.port !== '') {
+		return Number(url.port);
+	}
 
-    if (url.protocol === 'http:') {
-        return 80;
-    }
+	if (url.protocol === 'http:') {
+		return 80;
+	}
 
-    if (url.protocol === 'https:') {
-        return 443;
-    }
+	if (url.protocol === 'https:') {
+		return 443;
+	}
 
-    throw new Error(`Unexpected protocol: ${url.protocol}`);
+	throw new Error(`Unexpected protocol: ${url.protocol}`);
 };
 
 const getBasic = (url: URL): string => {
-    let basic = '';
-    if (url.username || url.password) {
-        const username = decodeURIComponent(url.username);
-        const password = decodeURIComponent(url.password);
+	let basic = '';
+	if (url.username || url.password) {
+		const username = decodeURIComponent(url.username);
+		const password = decodeURIComponent(url.password);
 
-        basic = Buffer.from(`${username}:${password}`).toString('base64');
+		basic = Buffer.from(`${username}:${password}`).toString('base64');
 
-        return `Basic ${basic}`;
-    }
+		return `Basic ${basic}`;
+	}
 
-    return basic;
+	return basic;
 };
 
 export class HttpRegularProxyAgent extends http.Agent {
-    proxy!: URL;
+	proxy!: URL;
 
-    constructor(options: AgentOptions) {
-        super(options);
+	constructor(options: AgentOptions) {
+		super(options);
 
-        initialize(this, options);
-    }
+		initialize(this, options);
+	}
 
-    addRequest(request: ClientRequest, options: ClientRequestArgs): void {
-        if (options.socketPath) {
-            // @ts-expect-error @types/node is missing types
-            super.addRequest(request, options);
-            return;
-        }
+	addRequest(request: ClientRequest, options: ClientRequestArgs): void {
+		if (options.socketPath) {
+			// @ts-expect-error @types/node is missing types
+			super.addRequest(request, options);
+			return;
+		}
 
-        let hostport = `${options.host}:${options.port}`;
+		let hostport = `${options.host}:${options.port}`;
 
-        if (isIPv6(options.host!)) {
-            hostport = `[${options.host}]:${options.port}`;
-        }
+		if (isIPv6(options.host!)) {
+			hostport = `[${options.host}]:${options.port}`;
+		}
 
-        const url = new URL(`${request.protocol}//${hostport}${request.path}`);
+		const url = new URL(`${request.protocol}//${hostport}${request.path}`);
 
-        options = {
-            ...options,
-            host: this.proxy.hostname,
-            port: getPort(this.proxy),
-        };
+		options = {
+			...options,
+			host: this.proxy.hostname,
+			port: getPort(this.proxy),
+		};
 
-        request.path = url.href;
+		request.path = url.href;
 
-        const basic = getBasic(this.proxy);
-        if (basic) {
-            request.setHeader('proxy-authorization', basic);
-        }
+		const basic = getBasic(this.proxy);
+		if (basic) {
+			request.setHeader('proxy-authorization', basic);
+		}
 
-        // @ts-expect-error @types/node is missing types
-        super.addRequest(request, options);
-    }
+		// @ts-expect-error @types/node is missing types
+		super.addRequest(request, options);
+	}
 }
 
 export class HttpProxyAgent extends http.Agent {
-    proxy!: URL;
+	proxy!: URL;
 
-    constructor(options: AgentOptions) {
-        super(options);
+	constructor(options: AgentOptions) {
+		super(options);
 
-        initialize(this, options);
-    }
+		initialize(this, options);
+	}
 
-    createConnection(options: ConnectionOptions, callback: (error: Error | undefined, socket?: unknown) => void): void {
-        if (options.path) {
-            // @ts-expect-error @types/node is missing types
-            super.createConnection(options, callback);
-            return;
-        }
+	createConnection(options: ConnectionOptions, callback: (error: Error | undefined, socket?: unknown) => void): void {
+		if (options.path) {
+			// @ts-expect-error @types/node is missing types
+			super.createConnection(options, callback);
+			return;
+		}
 
-        const fn = this.proxy.protocol === 'https:' ? https.request : http.request;
+		const fn = this.proxy.protocol === 'https:' ? https.request : http.request;
 
-        let hostport = `${options.host}:${options.port}`;
+		let hostport = `${options.host}:${options.port}`;
 
-        if (isIPv6(options.host!)) {
-            hostport = `[${options.host}]:${options.port}`;
-        }
+		if (isIPv6(options.host!)) {
+			hostport = `[${options.host}]:${options.port}`;
+		}
 
-        const headers: Record<string, string> = {
-            host: hostport,
-        };
+		const headers: Record<string, string> = {
+			host: hostport,
+		};
 
-        const basic = getBasic(this.proxy);
-        if (basic) {
-            headers['proxy-authorization'] = basic;
-            headers.authorization = basic;
-        }
+		const basic = getBasic(this.proxy);
+		if (basic) {
+			headers['proxy-authorization'] = basic;
+			headers.authorization = basic;
+		}
 
-        const connectRequest = fn(this.proxy, {
-            method: 'CONNECT',
-            headers,
-            path: hostport,
-            agent: false,
+		const connectRequest = fn(this.proxy, {
+			method: 'CONNECT',
+			headers,
+			path: hostport,
+			agent: false,
 
-            rejectUnauthorized: false,
-        });
+			rejectUnauthorized: false,
+		});
 
-        connectRequest.once('connect', (response, socket, head) => {
-            if (head.length > 0 || response.statusCode !== 200) {
-                socket.destroy();
+		connectRequest.once('connect', (response, socket, head) => {
+			if (head.length > 0 || response.statusCode !== 200) {
+				socket.destroy();
 
-                const error = new Error(`The proxy responded with ${response.statusCode}: ${head.toString()}`);
-                callback(error);
-                return;
-            }
+				const error = new Error(`The proxy responded with ${response.statusCode}: ${head.toString()}`);
+				callback(error);
+				return;
+			}
 
-            if ((options as any).protocol === 'https:') {
-                callback(undefined, tls.connect({
-                    ...options,
-                    socket,
-                }));
-                return;
-            }
+			if ((options as any).protocol === 'https:') {
+				callback(undefined, tls.connect({
+					...options,
+					socket,
+				}));
+				return;
+			}
 
-            callback(undefined, socket);
-        });
+			callback(undefined, socket);
+		});
 
-        connectRequest.once('error', (error) => {
-            callback(error);
-        });
+		connectRequest.once('error', (error) => {
+			callback(error);
+		});
 
-        connectRequest.end();
-    }
+		connectRequest.end();
+	}
 }
 
 export class HttpsProxyAgent extends https.Agent {
-    proxy!: URL;
+	proxy!: URL;
 
-    constructor(options: AgentOptions) {
-        super(options);
+	constructor(options: AgentOptions) {
+		super(options);
 
-        initialize(this, options);
-    }
+		initialize(this, options);
+	}
 
-    createConnection(options: ConnectionOptions, callback: (error: Error | undefined, socket?: unknown) => void): void {
-        HttpProxyAgent.prototype.createConnection.call(this, options, callback);
-    }
+	createConnection(options: ConnectionOptions, callback: (error: Error | undefined, socket?: unknown) => void): void {
+		HttpProxyAgent.prototype.createConnection.call(this, options, callback);
+	}
 }

--- a/source/core/proxy/agents.ts
+++ b/source/core/proxy/agents.ts
@@ -1,0 +1,180 @@
+import { URL } from 'url';
+import { isIPv6 } from 'net';
+import tls, { ConnectionOptions } from 'tls';
+import http, { ClientRequest, ClientRequestArgs } from 'http';
+import https from 'https';
+import { proxies } from 'http2-wrapper';
+
+export const {
+    HttpOverHttp2,
+    HttpsOverHttp2,
+    Http2OverHttp2,
+    Http2OverHttps,
+    Http2OverHttp,
+} = proxies;
+
+interface AgentOptions extends http.AgentOptions {
+    proxy: string | URL;
+    disableConnect?: boolean;
+}
+
+const initialize = (self: http.Agent & { proxy: URL }, options: AgentOptions) => {
+    self.proxy = typeof options.proxy === 'string' ? new URL(options.proxy) : options.proxy;
+};
+
+const getPort = (url: URL): number => {
+    if (url.port !== '') {
+        return Number(url.port);
+    }
+
+    if (url.protocol === 'http:') {
+        return 80;
+    }
+
+    if (url.protocol === 'https:') {
+        return 443;
+    }
+
+    throw new Error(`Unexpected protocol: ${url.protocol}`);
+};
+
+const getBasic = (url: URL): string => {
+    let basic = '';
+    if (url.username || url.password) {
+        const username = decodeURIComponent(url.username);
+        const password = decodeURIComponent(url.password);
+
+        basic = Buffer.from(`${username}:${password}`).toString('base64');
+
+        return `Basic ${basic}`;
+    }
+
+    return basic;
+};
+
+export class HttpRegularProxyAgent extends http.Agent {
+    proxy!: URL;
+
+    constructor(options: AgentOptions) {
+        super(options);
+
+        initialize(this, options);
+    }
+
+    addRequest(request: ClientRequest, options: ClientRequestArgs): void {
+        if (options.socketPath) {
+            // @ts-expect-error @types/node is missing types
+            super.addRequest(request, options);
+            return;
+        }
+
+        let hostport = `${options.host}:${options.port}`;
+
+        if (isIPv6(options.host!)) {
+            hostport = `[${options.host}]:${options.port}`;
+        }
+
+        const url = new URL(`${request.protocol}//${hostport}${request.path}`);
+
+        options = {
+            ...options,
+            host: this.proxy.hostname,
+            port: getPort(this.proxy),
+        };
+
+        request.path = url.href;
+
+        const basic = getBasic(this.proxy);
+        if (basic) {
+            request.setHeader('proxy-authorization', basic);
+        }
+
+        // @ts-expect-error @types/node is missing types
+        super.addRequest(request, options);
+    }
+}
+
+export class HttpProxyAgent extends http.Agent {
+    proxy!: URL;
+
+    constructor(options: AgentOptions) {
+        super(options);
+
+        initialize(this, options);
+    }
+
+    createConnection(options: ConnectionOptions, callback: (error: Error | undefined, socket?: unknown) => void): void {
+        if (options.path) {
+            // @ts-expect-error @types/node is missing types
+            super.createConnection(options, callback);
+            return;
+        }
+
+        const fn = this.proxy.protocol === 'https:' ? https.request : http.request;
+
+        let hostport = `${options.host}:${options.port}`;
+
+        if (isIPv6(options.host!)) {
+            hostport = `[${options.host}]:${options.port}`;
+        }
+
+        const headers: Record<string, string> = {
+            host: hostport,
+        };
+
+        const basic = getBasic(this.proxy);
+        if (basic) {
+            headers['proxy-authorization'] = basic;
+            headers.authorization = basic;
+        }
+
+        const connectRequest = fn(this.proxy, {
+            method: 'CONNECT',
+            headers,
+            path: hostport,
+            agent: false,
+
+            rejectUnauthorized: false,
+        });
+
+        connectRequest.once('connect', (response, socket, head) => {
+            if (head.length > 0 || response.statusCode !== 200) {
+                socket.destroy();
+
+                const error = new Error(`The proxy responded with ${response.statusCode}: ${head.toString()}`);
+                callback(error);
+                return;
+            }
+
+            if ((options as any).protocol === 'https:') {
+                callback(undefined, tls.connect({
+                    ...options,
+                    socket,
+                }));
+                return;
+            }
+
+            callback(undefined, socket);
+        });
+
+        connectRequest.once('error', (error) => {
+            callback(error);
+        });
+
+        connectRequest.end();
+    }
+}
+
+export class HttpsProxyAgent extends https.Agent {
+    proxy!: URL;
+
+    constructor(options: AgentOptions) {
+        super(options);
+
+        initialize(this, options);
+    }
+
+    createConnection(options: ConnectionOptions, callback: (error: Error | undefined, socket?: unknown) => void): void {
+        HttpProxyAgent.prototype.createConnection.call(this, options, callback);
+    }
+}

--- a/source/core/proxy/proxy.ts
+++ b/source/core/proxy/proxy.ts
@@ -5,81 +5,81 @@ import type { Agents } from '../options';
 import {
 	HttpsProxyAgent,
 	HttpRegularProxyAgent,
-    HttpOverHttp2,
-    HttpsOverHttp2,
-    Http2OverHttp2,
-    Http2OverHttps,
-    Http2OverHttp,
+	HttpOverHttp2,
+	HttpsOverHttp2,
+	Http2OverHttp2,
+	Http2OverHttps,
+	Http2OverHttp,
 } from './agents';
 
 export async function getProxyAgents(parsedProxyUrl: URL, rejectUnauthorized: boolean) {
-    // Sockets must not be reused, the proxy server may rotate upstream proxies as well.
+	// Sockets must not be reused, the proxy server may rotate upstream proxies as well.
 
-    // `http2-wrapper` Agent options
-    const wrapperOptions = {
-        proxyOptions: {
-            url: parsedProxyUrl,
+	// `http2-wrapper` Agent options
+	const wrapperOptions = {
+		proxyOptions: {
+			url: parsedProxyUrl,
 
-            // Based on the got https.rejectUnauthorized option
-            rejectUnauthorized,
-        },
+			// Based on the got https.rejectUnauthorized option
+			rejectUnauthorized,
+		},
 
-        // The sockets won't be reused, no need to keep them
-        maxFreeSockets: 0,
-        maxEmptySessions: 0,
-    };
+		// The sockets won't be reused, no need to keep them
+		maxFreeSockets: 0,
+		maxEmptySessions: 0,
+	};
 
-    // Native `http.Agent` options
-    const nativeOptions = {
-        proxy: parsedProxyUrl,
+	// Native `http.Agent` options
+	const nativeOptions = {
+		proxy: parsedProxyUrl,
 
-        // The sockets won't be reused, no need to keep them
-        maxFreeSockets: 0,
-    };
+		// The sockets won't be reused, no need to keep them
+		maxFreeSockets: 0,
+	};
 
-    let agent: Agents;
+	let agent: Agents;
 
-    if (parsedProxyUrl.protocol === 'https:') {
-        let alpnProtocol = 'http/1.1';
+	if (parsedProxyUrl.protocol === 'https:') {
+		let alpnProtocol = 'http/1.1';
 
-        try {
-            const result = await auto.resolveProtocol({
-                host: parsedProxyUrl.hostname,
-                port: parsedProxyUrl.port,
-                rejectUnauthorized,
-                ALPNProtocols: ['h2', 'http/1.1'],
-                servername: parsedProxyUrl.hostname,
-            });
+		try {
+			const result = await auto.resolveProtocol({
+				host: parsedProxyUrl.hostname,
+				port: parsedProxyUrl.port,
+				rejectUnauthorized,
+				ALPNProtocols: ['h2', 'http/1.1'],
+				servername: parsedProxyUrl.hostname,
+			});
 
-            alpnProtocol = result.alpnProtocol;
-        } catch {
-            // Some proxies don't support CONNECT protocol, use http/1.1
-        }
+			alpnProtocol = result.alpnProtocol;
+		} catch {
+			// Some proxies don't support CONNECT protocol, use http/1.1
+		}
 
-        const proxyIsHttp2 = alpnProtocol === 'h2';
+		const proxyIsHttp2 = alpnProtocol === 'h2';
 
-        if (proxyIsHttp2) {
-            agent = {
-                http: new HttpOverHttp2(wrapperOptions),
-                https: new HttpsOverHttp2(wrapperOptions),
-                http2: new Http2OverHttp2(wrapperOptions),
-            };
-        } else {
-            // Upstream proxies hang up connections on CONNECT + unsecure HTTP
-            agent = {
-                http: new HttpRegularProxyAgent(nativeOptions),
-                https: new HttpsProxyAgent(nativeOptions),
-                http2: new Http2OverHttps(wrapperOptions),
-            };
-        }
-    } else {
-        // Upstream proxies hang up connections on CONNECT + unsecure HTTP
-        agent = {
-            http: new HttpRegularProxyAgent(nativeOptions),
-            https: new HttpsProxyAgent(nativeOptions),
-            http2: new Http2OverHttp(wrapperOptions),
-        };
-    }
+		if (proxyIsHttp2) {
+			agent = {
+				http: new HttpOverHttp2(wrapperOptions),
+				https: new HttpsOverHttp2(wrapperOptions),
+				http2: new Http2OverHttp2(wrapperOptions),
+			};
+		} else {
+			// Upstream proxies hang up connections on CONNECT + unsecure HTTP
+			agent = {
+				http: new HttpRegularProxyAgent(nativeOptions),
+				https: new HttpsProxyAgent(nativeOptions),
+				http2: new Http2OverHttps(wrapperOptions),
+			};
+		}
+	} else {
+		// Upstream proxies hang up connections on CONNECT + unsecure HTTP
+		agent = {
+			http: new HttpRegularProxyAgent(nativeOptions),
+			https: new HttpsProxyAgent(nativeOptions),
+			http2: new Http2OverHttp(wrapperOptions),
+		};
+	}
 
-    return agent;
+	return agent;
 }

--- a/source/core/proxy/proxy.ts
+++ b/source/core/proxy/proxy.ts
@@ -1,0 +1,85 @@
+import type { URL } from 'url';
+import { auto } from 'http2-wrapper';
+import type { Agents } from '../options';
+
+import {
+	HttpsProxyAgent,
+	HttpRegularProxyAgent,
+    HttpOverHttp2,
+    HttpsOverHttp2,
+    Http2OverHttp2,
+    Http2OverHttps,
+    Http2OverHttp,
+} from './agents';
+
+export async function getProxyAgents(parsedProxyUrl: URL, rejectUnauthorized: boolean) {
+    // Sockets must not be reused, the proxy server may rotate upstream proxies as well.
+
+    // `http2-wrapper` Agent options
+    const wrapperOptions = {
+        proxyOptions: {
+            url: parsedProxyUrl,
+
+            // Based on the got https.rejectUnauthorized option
+            rejectUnauthorized,
+        },
+
+        // The sockets won't be reused, no need to keep them
+        maxFreeSockets: 0,
+        maxEmptySessions: 0,
+    };
+
+    // Native `http.Agent` options
+    const nativeOptions = {
+        proxy: parsedProxyUrl,
+
+        // The sockets won't be reused, no need to keep them
+        maxFreeSockets: 0,
+    };
+
+    let agent: Agents;
+
+    if (parsedProxyUrl.protocol === 'https:') {
+        let alpnProtocol = 'http/1.1';
+
+        try {
+            const result = await auto.resolveProtocol({
+                host: parsedProxyUrl.hostname,
+                port: parsedProxyUrl.port,
+                rejectUnauthorized,
+                ALPNProtocols: ['h2', 'http/1.1'],
+                servername: parsedProxyUrl.hostname,
+            });
+
+            alpnProtocol = result.alpnProtocol;
+        } catch {
+            // Some proxies don't support CONNECT protocol, use http/1.1
+        }
+
+        const proxyIsHttp2 = alpnProtocol === 'h2';
+
+        if (proxyIsHttp2) {
+            agent = {
+                http: new HttpOverHttp2(wrapperOptions),
+                https: new HttpsOverHttp2(wrapperOptions),
+                http2: new Http2OverHttp2(wrapperOptions),
+            };
+        } else {
+            // Upstream proxies hang up connections on CONNECT + unsecure HTTP
+            agent = {
+                http: new HttpRegularProxyAgent(nativeOptions),
+                https: new HttpsProxyAgent(nativeOptions),
+                http2: new Http2OverHttps(wrapperOptions),
+            };
+        }
+    } else {
+        // Upstream proxies hang up connections on CONNECT + unsecure HTTP
+        agent = {
+            http: new HttpRegularProxyAgent(nativeOptions),
+            https: new HttpsProxyAgent(nativeOptions),
+            http2: new Http2OverHttp(wrapperOptions),
+        };
+    }
+
+    return agent;
+}


### PR DESCRIPTION
We're in kinda stalemate position when it comes to proxies with Got. Many agents are unreliable and that drives off Got users, because they need to look for more and more agents. This might be better off in upper-level packages like [`got-scraping`](https://github.com/apify/got-scraping). Ideally this should be implemented in lower level, but unfortunately due to how Node.js designed the `http` module it looks kinda ugly.

@sindresorhus Please confirm do we want this in Got? If so, I'll continue with the tests & docs.