### PR TITLE
fix: remove unnecessary type assertions

### DIFF
--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -950,7 +950,7 @@ const cloneRaw = (raw: OptionsInit) => {
 };
 
 const getHttp2TimeoutOption = (internals: typeof defaultInternals): number | undefined => {
-	const delays = [internals.timeout.socket, internals.timeout.connect, internals.timeout.lookup, internals.timeout.request, internals.timeout.secureConnect].filter(delay => typeof delay === 'number') as number[];
+	const delays = [internals.timeout.socket, internals.timeout.connect, internals.timeout.lookup, internals.timeout.request, internals.timeout.secureConnect].filter(delay => typeof delay === 'number');
 
 	if (delays.length > 0) {
 		return Math.min(...delays);

--- a/source/core/utils/options-to-url.ts
+++ b/source/core/utils/options-to-url.ts
@@ -63,7 +63,7 @@ export default function optionsToUrl(origin: string, options: URLOptions): URL {
 
 	for (const key of keys) {
 		if (options[key]) {
-			url[key] = options[key]!.toString();
+			url[key] = options[key].toString();
 		}
 	}
 


### PR DESCRIPTION
The `main` branch is [currently failing](https://github.com/sindresorhus/got/actions/runs/9679374025/job/26705223189) due to a tslint rule:

```
Error: /Users/runner/work/got/got/source/core/options.ts: line 953, col 17, Error - This assertion is unnecessary since it does not change the type of the expression. (@typescript-eslint/no-unnecessary-type-assertion)
Error: /Users/runner/work/got/got/source/core/utils/options-to-url.ts: line 66, col 15, Error - This assertion is unnecessary since it does not change the type of the expression. (@typescript-eslint/no-unnecessary-type-assertion)
```

So I removed the unnecessary type assertions.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.


