### PR TITLE
Update packagephobia badges and link in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -321,11 +321,11 @@ By default, Got will retry on failure. To disable this option, set [`options.ret
 [s7]: https://www.npmjs.com/package/visionmedia?activeTab=dependents
 
 <!-- INSTALL SIZE -->
-[gis]: https://badgen.net/packagephobia/install/got?color=blue&label
-[kis]: https://badgen.net/packagephobia/install/ky?color=blue&label
-[nis]: https://badgen.net/packagephobia/install/node-fetch?color=blue&label
-[ais]: https://badgen.net/packagephobia/install/axios?color=blue&label
-[sis]: https://badgen.net/packagephobia/install/superagent?color=blue&label
+[gis]: https://packagephobia.com/badge?p=got
+[kis]: https://packagephobia.com/badge?p=ky
+[nis]: https://packagephobia.com/badge?p=node-fetch
+[ais]: https://packagephobia.com/badge?p=axios
+[sis]: https://packagephobia.com/badge?p=superagent
 
 [g8]: https://packagephobia.com/result?p=got
 [k8]: https://packagephobia.com/result?p=ky
@@ -374,7 +374,7 @@ By default, Got will retry on failure. To disable this option, set [`options.ret
 
 [Click here][InstallSizeOfTheDependencies] to see the install size of the Got dependencies.
 
-[InstallSizeOfTheDependencies]: https://packagephobia.com/result?p=@sindresorhus/is@4.0.1,@szmarczak/http-timer@4.0.5,@types/cacheable-request@6.0.1,@types/responselike@1.0.0,cacheable-lookup@6.0.0,cacheable-request@7.0.2,decompress-response@6.0.0,get-stream@6.0.1,http2-wrapper@2.0.5,lowercase-keys@2.0.0,p-cancelable@2.1.1,responselike@2.0.0
+[InstallSizeOfTheDependencies]: https://packagephobia.com/result?p=@sindresorhus/is@6.3.1,@szmarczak/http-timer@5.0.1,cacheable-lookup@7.0.0,cacheable-request@12.0.1,decompress-response@6.0.0,form-data-encoder@4.0.2,get-stream@8.0.1,http2-wrapper@2.2.1,lowercase-keys@3.0.0,p-cancelable@4.0.1,responselike@3.0.0,type-fest@4.19.0
 
 ## Maintainers
 


### PR DESCRIPTION
Currently the readme uses badgen.net which seems to be having issues behind the github user content proxy. It lists the install size as 429 (which is probably the status code). Perhaps if we switch to using their native badge we won't have that problem.

### Current
![Screenshot 2024-07-11 111857](https://github.com/sindresorhus/got/assets/20630/e406152d-fd41-47e1-ac3d-d1139033f9b8)

### Proposed

![Screenshot 2024-07-11 113411](https://github.com/sindresorhus/got/assets/20630/d33ebadb-1fc0-4b07-955a-e59246586fc5)

I also updated the link for the install size to the current version's dependencies.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
