### PR TITLE
Strip `proxy-authorization` header on cross-origin redirect

### DIFF
--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -1050,6 +1050,10 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 							updatedOptions.deleteInternalHeader('authorization');
 						}
 
+						if ('proxy-authorization' in updatedHeaders) {
+							updatedOptions.deleteInternalHeader('proxy-authorization');
+						}
+
 						if (updatedOptions.username || updatedOptions.password) {
 							updatedOptions.username = '';
 							updatedOptions.password = '';

--- a/test/redirects.ts
+++ b/test/redirects.ts
@@ -668,6 +668,28 @@ test('clears the authorization header when redirecting to a different hostname',
 	});
 });
 
+test('clears the proxy-authorization header when redirecting to a different hostname', withServer, async (t, server1, got) => {
+	await withServer.exec(t, async (t, server2) => {
+		server1.get('/', (_request, response) => {
+			response.writeHead(302, {
+				location: `http://localhost:${server2.port}/`,
+			});
+			response.end();
+		});
+
+		server2.get('/', (request, response) => {
+			response.end(JSON.stringify({headers: request.headers}));
+		});
+
+		const {headers} = await got('', {
+			headers: {
+				'proxy-authorization': 'Basic cHJveHl1c2VyOnByb3h5cGFzcw==',
+			},
+		}).json<{headers: Record<string, string | undefined>}>();
+		t.is(headers['proxy-authorization'], undefined);
+	});
+});
+
 test('clears credentials and sensitive headers when redirecting to a different protocol on the same hostname', withHttpsServer(), async (t, serverHttps, got) => {
 	await withServer.exec(t, async (t, serverHttp) => {
 		serverHttps.get('/', (_request, response) => {


### PR DESCRIPTION
### Describe the bug

 - Node.js version: All
 - OS & version: All

When `got` follows a cross-origin redirect (301, 302, 307, 308), it correctly strips the `authorization`, `cookie`, and `host` headers from the redirected request. However, it does not strip the `proxy-authorization` header.

This is inconsistent with how other HTTP clients handle this header on cross-origin redirects. Both Node.js native `fetch` (undici) and `curl` (since 7.85) strip `proxy-authorization` alongside `authorization` on cross-origin redirects.

While `proxy-authorization` is a hop-by-hop header that would typically be consumed by a proxy before reaching the application layer, users can set it directly via `headers`. In that case, a malicious origin could redirect to a different host and receive the header in the forwarded request.

Stripping it alongside the other credential headers would be a low-risk hardening improvement for consistency and defense in depth.

#### Actual behavior

`proxy-authorization` header is forwarded to the redirect target on cross-origin redirects.

#### Expected behavior

`proxy-authorization` header should be stripped on cross-origin redirects, consistent with the handling of `authorization` and `cookie`.

#### Code to reproduce

```js
import http from 'node:http';
import got from 'got';

const server2 = http.createServer((req, res) => {
  console.log('proxy-authorization:', req.headers['proxy-authorization']);
  // Prints: Basic cHJveHl1c2VyOnByb3h5cGFzcw==
  // Expected: undefined
  res.end('ok');
});

const server1 = http.createServer((req, res) => {
  res.writeHead(302, {
    location: 'http://127.0.0.1:' + server2.address().port + '/collect',
  });
  res.end();
});

await new Promise(r => server2.listen(0, '127.0.0.1', r));
await new Promise(r => server1.listen(0, '127.0.0.1', r));

await got('http://127.0.0.1:' + server1.address().port + '/', {
  headers: {
    'proxy-authorization': 'Basic cHJveHl1c2VyOnByb3h5cGFzcw==',
  },
  throwHttpErrors: false,
});
```

Checklist

- I have read the documentation.
- I have tried my code with the latest version of Node.js and Got.

---