### PR TITLE
Fix 404 links related to cacheable-request

### DIFF
--- a/documentation/cache.md
+++ b/documentation/cache.md
@@ -2,7 +2,7 @@
 
 ## Cache
 
-Got implements [RFC 7234](https://httpwg.org/specs/rfc7234.html) compliant HTTP caching which works out of the box in-memory and is easily pluggable with a wide range of storage adapters. Fresh cache entries are served directly from the cache, and stale cache entries are revalidated with `If-None-Match` / `If-Modified-Since` headers. You can read more about the underlying cache behavior in the [`cacheable-request` documentation](https://github.com/lukechilds/cacheable-request).
+Got implements [RFC 7234](https://httpwg.org/specs/rfc7234.html) compliant HTTP caching which works out of the box in-memory and is easily pluggable with a wide range of storage adapters. Fresh cache entries are served directly from the cache, and stale cache entries are revalidated with `If-None-Match` / `If-Modified-Since` headers. You can read more about the underlying cache behavior in the [`cacheable-request` documentation](https://www.npmjs.com/package/cacheable-request).
 
 You can use the JavaScript `Map` type as an in-memory cache:
 

--- a/source/core/response.ts
+++ b/source/core/response.ts
@@ -25,7 +25,7 @@ export type PlainResponse = {
 	/**
 	The remote IP address.
 
-	This is hopefully a temporary limitation, see [lukechilds/cacheable-request#86](https://github.com/lukechilds/cacheable-request/issues/86).
+	This is hopefully a temporary limitation, see [lukechilds/cacheable-request#86](https://web.archive.org/web/20220804165050/https://github.com/jaredwray/cacheable-request/issues/86).
 
 	__Note__: Not available when the response is cached.
 	*/


### PR DESCRIPTION
#### Description

lukechilds/cacheable-request was moved as jaredwray/cacheable-request before.

then jaredwray moved the codebase of cacheable-request into jaredwray/cacheable by deleting the cacheable-request repo, thus the original cacheable-request repo has been gone forever.

This PR:

1. use an npm link instead of https://github.com/lukechilds/cacheable-request.
2. use a time machine wayback link instead of its issue link.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] (excluded) I have included some tests
- [x] (excluded) If it's a new feature, I have included documentation updates in both the README and the types.
