### PR TITLE
fix: correct support for AbortSignal:timeout()

### DIFF
--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -264,7 +264,12 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 
 		if (this.options.signal) {
 			const abort = () => {
-				this.destroy(new AbortError(this));
+				// See https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static#return_value
+				if (this.options.signal?.reason?.name === 'TimeoutError') {
+					this.destroy(new TimeoutError(this.options.signal.reason, this.timings!, this));
+				} else {
+					this.destroy(new AbortError(this));
+				}
 			};
 
 			if (this.options.signal.aborted) {

--- a/test/abort.ts
+++ b/test/abort.ts
@@ -325,6 +325,7 @@ test('support setting the signal as a default option', async t => {
 	t.true(signalHandlersRemoved(), 'Abort signal event handlers not removed');
 });
 
+const timeoutErrorCode = 23;
 // See https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static
 test('support AbortSignal.timeout()', async t => {
 	const signal = AbortSignal.timeout(1);
@@ -332,7 +333,7 @@ test('support AbortSignal.timeout()', async t => {
 	const p = got('http://example.com', {signal});
 
 	await t.throwsAsync(p, {
-		code: 23,
+		code: timeoutErrorCode,
 		message: 'The operation was aborted due to timeout',
 	});
 });
@@ -347,7 +348,7 @@ test('support AbortSignal.timeout() without user abort', async t => {
 	const p = got('http://example.com', {signal});
 
 	await t.throwsAsync(p, {
-		code: 23,
+		code: timeoutErrorCode,
 		message: 'The operation was aborted due to timeout',
 	});
 

--- a/test/abort.ts
+++ b/test/abort.ts
@@ -324,3 +324,54 @@ test('support setting the signal as a default option', async t => {
 
 	t.true(signalHandlersRemoved(), 'Abort signal event handlers not removed');
 });
+
+// See https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static
+test('support AbortSignal.timeout()', async t => {
+	const signal = AbortSignal.timeout(1);
+
+	const p = got('http://example.com', {signal});
+
+	await t.throwsAsync(p, {
+		code: 23,
+		message: 'The operation was aborted due to timeout',
+	});
+});
+
+test('support AbortSignal.timeout() without user abort', async t => {
+	const {controller, signalHandlersRemoved} = createAbortController();
+	const timeoutSignal = AbortSignal.timeout(1);
+	const signal = AbortSignal.any([
+		controller.signal,
+		timeoutSignal,
+	]);
+	const p = got('http://example.com', {signal});
+
+	await t.throwsAsync(p, {
+		code: 23,
+		message: 'The operation was aborted due to timeout',
+	});
+
+	t.true(signalHandlersRemoved(), 'Abort signal event handlers not removed');
+});
+
+test('support AbortSignal.timeout() with user abort', async t => {
+	const {controller, signalHandlersRemoved} = createAbortController();
+	const timeoutSignal = AbortSignal.timeout(1000);
+	const signal = AbortSignal.any([
+		controller.signal,
+		timeoutSignal,
+	]);
+
+	setTimeout(() => {
+		controller.abort();
+	}, 10);
+
+	const p = got('http://example.com', {signal});
+
+	await t.throwsAsync(p, {
+		code: 'ERR_ABORTED',
+		message: 'This operation was aborted.',
+	});
+
+	t.true(signalHandlersRemoved(), 'Abort signal event handlers not removed');
+});


### PR DESCRIPTION
See #2371

This changes the rejected value to TimeotError when `AbortSignal:timeout()` is initially aborted.

As stated in [docs](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static#return_value):

> The signal will abort with its [AbortSignal.reason](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/reason) property set to a TimeoutError [DOMException](https://developer.mozilla.org/en-US/docs/Web/API/DOMException) on timeout, or an AbortError [DOMException](https://developer.mozilla.org/en-US/docs/Web/API/DOMException) if the operation was user-triggered.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [x] I have included some tests.
- [x] If it's a new feature, I have included documentation updates in both the README and the types.
