### PR TITLE
Allow specifying `undefined` for options

### DIFF
--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -1078,7 +1078,13 @@ export default class Options {
 				}
 
 				// @ts-expect-error Type 'unknown' is not assignable to type 'never'.
-				this[key as keyof Options] = options[key as keyof Options];
+				const value = options[key as keyof Options];
+				if (value === undefined) {
+					continue;
+				}
+
+				// @ts-expect-error Type 'unknown' is not assignable to type 'never'.
+				this[key as keyof Options] = value;
 
 				push = true;
 			}

--- a/test/agent.ts
+++ b/test/agent.ts
@@ -205,3 +205,17 @@ test('no socket hung up regression', withServer, async (t, server, got) => {
 
 	agent.destroy();
 });
+
+test('accept undefined agent', withServer, async (t, server, got) => {
+	server.get('/', (_request, response) => {
+		response.end('ok');
+	});
+
+	const undefinedAgent = undefined;
+	t.truthy((await got({
+		https: {
+			rejectUnauthorized: false,
+		},
+		agent: undefinedAgent,
+	})).body);
+});


### PR DESCRIPTION
Fix: https://github.com/sindresorhus/got/issues/2257
Does not throw exception when passing undefined agent.


#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] If it's a new feature, I have included documentation updates in both the README and the types.
