### PR TITLE
Update tough-cookie from 4.0.0 to 4.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
 		"tempy": "^3.0.0",
 		"then-busboy": "^5.2.1",
 		"to-readable-stream": "^3.0.0",
-		"tough-cookie": "4.0.0",
+		"tough-cookie": "4.1.2",
 		"ts-node": "^10.8.2",
 		"type-fest": "^3.0.0",
 		"typescript": "~4.8.2",

--- a/test/cookies.ts
+++ b/test/cookies.ts
@@ -57,7 +57,7 @@ test('cookies doesn\'t break on redirects', withServer, async (t, server, got) =
 
 test('throws on invalid cookies', withServer, async (t, server, got) => {
 	server.get('/', (_request, response) => {
-		response.setHeader('set-cookie', 'hello=world; domain=localhost');
+		response.setHeader('set-cookie', 'invalid cookie; domain=localhost');
 		response.end();
 	});
 
@@ -65,13 +65,13 @@ test('throws on invalid cookies', withServer, async (t, server, got) => {
 
 	await t.throwsAsync(got({cookieJar}), {
 		instanceOf: RequestError,
-		message: 'Cookie has domain set to a public suffix',
+		message: 'Cookie failed to parse',
 	});
 });
 
 test('does not throw on invalid cookies when options.ignoreInvalidCookies is set', withServer, async (t, server, got) => {
 	server.get('/', (_request, response) => {
-		response.setHeader('set-cookie', 'hello=world; domain=localhost');
+		response.setHeader('set-cookie', 'invalid cookie; domain=localhost');
 		response.end();
 	});
 


### PR DESCRIPTION
There is a bug in the `4.0.0` release of `tough-cookie` which causes cookies set on the `localhost` domain to be treated as an error.  This has been fixed in later versions.  This PR updates the dependency and fixes the related tests.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] ~If it's a new feature, I have included documentation updates in both the README and the types.~ (not applicable)
