### PR TITLE
docs: updated basic post example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,14 +108,16 @@ Furthermore, the promise exposes a `.json<T>()` function that returns `Promise<T
 ```js
 import got from 'got';
 
-const {data} = await got.post('https://httpbin.org/anything', {
-	json: {
+const { body: data } = await got.post('https://httpbin.org/anything', {
+	json: true,
+        body: {
 		hello: 'world'
 	}
-}).json();
+});
 
 console.log(data);
 //=> {"hello": "world"}
+
 ```
 
 For advanced JSON usage, check out the [`parseJson`](documentation/2-options.md#parsejson) and [`stringifyJson`](documentation/2-options.md#stringifyjson) options.


### PR DESCRIPTION
#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] If it's a new feature, I have included documentation updates in both the README and the types.

#### PR Description
I tried the basic post example from the `readme` but I was getting type errors. For reference:

```js
import got from 'got';

const {data} = await got.post('https://httpbin.org/anything', {
	json: true,
  body: {
		hello: 'world'
	}
}).json();

console.log(data);
//=> {"hello": "world"}
```


Odds are I'm just such a newbie that I am way off base. But on the off chance that the docs are out of date, the following does not give me type errors:

```js
import got from 'got';

const { body: data } = await got.post('https://httpbin.org/anything', {
	json: true,
  body: {
		hello: 'world'
	}
});

console.log(data);
//=> {"hello": "world"}
```

I updated the sample in the `readme` to match.