### PR TITLE
feature: modernize output, reducing bundle size

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,18 +2,12 @@
 	"extends": "@sindresorhus/tsconfig",
 	"compilerOptions": {
 		"outDir": "dist",
-		"target": "es2020", // Node.js 14
-		"lib": [
-			"es2020"
-		],
+		"target": "ES2022", // Node.js 18
+		"lib": ["ES2022"],
 		"noPropertyAccessFromIndexSignature": false,
 		"isolatedModules": true
 	},
-	"include": [
-		"source",
-		"test",
-		"benchmark"
-	],
+	"include": ["source", "test", "benchmark"],
 	"ts-node": {
 		"transpileOnly": true,
 		"files": true,


### PR DESCRIPTION
This changes the typescript output target from `ES2020` to `ES2022`. Trying it out locally, the modern code is still compatible with node 14, 16, 18 and 20.

Fixes https://github.com/sindresorhus/got/issues/2286


#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates in both the README and the types.
