### PR TITLE
Patch 1

### DIFF
--- a/documentation/2-options.md
+++ b/documentation/2-options.md
@@ -28,7 +28,7 @@ const options = new Options({
 	}
 });
 
-options.headers. = 'bar';
+options.headers.foo = 'bar';
 
 // Note that `Options` stores normalized options, therefore it needs to be passed as the third argument.
 const {headers} = await got('anything', undefined, options).json();

--- a/documentation/2-options.md
+++ b/documentation/2-options.md
@@ -28,11 +28,11 @@ const options = new Options({
 	}
 });
 
-options.headers.foo = 'bar';
+options.headers. = 'bar';
 
 // Note that `Options` stores normalized options, therefore it needs to be passed as the third argument.
 const {headers} = await got('anything', undefined, options).json();
-console.log(headers.Foo);
+console.log(headers.foo);
 //=> 'bar'
 ```
 
@@ -52,7 +52,7 @@ options.headers.foo = 'bar';
 
 // Note that `options` is a plain object, therefore it needs to be passed as the second argument.
 const {headers} = await got('anything', options).json();
-console.log(headers.Foo);
+console.log(headers.foo);
 //=> 'bar'
 ```
 


### PR DESCRIPTION
Lowercased two inappropriately caliptalized occurrences of "foo".  I wasn't sure if this was correct so I asked an AI (Gemini) which explained that while HTTP headers are case insensitive, the property names of Javascript objects are not, so foo and Foo are different and the code was asking for the wrong one.

#### Checklist

- [X] I have read the documentation.
- [X] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates in both the README and the types.
