### PR TITLE
Fix "Unknown HTTP2 promise event"

### DIFF
--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -1001,13 +1001,13 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 										handler(error);
 									}
 								})();
-							} else if (event === 'abort') {
+							} else if (event === 'abort' || event === 'destroy') {
 								// The empty catch is needed here in case when
 								// it rejects before it's `await`ed in `_makeRequest`.
 								(async () => {
 									try {
 										const request = (await result) as ClientRequest;
-										request.once('abort', handler);
+										request.once(event, handler);
 									} catch {}
 								})();
 							} else {

--- a/test/cache.ts
+++ b/test/cache.ts
@@ -179,6 +179,15 @@ test('doesn\'t cache response when received HTTP error', withServer, async (t, s
 	t.is(body, 'ok');
 });
 
+test('cache should work with http2', async t => {
+	const instance = got.extend({
+		cache: true,
+		http2: true,
+	});
+
+	await t.notThrowsAsync(instance('https://example.com'));
+});
+
 test('DNS cache works', async t => {
 	const instance = got.extend({
 		dnsCache: true,


### PR DESCRIPTION
#### Description 

##### Fix issue:

```js
// will throw "Unknown HTTP2 promise event: destroy"
await got('https://example.com', { cache:true, http2:true })
```

##### Caused by:

https://github.com/jaredwray/cacheable/blob/8429488fdc78e9b204e38f5d61b616d00f476f74/packages/cacheable-request/src/index.ts?plain=1#L188

```ts
				request_.once('destroy', requestErrorCallback);
```

cacheable-request add this line since 10.2.3


#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] (excluded) If it's a new feature, I have included documentation updates in both the README and the types.
