### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
 	"dependencies": {
 		"@sindresorhus/is": "^5.2.0",
 		"@szmarczak/http-timer": "^5.0.1",
-		"@types/cacheable-request": "^6.0.2",
 		"cacheable-lookup": "^6.0.4",
 		"cacheable-request": "^7.0.2",
 		"decompress-response": "^6.0.0",


### PR DESCRIPTION
According to the below GitHub discussion, the author of `cacheable-request` said that `@types/cacheable-request` is unnecessary.
https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/62099#discussioncomment-3543751
(And I wrote about my issue also in the discussion, so please check it if you have interesting)

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates in both the README and the types.
