### PR TITLE
Fix v11 build

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 		"@sinonjs/fake-timers": "^6.0.1",
 		"@types/benchmark": "^1.0.33",
 		"@types/express": "^4.17.7",
+		"@types/express-serve-static-core": "4.17.18 - 4.17.30",
 		"@types/node": "^14.14.0",
 		"@types/node-fetch": "^2.5.7",
 		"@types/pem": "^1.9.5",

--- a/test/cookies.ts
+++ b/test/cookies.ts
@@ -60,7 +60,7 @@ test('cookies doesn\'t break on redirects', withServer, async (t, server, got) =
 
 test('throws on invalid cookies', withServer, async (t, server, got) => {
 	server.get('/', (_request, response) => {
-		response.setHeader('set-cookie', 'hello=world; domain=localhost');
+		response.setHeader('set-cookie', 'hello=world; domain=com');
 		response.end();
 	});
 
@@ -71,7 +71,7 @@ test('throws on invalid cookies', withServer, async (t, server, got) => {
 
 test('does not throw on invalid cookies when options.ignoreInvalidCookies is set', withServer, async (t, server, got) => {
 	server.get('/', (_request, response) => {
-		response.setHeader('set-cookie', 'hello=world; domain=localhost');
+		response.setHeader('set-cookie', 'hello=world; domain=com');
 		response.end();
 	});
 


### PR DESCRIPTION
#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- n/a I have included some tests.
- n/a If it's a new feature, I have included documentation updates in both the README and the types.

#### Changes
 - The current latest @types/express-serve-static-core (v4.7.31) was causing the build to fail. The current solution is to set the upper bound to v4.7.30 (see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/62243).
 - `localhost` is not in the [public suffixes list](https://publicsuffix.org/list/public_suffix_list.dat) and was causing [2 tests](https://github.com/sindresorhus/got/blob/v11/test/cookies.ts#L61-L87) to fail, switching to `com` fixes it.

@sindresorhus with these changes the v11 build succeeds and tests pass for node 10 and 14.

There's a weird issue with node 12 where [this test](https://github.com/sindresorhus/got/blob/v11/test/timeout.ts#L340-L348) fails with an `ECONNRESET` error but the issue is really with [these other two tests](https://github.com/sindresorhus/got/blob/v11/test/timeout.ts#L306-L338). If you remove them the test suite passes.

The error is: 
```
  Error [ERR_INTERNAL_ASSERTION]: This is caused by either a bug in Node.js or incorrect usage of Node.js internals.
  Please open an issue with this stack trace at https://github.com/nodejs/node/issues
```
