### PR TITLE
Update @sindresorhus/is to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"ky"
 	],
 	"dependencies": {
-		"@sindresorhus/is": "^6.3.1",
+		"@sindresorhus/is": "^7.0.0",
 		"@szmarczak/http-timer": "^5.0.1",
 		"cacheable-lookup": "^7.0.0",
 		"cacheable-request": "^12.0.1",

--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -1075,7 +1075,7 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 			if (is.undefined(headers[key])) {
 				// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
 				delete headers[key];
-			} else if (is.null_(headers[key])) {
+			} else if (is.null(headers[key])) {
 				throw new TypeError(`Use \`undefined\` instead of \`null\` to delete the \`${key}\` header`);
 			}
 		}

--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -622,7 +622,7 @@ function validateSearchParameters(searchParameters: Record<string, unknown>): as
 	for (const key in searchParameters) {
 		const value = searchParameters[key];
 
-		assert.any([is.string, is.number, is.boolean, is.null_, is.undefined], value);
+		assert.any([is.string, is.number, is.boolean, is.null, is.undefined], value);
 	}
 }
 
@@ -1102,7 +1102,7 @@ export default class Options {
 	}
 
 	set request(value: RequestFunction | undefined) {
-		assert.any([is.function_, is.undefined], value);
+		assert.any([is.function, is.undefined], value);
 
 		this._internals.request = value;
 	}
@@ -1474,8 +1474,8 @@ export default class Options {
 
 		let {setCookie, getCookieString} = value;
 
-		assert.function_(setCookie);
-		assert.function_(getCookieString);
+		assert.function(setCookie);
+		assert.function(getCookieString);
 
 		/* istanbul ignore next: Horrible `tough-cookie` v3 check */
 		if (setCookie.length === 4 && getCookieString.length === 0) {
@@ -1635,7 +1635,7 @@ export default class Options {
 	}
 
 	set dnsLookup(value: CacheableLookup['lookup'] | undefined) {
-		assert.any([is.function_, is.undefined], value);
+		assert.any([is.function, is.undefined], value);
 
 		this._internals.dnsLookup = value;
 	}
@@ -1735,7 +1735,7 @@ export default class Options {
 
 			if (hooks) {
 				for (const hook of hooks) {
-					assert.function_(hook);
+					assert.function(hook);
 				}
 			}
 
@@ -1770,7 +1770,7 @@ export default class Options {
 	}
 
 	set followRedirect(value: boolean | ((response: PlainResponse) => boolean)) {
-		assert.any([is.boolean, is.function_], value);
+		assert.any([is.boolean, is.function], value);
 
 		this._internals.followRedirect = value;
 	}
@@ -2013,7 +2013,7 @@ export default class Options {
 	}
 
 	set parseJson(value: ParseJsonFunction) {
-		assert.function_(value);
+		assert.function(value);
 
 		this._internals.parseJson = value;
 	}
@@ -2064,7 +2064,7 @@ export default class Options {
 	}
 
 	set stringifyJson(value: StringifyJsonFunction) {
-		assert.function_(value);
+		assert.function(value);
 
 		this._internals.stringifyJson = value;
 	}
@@ -2098,7 +2098,7 @@ export default class Options {
 	set retry(value: Partial<RetryOptions>) {
 		assert.plainObject(value);
 
-		assert.any([is.function_, is.undefined], value.calculateDelay);
+		assert.any([is.function, is.undefined], value.calculateDelay);
 		assert.any([is.number, is.undefined], value.maxRetryAfter);
 		assert.any([is.number, is.undefined], value.limit);
 		assert.any([is.array, is.undefined], value.methods);
@@ -2164,7 +2164,7 @@ export default class Options {
 	}
 
 	set createConnection(value: CreateConnectionFunction | undefined) {
-		assert.any([is.function_, is.undefined], value);
+		assert.any([is.function, is.undefined], value);
 
 		this._internals.createConnection = value;
 	}
@@ -2210,7 +2210,7 @@ export default class Options {
 		assert.plainObject(value);
 
 		assert.any([is.boolean, is.undefined], value.rejectUnauthorized);
-		assert.any([is.function_, is.undefined], value.checkServerIdentity);
+		assert.any([is.function, is.undefined], value.checkServerIdentity);
 		assert.any([is.string, is.object, is.array, is.undefined], value.certificateAuthority);
 		assert.any([is.string, is.object, is.array, is.undefined], value.key);
 		assert.any([is.string, is.object, is.array, is.undefined], value.certificate);

--- a/source/core/utils/is-form-data.ts
+++ b/source/core/utils/is-form-data.ts
@@ -7,5 +7,5 @@ type FormData = {
 } & Readable;
 
 export default function isFormData(body: unknown): body is FormData {
-	return is.nodeStream(body) && is.function_((body as FormData).getBoundary);
+	return is.nodeStream(body) && is.function((body as FormData).getBoundary);
 }

--- a/source/create.ts
+++ b/source/create.ts
@@ -22,7 +22,7 @@ const delay = async (ms: number) => new Promise(resolve => {
 	setTimeout(resolve, ms);
 });
 
-const isGotInstance = (value: Got | ExtendOptions): value is Got => is.function_(value);
+const isGotInstance = (value: Got | ExtendOptions): value is Got => is.function(value);
 
 const aliases: readonly HTTPAlias[] = [
 	'get',
@@ -134,10 +134,10 @@ const create = (defaults: InstanceDefaults): Got => {
 
 		const {pagination} = normalizedOptions;
 
-		assert.function_(pagination.transform);
-		assert.function_(pagination.shouldContinue);
-		assert.function_(pagination.filter);
-		assert.function_(pagination.paginate);
+		assert.function(pagination.transform);
+		assert.function(pagination.shouldContinue);
+		assert.function(pagination.filter);
+		assert.function(pagination.paginate);
 		assert.number(pagination.countLimit);
 		assert.number(pagination.requestLimit);
 		assert.number(pagination.backoff);

--- a/test/create.ts
+++ b/test/create.ts
@@ -329,7 +329,7 @@ test('async handlers', withServer, async (t, server, got) => {
 	});
 
 	const promise = instance('');
-	t.true(is.function_(promise.cancel));
+	t.true(is.function(promise.cancel));
 	// @ts-expect-error Manual tests
 	t.true((await promise).modified);
 });

--- a/test/stream.ts
+++ b/test/stream.ts
@@ -178,8 +178,8 @@ test('check for pipe method', withServer, (t, server, got) => {
 	server.get('/', defaultHandler);
 
 	const stream = got.stream('');
-	t.true(is.function_(stream.pipe));
-	t.true(is.function_(stream.on('foobar', () => {}).pipe));
+	t.true(is.function(stream.pipe));
+	t.true(is.function(stream.on('foobar', () => {}).pipe));
 
 	stream.destroy();
 });


### PR DESCRIPTION
The latest version of `@sindresorhus/is` removes the deprecated methods `function_` & `null_` in favor of `function` & `null`

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
