### PR TITLE
Fix: allow invalid arguments to throw appropriate Error message

### DIFF
--- a/source/create.ts
+++ b/source/create.ts
@@ -54,10 +54,10 @@ const create = (defaults: InstanceDefaults): Got => {
 		const lastHandler = (normalized: Options): GotReturn => {
 			// Note: `options` is `undefined` when `new Options(...)` fails
 			request.options = normalized;
-			request._noPipe = !normalized.isStream;
+			request._noPipe = !normalized?.isStream;
 			void request.flush();
 
-			if (normalized.isStream) {
+			if (normalized?.isStream) {
 				return request;
 			}
 
@@ -72,7 +72,7 @@ const create = (defaults: InstanceDefaults): Got => {
 
 			const result = handler(newOptions, iterateHandlers) as GotReturn;
 
-			if (is.promise(result) && !request.options.isStream) {
+			if (is.promise(result) && !request.options?.isStream) {
 				promise ||= asPromise(request);
 
 				if (result !== promise) {

--- a/test/arguments.ts
+++ b/test/arguments.ts
@@ -42,6 +42,16 @@ test('throws if the url option is missing', async t => {
 	});
 });
 
+test('throws if an invalid argument is passed', async t => {
+	await t.throwsAsync(
+		// @ts-expect-error Error tests
+		got(false),
+		{
+			instanceOf: RequestError,
+			message: 'Expected values which are `string`, `URL`, `Object`, or `undefined`. Received values of type `boolean`.',
+		});
+});
+
 test('throws an error if the protocol is not specified', async t => {
 	const error = await t.throwsAsync(got('example.com'));
 	invalidUrl(t, error!, 'example.com');


### PR DESCRIPTION
Fixes: #2366

When invalid arguments are passed to the `got` function such as `false`, the `new Options()` returns undefined. But that option object is destructured **_without_** checking for it being `undefined` inside the got function.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.

