### PR TITLE
Improve docs and disable method rewriting on 307 and 308

### DIFF
--- a/documentation/2-options.md
+++ b/documentation/2-options.md
@@ -692,7 +692,7 @@ Defines if redirect responses should be followed automatically.
 
 #### **Note:**
 > - If a `303` is sent by the server in response to any request type (POST, DELETE, etc.), Got will request the resource pointed to in the location header via GET.\
->  This is in accordance with the [specification](https://tools.ietf.org/html/rfc7231#section-6.4.4).
+>  This is in accordance with the [specification](https://tools.ietf.org/html/rfc7231#section-6.4.4). You can optionally turn on this behavior also for other redirect codes - see `methodRewriting`.
 
 ```js
 import got from 'got';
@@ -936,9 +936,14 @@ Optionally overrides the value of [`--max-http-header-size`](https://nodejs.org/
 **Type: `boolean`**\
 **Default: `false`**
 
-By default, requests will not use [method rewriting](https://datatracker.ietf.org/doc/html/rfc7231#section-6.4).
+Specifies if the HTTP request method should be [rewritten as `GET`](https://tools.ietf.org/html/rfc7231#section-6.4) on redirects.
 
-For example, when sending a `POST` request and receiving a `302`, it will resend the body to the new location using the same HTTP method (`POST` in this case). To rewrite the request as `GET`, set this option to `true`.
+As the [specification](https://tools.ietf.org/html/rfc7231#section-6.4) prefers to rewrite the HTTP method only on `303` responses, this is Got's default behavior.
+
+However, since the spec also allows to rewrite to `GET` for `301` and `302` responses and many user agents - including, e.g., [`curl`](https://everything.curl.dev/http/redirects#get-or-post) and all major browsers - do so by default, this option may be used to mimic the same behavior and reach compatibility with servers expecting it.
+
+**Note:**
+> - Got never performs method rewriting on `307` and `308` responses, as this is [explicitly prohibited by the specification](https://www.rfc-editor.org/rfc/rfc7231#section-6.4.7).
 
 ### `enableUnixSockets`
 

--- a/documentation/2-options.md
+++ b/documentation/2-options.md
@@ -692,7 +692,7 @@ Defines if redirect responses should be followed automatically.
 
 #### **Note:**
 > - If a `303` is sent by the server in response to any request type (POST, DELETE, etc.), Got will request the resource pointed to in the location header via GET.\
->  This is in accordance with the [specification](https://tools.ietf.org/html/rfc7231#section-6.4.4). You can optionally turn on this behavior also for other redirect codes - see `methodRewriting`.
+>  This is in accordance with the [specification](https://tools.ietf.org/html/rfc7231#section-6.4.4). You can optionally turn on this behavior also for other redirect codes - see [`methodRewriting`](#methodrewriting).
 
 ```js
 import got from 'got';
@@ -938,9 +938,7 @@ Optionally overrides the value of [`--max-http-header-size`](https://nodejs.org/
 
 Specifies if the HTTP request method should be [rewritten as `GET`](https://tools.ietf.org/html/rfc7231#section-6.4) on redirects.
 
-As the [specification](https://tools.ietf.org/html/rfc7231#section-6.4) prefers to rewrite the HTTP method only on `303` responses, this is Got's default behavior.
-
-However, since the spec also allows to rewrite to `GET` for `301` and `302` responses and many user agents - including, e.g., [`curl`](https://everything.curl.dev/http/redirects#get-or-post) and all major browsers - do so by default, this option may be used to mimic the same behavior and reach compatibility with servers expecting it.
+As the [specification](https://tools.ietf.org/html/rfc7231#section-6.4) prefers to rewrite the HTTP method only on `303` responses, this is Got's default behavior. Setting `methodRewriting` to `true` will also rewrite `301` and `302` responses, as allowed by the spec. This is the behavior followed by `curl` and browsers.
 
 **Note:**
 > - Got never performs method rewriting on `307` and `308` responses, as this is [explicitly prohibited by the specification](https://www.rfc-editor.org/rfc/rfc7231#section-6.4.7).

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -733,7 +733,7 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 
 			if ((updatedOptions.methodRewriting && ![307, 308].includes(statusCode))
 				|| (statusCode === 303 && !['GET', 'HEAD'].includes(updatedOptions.method))) {
-				// Either the server responded with 303 or 
+				// Either the server responded with 303 or
 				// the methodRewriting option explicitly requests
 				// a rewrite to GET on non-307/308 responses
 				updatedOptions.method = 'GET';

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -734,7 +734,7 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 			const serverRequestedGet = statusCode === 303 && updatedOptions.method !== 'GET' && updatedOptions.method !== 'HEAD';
 			const canRewrite = statusCode !== 307 && statusCode !== 308;
 			const userRequestedGet = updatedOptions.methodRewriting && canRewrite;
-			
+
 			if (serverRequestedGet || userRequestedGet) {
 				updatedOptions.method = 'GET';
 

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -734,10 +734,8 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 			const serverRequestedGet = statusCode === 303 && updatedOptions.method !== 'GET' && updatedOptions.method !== 'HEAD';
 			const canRewrite = statusCode !== 307 && statusCode !== 308;
 			const userRequestedGet = updatedOptions.methodRewriting && canRewrite;
+			
 			if (serverRequestedGet || userRequestedGet) {
-				// Either the server responded with 303 or
-				// the methodRewriting option explicitly requests
-				// a rewrite to GET on non-307/308 responses
 				updatedOptions.method = 'GET';
 
 				updatedOptions.body = undefined;

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -731,8 +731,10 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 
 			const updatedOptions = new Options(undefined, undefined, this.options);
 
-			if ((updatedOptions.methodRewriting && ![307, 308].includes(statusCode))
-				|| (statusCode === 303 && !['GET', 'HEAD'].includes(updatedOptions.method))) {
+			const serverRequestedGet = statusCode === 303 && updatedOptions.method !== 'GET' && updatedOptions.method !== 'HEAD';
+			const canRewrite = statusCode !== 307 && statusCode !== 308;
+			const userRequestedGet = updatedOptions.methodRewriting && canRewrite;
+			if (serverRequestedGet || userRequestedGet) {
 				// Either the server responded with 303 or
 				// the methodRewriting option explicitly requests
 				// a rewrite to GET on non-307/308 responses

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -731,9 +731,11 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 
 			const updatedOptions = new Options(undefined, undefined, this.options);
 
-			if (updatedOptions.methodRewriting && ![307, 308].includes(statusCode) || statusCode === 303 && !['GET', 'HEAD'].includes(updatedOptions.method)) {
-				// Server responded with "see other", indicating that the resource exists at another location,
-				// and the client should request it from that location via GET or HEAD.
+			if ((updatedOptions.methodRewriting && ![307, 308].includes(statusCode))
+				|| (statusCode === 303 && !['GET', 'HEAD'].includes(updatedOptions.method))) {
+				// Either the server responded with 303 or 
+				// the methodRewriting option explicitly requests
+				// a rewrite to GET on non-307/308 responses
 				updatedOptions.method = 'GET';
 
 				updatedOptions.body = undefined;

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -731,8 +731,7 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 
 			const updatedOptions = new Options(undefined, undefined, this.options);
 
-			const shouldBeGet = statusCode === 303 && updatedOptions.method !== 'GET' && updatedOptions.method !== 'HEAD';
-			if (shouldBeGet || updatedOptions.methodRewriting) {
+			if (updatedOptions.methodRewriting && ![307, 308].includes(statusCode) || statusCode === 303 && !['GET', 'HEAD'].includes(updatedOptions.method)) {
 				// Server responded with "see other", indicating that the resource exists at another location,
 				// and the client should request it from that location via GET or HEAD.
 				updatedOptions.method = 'GET';

--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -1957,9 +1957,9 @@ export default class Options {
 	/**
 	Specifies if the HTTP request method should be [rewritten as `GET`](https://tools.ietf.org/html/rfc7231#section-6.4) on redirects.
 
-	As the [specification](https://tools.ietf.org/html/rfc7231#section-6.4) prefers to rewrite the HTTP method only on `303` responses, this is Got's default behavior. 
+	As the [specification](https://tools.ietf.org/html/rfc7231#section-6.4) prefers to rewrite the HTTP method only on `303` responses, this is Got's default behavior.
 	Setting `methodRewriting` to `true` will also rewrite `301` and `302` responses, as allowed by the spec. This is the behavior followed by `curl` and browsers.
-	
+
 	__Note__: Got never performs method rewriting on `307` and `308` responses, as this is [explicitly prohibited by the specification](https://www.rfc-editor.org/rfc/rfc7231#section-6.4.7).
 
 	@default false

--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -1764,7 +1764,7 @@ export default class Options {
 	Defines if redirect responses should be followed automatically.
 
 	Note that if a `303` is sent by the server in response to any request type (`POST`, `DELETE`, etc.), Got will automatically request the resource pointed to in the location header via `GET`.
-	This is in accordance with [the spec](https://tools.ietf.org/html/rfc7231#section-6.4.4).
+	This is in accordance with [the spec](https://tools.ietf.org/html/rfc7231#section-6.4.4). You can optionally turn on this behavior also for other redirect codes - see `methodRewriting`.
 
 	@default true
 	*/
@@ -1955,9 +1955,12 @@ export default class Options {
 	}
 
 	/**
-	Specifies if the redirects should be [rewritten as `GET`](https://tools.ietf.org/html/rfc7231#section-6.4).
+	Specifies if the HTTP request method should be [rewritten as `GET`](https://tools.ietf.org/html/rfc7231#section-6.4) on redirects.
 
-	If `false`, when sending a POST request and receiving a `302`, it will resend the body to the new location using the same HTTP method (`POST` in this case).
+	As the [specification](https://tools.ietf.org/html/rfc7231#section-6.4) prefers to rewrite the HTTP method only on `303` responses, this is Got's default behavior.
+	However, since the spec also allows to rewrite to `GET` for `301` and `302` responses and many user agents - including, e.g., [`curl`](https://everything.curl.dev/http/redirects#get-or-post) and all major browsers - do so by default, this option may be used to mimic the same behavior and reach compatibility with servers expecting it.
+
+	__Note__: Got never performs method rewriting on `307` and `308` responses, as this is [explicitly prohibited by the specification](https://www.rfc-editor.org/rfc/rfc7231#section-6.4.7).
 
 	@default false
 	*/

--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -1957,9 +1957,9 @@ export default class Options {
 	/**
 	Specifies if the HTTP request method should be [rewritten as `GET`](https://tools.ietf.org/html/rfc7231#section-6.4) on redirects.
 
-	As the [specification](https://tools.ietf.org/html/rfc7231#section-6.4) prefers to rewrite the HTTP method only on `303` responses, this is Got's default behavior.
-	However, since the spec also allows to rewrite to `GET` for `301` and `302` responses and many user agents - including, e.g., [`curl`](https://everything.curl.dev/http/redirects#get-or-post) and all major browsers - do so by default, this option may be used to mimic the same behavior and reach compatibility with servers expecting it.
-
+	As the [specification](https://tools.ietf.org/html/rfc7231#section-6.4) prefers to rewrite the HTTP method only on `303` responses, this is Got's default behavior. 
+	Setting `methodRewriting` to `true` will also rewrite `301` and `302` responses, as allowed by the spec. This is the behavior followed by `curl` and browsers.
+	
 	__Note__: Got never performs method rewriting on `307` and `308` responses, as this is [explicitly prohibited by the specification](https://www.rfc-editor.org/rfc/rfc7231#section-6.4.7).
 
 	@default false

--- a/test/redirects.ts
+++ b/test/redirects.ts
@@ -459,9 +459,18 @@ test('method rewriting', withServer, async (t, server, got) => {
 		});
 		response.end();
 	});
+	server.get('/', (request, response) => {
+		request.pipe(response);
+	});
 
-	server.get('/', (_request, response) => {
+	server.post('/temporaryRedirect', (_request, response) => {
+		response.writeHead(307, {
+			location: '/',
+		})
 		response.end();
+	});
+	server.post('/', (request, response) => {
+		request.pipe(response);
 	});
 
 	const {body} = await got.post('redirect', {
@@ -477,6 +486,21 @@ test('method rewriting', withServer, async (t, server, got) => {
 	});
 
 	t.is(body, '');
+
+	// Do not rewrite method on 307 or 308
+	const {body: tempRedirectBody} = await got.post('temporaryRedirect', {
+		body: 'foobar',
+		methodRewriting: true,
+		hooks: {
+			beforeRedirect: [
+				options => {
+					t.is(options.body, 'foobar');
+				},
+			],
+		},
+	});
+
+	t.is(tempRedirectBody, 'foobar');
 });
 
 test('clears username and password when redirecting to a different hostname', withServer, async (t, server, got) => {

--- a/test/redirects.ts
+++ b/test/redirects.ts
@@ -466,7 +466,7 @@ test('method rewriting', withServer, async (t, server, got) => {
 	server.post('/temporaryRedirect', (_request, response) => {
 		response.writeHead(307, {
 			location: '/',
-		})
+		});
 		response.end();
 	});
 	server.post('/', (request, response) => {
@@ -488,7 +488,7 @@ test('method rewriting', withServer, async (t, server, got) => {
 	t.is(body, '');
 
 	// Do not rewrite method on 307 or 308
-	const {body: tempRedirectBody} = await got.post('temporaryRedirect', {
+	const {body: temporaryRedirectBody} = await got.post('temporaryRedirect', {
 		body: 'foobar',
 		methodRewriting: true,
 		hooks: {
@@ -500,7 +500,7 @@ test('method rewriting', withServer, async (t, server, got) => {
 		},
 	});
 
-	t.is(tempRedirectBody, 'foobar');
+	t.is(temporaryRedirectBody, 'foobar');
 });
 
 test('clears username and password when redirecting to a different hostname', withServer, async (t, server, got) => {

--- a/test/redirects.ts
+++ b/test/redirects.ts
@@ -459,8 +459,8 @@ test('method rewriting', withServer, async (t, server, got) => {
 		});
 		response.end();
 	});
-	server.get('/', (request, response) => {
-		request.pipe(response);
+	server.get('/', (_request, response) => {
+		response.end();
 	});
 
 	server.post('/temporaryRedirect', (_request, response) => {


### PR DESCRIPTION
Solves #2136:

- Improve/extend the documentation on method rewriting behavior
- Disable method rewriting on 307 and 308 redirects, as this is explicitly prohibited by the spec

#### Checklist
- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
