### PR TITLE
Fix httpbin response examples in JSON and form docs

### DIFF
--- a/documentation/2-options.md
+++ b/documentation/2-options.md
@@ -381,13 +381,13 @@ JSON **request** body. If set, the `content-type` header defaults to `applicatio
 ```js
 import got from 'got';
 
-const {data} = await got.post('https://httpbin.org/anything', {
+const {json} = await got.post('https://httpbin.org/anything', {
 	json: {
 		hello: 'world'
 	}
 }).json();
 
-console.log(data);
+console.log(json);
 //=> `{hello: 'world'}`
 ```
 
@@ -402,14 +402,14 @@ If set, the `content-type` header defaults to [`application/x-www-form-urlencode
 ```js
 import got from 'got';
 
-const {data} = await got.post('https://httpbin.org/anything', {
+const {form} = await got.post('https://httpbin.org/anything', {
 	form: {
 		hello: 'world'
 	}
 }).json();
 
-console.log(data);
-//=> 'hello=world'
+console.log(form);
+//=> {hello: 'world'}
 ```
 
 ### `parseJson`

--- a/readme.md
+++ b/readme.md
@@ -87,13 +87,13 @@ Furthermore, the promise exposes a `.json<T>()` function that returns `Promise<T
 ```js
 import got from 'got';
 
-const {data} = await got.post('https://httpbin.org/anything', {
+const {json} = await got.post('https://httpbin.org/anything', {
 	json: {
 		hello: 'world'
 	}
 }).json();
 
-console.log(data);
+console.log(json);
 //=> {"hello": "world"}
 ```
 


### PR DESCRIPTION

**Repo:** sindresorhus/got (⭐ 14000)
**Type:** docs
**Files changed:** 2
**Lines:** +7/-7

## What
This change corrects the `httpbin.org/anything` examples in the README and options documentation so they reference the response fields that `httpbin` actually returns. The JSON example now reads from `json`, and the form example now reads from `form`, with the expected output updated to match.

## Why
The previous snippets were misleading for readers who copy-paste examples while learning Got’s request body helpers. `httpbin` echoes raw bodies in `data`, parsed JSON in `json`, and form payloads in `form`, so the old examples could make correct Got usage look broken.

## Testing
Verified the rendered diff manually and ran `git diff --check` successfully. No automated test run was needed because this is a docs-only change.

## Risk
Low / Documentation-only patch with no runtime behavior changes.
