### PR TITLE
Update Axios in comparison table

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -215,14 +215,14 @@ By default, Got will retry on failure. To disable this option, set [`options.ret
 | HTTP/2 support        | :heavy_check_mark:¹ | :x:                | :x:                  | :x:                      | :x:                | :heavy_check_mark:\*\* |
 | Browser support       | :x:                 | :x:                | :heavy_check_mark:\* | :heavy_check_mark:       | :heavy_check_mark: | :heavy_check_mark:     |
 | Promise API           | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark:   | :heavy_check_mark:       | :heavy_check_mark: | :heavy_check_mark:     |
-| Stream API            | :heavy_check_mark:  | :heavy_check_mark: | Node.js only         | :x:                      | :x:                | :heavy_check_mark:     |
+| Stream API            | :heavy_check_mark:  | :heavy_check_mark: | Node.js only         | :x:                      | Node.js only       | :heavy_check_mark:     |
 | Pagination API        | :heavy_check_mark:  | :x:                | :x:                  | :x:                      | :x:                | :x:                    |
 | Request cancelation   | :heavy_check_mark:  | :x:                | :heavy_check_mark:   | :heavy_check_mark:       | :heavy_check_mark: | :heavy_check_mark:     |
 | RFC compliant caching | :heavy_check_mark:  | :x:                | :x:                  | :x:                      | :x:                | :x:                    |
 | Cookies (out-of-box)  | :heavy_check_mark:  | :heavy_check_mark: | :x:                  | :x:                      | :x:                | :x:                    |
 | Follows redirects     | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark:   | :heavy_check_mark:       | :heavy_check_mark: | :heavy_check_mark:     |
 | Retries on failure    | :heavy_check_mark:  | :x:                | :x:                  | :heavy_check_mark:       | :x:                | :heavy_check_mark:     |
-| Progress events       | :heavy_check_mark:  | :x:                | :x:                  | :heavy_check_mark:\*\*\* | Browser only       | :heavy_check_mark:     |
+| Progress events       | :heavy_check_mark:  | :x:                | :x:                  | :heavy_check_mark:\*\*\* | :heavy_check_mark: | :heavy_check_mark:     |
 | Handles gzip/deflate  | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark:   | :heavy_check_mark:       | :heavy_check_mark: | :heavy_check_mark:     |
 | Advanced timeouts     | :heavy_check_mark:  | :x:                | :x:                  | :x:                      | :x:                | :x:                    |
 | Timings               | :heavy_check_mark:  | :heavy_check_mark: | :x:                  | :x:                      | :x:                | :x:                    |


### PR DESCRIPTION
Hi there -- I was looking at the comparison table and had just been checking out Axios. It seems like there's some mistakes or omissions: Axios supports progress events for both Node and the browser, as well as streams for Node.

Incidentally, most of these criteria are clear, but I'm not too sure what a few of them (like "composable") mean.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests. (n/a)
- [x] If it's a new feature, I have included documentation updates in both the README and the types.
