### PR TITLE
Do not enforce newest URI rules on URLs

### DIFF
--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -1403,7 +1403,6 @@ export default class Options {
 		const urlString = `${this.prefixUrl as string}${value.toString()}`;
 		const url = new URL(urlString);
 		this._internals.url = url;
-		decodeURI(urlString);
 
 		if (url.protocol === 'unix:') {
 			url.href = `http://unix${url.pathname}${url.search}`;


### PR DESCRIPTION
There are still sites in the wild that only support Latin1 encoded URLs, but GOT throws a URI malformed error even though the page can be retrieved. This PR removes the assertion made with `decodeURI` to solve the problem.

My question would be, why is `decodeURI` used here for assertion?

Samples:
* http://www.wrgag.ch/Inserat_Servicemonteur_L%FCftung_Klima.pdf


#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates in both the README and the types.
