### PR TITLE
Improve TypeScript 4.9 compatibility

### DIFF
--- a/source/core/timed-out.ts
+++ b/source/core/timed-out.ts
@@ -188,6 +188,6 @@ export default function timedOut(request: ClientRequest, delays: Delays, options
 declare module 'http' {
 	// eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- This has to be an `interface` to be able to be merged.
 	interface ClientRequest {
-		[reentry]: boolean;
+		[reentry]?: boolean;
 	}
 }


### PR DESCRIPTION
TypeScript 4.9 can narrow more correctly with the `in` operator. Since this property is declared as being always present, code that only runs if it's *not* present marks that variable as `never` and causes errors. The correct definition is to mark this as optional (alternatively, you can upcast `reentry` to `symbol` in the `in` checks, but that's more invasive and less correct)
