### PR TITLE
pass msg body to the error

### DIFF
--- a/source/core/errors.ts
+++ b/source/core/errors.ts
@@ -96,7 +96,7 @@ export class HTTPError<T = any> extends RequestError<T> {
 	declare readonly timings: Timings;
 
 	constructor(response: PlainResponse) {
-		super(`Response code ${response.statusCode} (${response.statusMessage!}), Body: ${response.body}`, {}, response.request);
+		super(`Response code ${response.statusCode} (${response.statusMessage!}), Body: ${response?.body}`, {}, response.request);
 		this.name = 'HTTPError';
 		this.code = 'ERR_NON_2XX_3XX_RESPONSE';
 	}

--- a/source/core/errors.ts
+++ b/source/core/errors.ts
@@ -96,7 +96,7 @@ export class HTTPError<T = any> extends RequestError<T> {
 	declare readonly timings: Timings;
 
 	constructor(response: PlainResponse) {
-		super(`Response code ${response.statusCode} (${response.statusMessage!})`, {}, response.request);
+		super(`Response code ${response.statusCode} (${response.statusMessage!}), Body: ${response.body}`, {}, response.request);
 		this.name = 'HTTPError';
 		this.code = 'ERR_NON_2XX_3XX_RESPONSE';
 	}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,8 @@
 		"source",
 		"test",
 		"benchmark"
+	],
+	"exclude": [
+		"test/",
 	]
 }


### PR DESCRIPTION
This PR addresses an issue where the server response is obscured when encountering a 400 status code. My colleague and I encountered difficulties due to the library's behavior of hiding the server response in such cases. This situation is particularly problematic as some servers provide valuable error messages within the response body for 400 status codes.

The changes included in this PR aim to enhance the handling of 400 response status codes by ensuring that the server response is properly surfaced and accessible to users. By exposing the full server response, we can better diagnose and address issues encountered during API interactions, leading to improved usability and developer experience.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates in both the README and the types.
