### PR TITLE
Fix timeout error firing even though it's cancelled

### DIFF
--- a/source/core/timed-out.ts
+++ b/source/core/timed-out.ts
@@ -71,7 +71,7 @@ export default function timedOut(request: ClientRequest, delays: Delays, options
 	const {host, hostname} = options;
 
 	const timeoutHandler = (delay: number, event: string): void => {
-		// Use queueMicroTask to allow for any cancelled events to be handled first, 
+		// Use queueMicroTask to allow for any cancelled events to be handled first,
 		// to prevent firing any TimeoutError unneeded when the event loop is busy or blocked
 		queueMicrotask(() => {
 			if (!handled.has(event)) {

--- a/source/core/timed-out.ts
+++ b/source/core/timed-out.ts
@@ -51,7 +51,7 @@ export default function timedOut(request: ClientRequest, delays: Delays, options
 	request[reentry] = true;
 	const cancelers: Array<typeof noop> = [];
 	const {once, unhandleAll} = unhandler();
-	const handled: Record<string, boolean> = {};
+	const handled: Map<string, boolean> = new Map<string, boolean>();
 
 	const addTimeout = (delay: number, callback: (delay: number, event: string) => void, event: string): (typeof noop) => {
 		const timeout = setTimeout(callback, delay, delay, event) as unknown as NodeJS.Timeout;
@@ -59,7 +59,7 @@ export default function timedOut(request: ClientRequest, delays: Delays, options
 		timeout.unref?.();
 
 		const cancel = (): void => {
-			handled[event] = true;
+			handled.set(event, true);
 			clearTimeout(timeout);
 		};
 
@@ -71,11 +71,13 @@ export default function timedOut(request: ClientRequest, delays: Delays, options
 	const {host, hostname} = options;
 
 	const timeoutHandler = (delay: number, event: string): void => {
-		setTimeout(() => {
-			if (!handled[event]) {
+		// Use queueMicroTask to allow for any cancelled events to be handled first, 
+		// to prevent firing any TimeoutError unneeded when the event loop is busy or blocked
+		queueMicrotask(() => {
+			if (!handled.has(event)) {
 				request.destroy(new TimeoutError(delay, event));
 			}
-		}, 0);
+		});
 	};
 
 	const cancelTimeouts = (): void => {

--- a/source/core/timed-out.ts
+++ b/source/core/timed-out.ts
@@ -52,7 +52,7 @@ export default function timedOut(request: ClientRequest, delays: Delays, options
 	const cancelers: Array<typeof noop> = [];
 	const {once, unhandleAll} = unhandler();
 	const handled: Record<string, boolean> = {};
-	
+
 	const addTimeout = (delay: number, callback: (delay: number, event: string) => void, event: string): (typeof noop) => {
 		const timeout = setTimeout(callback, delay, delay, event) as unknown as NodeJS.Timeout;
 

--- a/source/core/timed-out.ts
+++ b/source/core/timed-out.ts
@@ -71,13 +71,13 @@ export default function timedOut(request: ClientRequest, delays: Delays, options
 	const {host, hostname} = options;
 
 	const timeoutHandler = (delay: number, event: string): void => {
-		// Use queueMicroTask to allow for any cancelled events to be handled first,
+		// Use setTimeout to allow for any cancelled events to be handled first,
 		// to prevent firing any TimeoutError unneeded when the event loop is busy or blocked
-		queueMicrotask(() => {
+		setTimeout(() => {
 			if (!handled.has(event)) {
 				request.destroy(new TimeoutError(delay, event));
 			}
-		});
+		}, 0);
 	};
 
 	const cancelTimeouts = (): void => {

--- a/test/retry.ts
+++ b/test/retry.ts
@@ -23,17 +23,9 @@ const handler413: Handler = (_request, response) => {
 };
 
 const createSocketTimeoutStream = (): http.ClientRequest => {
-	const stream = new PassThroughStream();
-	// @ts-expect-error Mocking the behaviour of a ClientRequest
-	stream.setTimeout = (ms, callback) => {
-		process.nextTick(callback);
-	};
-
-	// @ts-expect-error Mocking the behaviour of a ClientRequest
-	stream.abort = () => {};
-	stream.resume();
-
-	return stream as unknown as http.ClientRequest;
+	return http.request("http://example.com", {
+	  timeout: socketTimeout
+	});
 };
 
 test('works on timeout', withServer, async (t, server, got) => {

--- a/test/retry.ts
+++ b/test/retry.ts
@@ -22,7 +22,7 @@ const handler413: Handler = (_request, response) => {
 	response.end();
 };
 
-const createSocketTimeoutStream = (url): http.ClientRequest => {
+const createSocketTimeoutStream = (url: string): http.ClientRequest => {
 	if (url.indexOf("https:") > -1) {
 		return https.request(url, {
 		  timeout: 1

--- a/test/retry.ts
+++ b/test/retry.ts
@@ -28,6 +28,7 @@ const createSocketTimeoutStream = (url: string): http.ClientRequest => {
 			timeout: 1,
 		});
 	}
+
 	return http.request(url, {
 		timeout: socketTimeout,
 	});
@@ -90,7 +91,7 @@ test('setting to `0` disables retrying', async t => {
 				return 0;
 			},
 		},
-		request: () => createSocketTimeoutStream("https://example.com"),
+		request: () => createSocketTimeoutStream('https://example.com'),
 	}), {
 		instanceOf: TimeoutError,
 		message: `Timeout awaiting 'socket' for ${socketTimeout}ms`,

--- a/test/retry.ts
+++ b/test/retry.ts
@@ -1,4 +1,3 @@
-import process from 'node:process';
 import {EventEmitter} from 'node:events';
 import {PassThrough as PassThroughStream} from 'node:stream';
 import type {Socket} from 'node:net';

--- a/test/retry.ts
+++ b/test/retry.ts
@@ -23,13 +23,13 @@ const handler413: Handler = (_request, response) => {
 };
 
 const createSocketTimeoutStream = (url: string): http.ClientRequest => {
-	if (url.indexOf("https:") > -1) {
+	if (url.includes('https:')) {
 		return https.request(url, {
-		  timeout: 1
-		});	
+			timeout: 1,
+		});
 	}
 	return http.request(url, {
-	  timeout: socketTimeout
+		timeout: socketTimeout,
 	});
 };
 

--- a/test/timeout.ts
+++ b/test/timeout.ts
@@ -1,6 +1,6 @@
 import process from 'node:process';
 import {EventEmitter} from 'node:events';
-import stream, {PassThrough as PassThroughStream} from 'node:stream';
+import stream from 'node:stream';
 import {pipeline as streamPipeline} from 'node:stream/promises';
 import http from 'node:http';
 import https from 'node:https';

--- a/test/timeout.ts
+++ b/test/timeout.ts
@@ -3,6 +3,7 @@ import {EventEmitter} from 'node:events';
 import stream, {PassThrough as PassThroughStream} from 'node:stream';
 import {pipeline as streamPipeline} from 'node:stream/promises';
 import http from 'node:http';
+import https from 'node:https';
 import net from 'node:net';
 import getStream from 'get-stream';
 import test from 'ava';
@@ -90,17 +91,9 @@ test.serial('socket timeout', async t => {
 				limit: 0,
 			},
 			request() {
-				const stream = new PassThroughStream();
-				// @ts-expect-error Mocking the behaviour of a ClientRequest
-				stream.setTimeout = (ms, callback) => {
-					process.nextTick(callback);
-				};
-
-				// @ts-expect-error Mocking the behaviour of a ClientRequest
-				stream.abort = () => {};
-				stream.resume();
-
-				return stream as unknown as http.ClientRequest;
+				return https.request('https://example.com', {
+					timeout: 0,
+				});
 			},
 		}),
 		{


### PR DESCRIPTION
This is fixes https://github.com/sindresorhus/got/issues/2248, as supplied by [@thegedge](https://github.com/thegedge) earlier. See the original issue for a description of the issue and the proposed solution.

It's hard to add a unit test for this behavior, as it involves blocking the event loop for a certain amount of time.
Let me know if this is something that would be considered or if there are any concerns.

#### Checklist

- [x] I have read the documentation.
- [x] I have included a pull request description of my changes.
- [ ] I have included some tests.
