### PR TITLE
catch error in fall back to utf8

### DIFF
--- a/test/error.ts
+++ b/test/error.ts
@@ -343,6 +343,23 @@ test('no uncaught parse errors #2', async t => {
 	await close();
 });
 
+test('no uncaught parse errors on fall back to utf8', withServer, async (t, server, got) => {
+	server.get('/', (_request, response) => {
+		const buffer = Buffer.alloc(536_870_912, 'A');
+		response.statusCode = 200;
+		response.end(buffer);
+	});
+
+	await t.throwsAsync(got({
+		timeout: {
+			request: 60_000,
+		},
+	}), {
+		instanceOf: RequestError,
+		code: 'ERR_BODY_PARSE_FAILURE',
+	});
+});
+
 // Fails randomly on Node 10:
 // Blocked by https://github.com/istanbuljs/nyc/issues/619
 // eslint-disable-next-line ava/no-skip-test

--- a/test/error.ts
+++ b/test/error.ts
@@ -343,7 +343,7 @@ test('no uncaught parse errors #2', async t => {
 	await close();
 });
 
-test('no uncaught parse errors on fall back to utf8', withServer, async (t, server, got) => {
+test('no uncaught parse errors on fallback to utf8', withServer, async (t, server, got) => {
 	server.get('/', (_request, response) => {
 		const buffer = Buffer.alloc(536_870_912, 'A');
 		response.statusCode = 200;


### PR DESCRIPTION
To reproduce error fetch big file and then read body of the response. You will receive the error but you won't be able to catch it with try-catch.

```javascript
import got from "got";

try {
  const res = await got("https://mp4-download.com/8k-5-MP4");
  console.log(res.body);
} catch (error) {
  console.log("Catch error:", error.message);
}
```

So what I add is try-catch block to `response.rawBody.toString()` as it is in `parseBody` method from `got\dist\source\core\response.js`

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates in both the README and the types.
