### PR TITLE
Support FormData without known length

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"cacheable-lookup": "^6.0.4",
 		"cacheable-request": "^7.0.2",
 		"decompress-response": "^6.0.0",
-		"form-data-encoder": "^2.0.1",
+		"form-data-encoder": "^2.1.0",
 		"get-stream": "^6.0.1",
 		"http2-wrapper": "^2.1.10",
 		"lowercase-keys": "^3.0.0",

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -570,7 +570,9 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 						headers['content-type'] = encoder.headers['Content-Type'];
 					}
 
-					headers['content-length'] = encoder.headers['Content-Length'];
+					if ('Content-Length' in encoder.headers) {
+						headers['content-length'] = encoder.headers['Content-Length'];
+					}
 
 					options.body = encoder.encode();
 				}

--- a/test/helpers/create-https-test-server.ts
+++ b/test/helpers/create-https-test-server.ts
@@ -5,7 +5,7 @@ import type {SecureContextOptions} from 'tls';
 import express from 'express';
 import pify from 'pify';
 import pem from 'pem';
-import type {CreateCSR, CreateCertificate} from '../types/pem.js';
+import type {CreateCsr, CreateCertificate} from '../types/pem.js';
 
 export type HttpsServerOptions = {
 	commonName?: string;
@@ -26,7 +26,7 @@ export type ExtendedHttpsTestServer = {
 } & express.Express;
 
 const createHttpsTestServer = async (options: HttpsServerOptions = {}): Promise<ExtendedHttpsTestServer> => {
-	const createCsr = pify(pem.createCSR as CreateCSR);
+	const createCsr = pify(pem.createCSR as CreateCsr);
 	const createCertificate = pify(pem.createCertificate as CreateCertificate);
 
 	const caCsrResult = await createCsr({commonName: 'authority'});

--- a/test/helpers/create-https-test-server.ts
+++ b/test/helpers/create-https-test-server.ts
@@ -5,6 +5,7 @@ import type {SecureContextOptions} from 'tls';
 import express from 'express';
 import pify from 'pify';
 import pem from 'pem';
+import type {CreateCSR, CreateCertificate} from '../types/pem.js';
 
 export type HttpsServerOptions = {
 	commonName?: string;
@@ -25,8 +26,8 @@ export type ExtendedHttpsTestServer = {
 } & express.Express;
 
 const createHttpsTestServer = async (options: HttpsServerOptions = {}): Promise<ExtendedHttpsTestServer> => {
-	const createCsr = pify(pem.createCSR);
-	const createCertificate = pify(pem.createCertificate);
+	const createCsr = pify(pem.createCSR as CreateCSR);
+	const createCertificate = pify(pem.createCertificate as CreateCertificate);
 
 	const caCsrResult = await createCsr({commonName: 'authority'});
 	const caResult = await createCertificate({
@@ -68,7 +69,7 @@ const createHttpsTestServer = async (options: HttpsServerOptions = {}): Promise<
 
 	await pify(server.https.listen.bind(server.https))();
 
-	server.caKey = caKey;
+	server.caKey = caKey as any;
 	server.caCert = caCert;
 	server.port = (server.https.address() as net.AddressInfo).port;
 	server.url = `https://localhost:${(server.port)}`;

--- a/test/https.ts
+++ b/test/https.ts
@@ -6,10 +6,11 @@ import pify from 'pify';
 import pem from 'pem';
 import got from '../source/index.js';
 import {withHttpsServer} from './helpers/with-server.js';
+import type {CreatePrivateKey, CreateCSR, CreateCertificate} from './types/pem.js';
 
-const createPrivateKey = pify(pem.createPrivateKey);
-const createCsr = pify(pem.createCSR);
-const createCertificate = pify(pem.createCertificate);
+const createPrivateKey = pify(pem.createPrivateKey as CreatePrivateKey);
+const createCsr = pify(pem.createCSR as CreateCSR);
+const createCertificate = pify(pem.createCertificate as CreateCertificate);
 const createPkcs12 = pify(pem.createPkcs12);
 
 test('https request without ca', withHttpsServer(), async (t, server, got) => {

--- a/test/https.ts
+++ b/test/https.ts
@@ -6,10 +6,10 @@ import pify from 'pify';
 import pem from 'pem';
 import got from '../source/index.js';
 import {withHttpsServer} from './helpers/with-server.js';
-import type {CreatePrivateKey, CreateCSR, CreateCertificate} from './types/pem.js';
+import type {CreatePrivateKey, CreateCsr, CreateCertificate} from './types/pem.js';
 
 const createPrivateKey = pify(pem.createPrivateKey as CreatePrivateKey);
-const createCsr = pify(pem.createCSR as CreateCSR);
+const createCsr = pify(pem.createCSR as CreateCsr);
 const createCertificate = pify(pem.createCertificate as CreateCertificate);
 const createPkcs12 = pify(pem.createPkcs12);
 

--- a/test/types/pem.ts
+++ b/test/types/pem.ts
@@ -1,0 +1,19 @@
+import type {
+	CertificateCreationOptions,
+	CertificateCreationResult,
+	PrivateKeyCreationOptions,
+	CSRCreationOptions,
+	Callback
+} from 'pem';
+
+export interface CreateCertificate {
+	(options: CertificateCreationOptions, callback: Callback<CertificateCreationResult>): void
+}
+
+export interface CreateCSR {
+	(options: CSRCreationOptions, callback: Callback<{ csr: string, clientKey: string }>): void
+}
+
+export interface CreatePrivateKey {
+	(keyBitsize: number, options: PrivateKeyCreationOptions, callback: Callback<{ key: string }>): void
+}

--- a/test/types/pem.ts
+++ b/test/types/pem.ts
@@ -1,19 +1,7 @@
-import type {
-	CertificateCreationOptions,
-	CertificateCreationResult,
-	PrivateKeyCreationOptions,
-	CSRCreationOptions,
-	Callback
-} from 'pem';
+import type {CertificateCreationOptions, CertificateCreationResult, PrivateKeyCreationOptions, CSRCreationOptions, Callback} from 'pem';
 
-export interface CreateCertificate {
-	(options: CertificateCreationOptions, callback: Callback<CertificateCreationResult>): void
-}
+export type CreateCertificate = (options: CertificateCreationOptions, callback: Callback<CertificateCreationResult>) => void;
 
-export interface CreateCSR {
-	(options: CSRCreationOptions, callback: Callback<{ csr: string, clientKey: string }>): void
-}
+export type CreateCsr = (options: CSRCreationOptions, callback: Callback<{csr: string; clientKey: string}>) => void;
 
-export interface CreatePrivateKey {
-	(keyBitsize: number, options: PrivateKeyCreationOptions, callback: Callback<{ key: string }>): void
-}
+export type CreatePrivateKey = (keyBitsize: number, options: PrivateKeyCreationOptions, callback: Callback<{key: string}>) => void;


### PR DESCRIPTION
This PR updates fixes support for FormData instances without known length. In detail:

* Updated `form-data-encoder` dependency to version 2.1.0;
* Fixed usage of headers, returned by `FormDataEncoder` instance;
* Added a test for `got.post` requests using `FormData` without known length.

Fixes #2111

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates in both the README and the types.
