### PR TITLE
fix: destroy request object after successful response (issue #1489)

### DIFF
--- a/source/as-promise/index.ts
+++ b/source/as-promise/index.ts
@@ -131,6 +131,7 @@ export default function asPromise<T>(normalizedOptions: NormalizedOptions): Canc
 					return;
 				}
 
+				request.destroy();
 				resolve(request.options.resolveBodyOnly ? response.body as T : response as unknown as T);
 			});
 

--- a/test/promise.ts
+++ b/test/promise.ts
@@ -95,3 +95,14 @@ test('promise.json() does not fail when server returns an error and throwHttpErr
 	const promise = got('', {throwHttpErrors: false});
 	await t.notThrowsAsync(promise.json());
 });
+
+test('the request is destroyed once the promise has resolved', withServer, async (t, server, got) => {
+	server.get('/', (_request, response) => {
+		response.statusCode = 200;
+		response.end('null');
+	});
+
+	const {request} = await got('');
+
+	t.true(request.destroyed);
+});


### PR DESCRIPTION
#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] (n/a) If it's a new feature, I have included documentation updates in both the README and the types.

Based on my testing this fixes #1489 for v11: late `ECONNRESET` errors no longer causes the "onCancel handler was attached after the promise settled" error. (I used [this gist](https://gist.github.com/nduthoit/00b0623a6b4a9a61f1e264ea1f982d33) for testing).

It mimics [what is done in v12](https://github.com/sindresorhus/got/blob/v12.5.3/source/as-promise/index.ts#L111) by calling `request.destroy()` after a successful response right before the promise is resolved.

I tried to add a test case where the server would reset the TCP connection and cause an ECONNRESET error after sending a success response but that proved to be challenging to do using an Express server. I also tried using a Python server executed from the test case but it proved to be too brittle to be a good test case. Therefore I landed on a simpler test case that ensures that the request has been destroyed once the promise has successfully resolved. 