### PR TITLE
Fix `searchParams` setter dropping the value when a URL is set

### DIFF
--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -2067,7 +2067,8 @@ export default class Options {
 		if (is.string(value)) {
 			updated = new URLSearchParams(value);
 		} else if (value instanceof URLSearchParams) {
-			updated = value;
+			// Clone so the caller-owned object is not stored by reference.
+			updated = new URLSearchParams(value);
 		} else {
 			validateSearchParameters(value);
 

--- a/source/core/options.ts
+++ b/source/core/options.ts
@@ -2100,9 +2100,10 @@ export default class Options {
 				searchParameters.append(key, value);
 			}
 		} else if (url) {
-			url.search = searchParameters.toString();
+			// Overrides the query string in the URL.
+			url.search = updated.toString();
 		} else {
-			this.#internals.searchParams = searchParameters;
+			this.#internals.searchParams = updated;
 		}
 	}
 

--- a/test/hooks.ts
+++ b/test/hooks.ts
@@ -415,6 +415,44 @@ test('beforeRequest allows modifications', withServer, async (t, server, got) =>
 	t.is(body.foo, 'bar');
 });
 
+test('beforeRequest allows overriding searchParams with an object', withServer, async (t, server, got) => {
+	server.get('/', (request, response) => {
+		response.end(request.url);
+	});
+
+	const {body} = await got('', {
+		searchParams: {old: 'value'},
+		hooks: {
+			beforeRequest: [
+				options => {
+					options.searchParams = {foo: 'bar'};
+				},
+			],
+		},
+	});
+
+	t.is(body, '/?foo=bar');
+});
+
+test('beforeRequest allows overriding searchParams with a string', withServer, async (t, server, got) => {
+	server.get('/', (request, response) => {
+		response.end(request.url);
+	});
+
+	const {body} = await got('', {
+		searchParams: {old: 'value'},
+		hooks: {
+			beforeRequest: [
+				options => {
+					options.searchParams = 'foo=bar';
+				},
+			],
+		},
+	});
+
+	t.is(body, '/?foo=bar');
+});
+
 test('beforeRequest is called with context', withServer, async (t, server, got) => {
 	server.get('/', echoHeaders);
 

--- a/test/normalize-arguments.ts
+++ b/test/normalize-arguments.ts
@@ -167,6 +167,18 @@ test('searchParams - multiple values for one key', t => {
 	);
 });
 
+test('searchParams - assigning a URLSearchParams clones it', t => {
+	const searchParameters = new URLSearchParams('foo=bar');
+
+	const options = new Options();
+	options.searchParams = searchParameters;
+
+	// Mutating the caller-owned object must not leak into the stored options.
+	searchParameters.set('foo', 'changed');
+
+	t.is(options.searchParams.toString(), 'foo=bar');
+});
+
 test('__proto__ in options does not cause prototype pollution', t => {
 	const malicious = JSON.parse('{"method": "POST", "__proto__": {"injected": true}}');
 	const options = new Options('https://example.com', malicious);


### PR DESCRIPTION
### Problem

Assigning to `options.searchParams` directly on an `Options` instance silently drops the new value. The query string the request is sent with is unchanged.

This happens outside the option-merging that the constructor uses internally — most notably in a `beforeRequest` hook, where the docs explicitly encourage mutating `options`:

```js
import got from 'got';

await got('https://example.com', {
	searchParams: {old: 'value'},
	hooks: {
		beforeRequest: [
			options => {
				options.searchParams = {foo: 'bar'};
			},
		],
	},
});
//=> request goes to https://example.com/?old=value
//   expected: https://example.com/?foo=bar
```

The `searchParams` documentation states the value *"will override the query string in `url`"*, so the request above should be sent with `?foo=bar`.

The same applies to a fresh `Options` instance with no URL yet:

```js
const options = new Options();
options.searchParams = {foo: 'bar'};
options.searchParams.toString(); //=> '' (expected 'foo=bar')
```

### Cause

In the `searchParams` setter, the incoming value is normalized into a local `updated` `URLSearchParams`. The merging branch consumes `updated`, but both non-merging branches wrote/stored `searchParameters` (the *existing* params) instead of `updated`, so the new value was never applied:

```ts
} else if (url) {
	url.search = searchParameters.toString(); // ignores `updated`
} else {
	this.#internals.searchParams = searchParameters; // ignores `updated`
}
```

The normal `got(url, {searchParams})` path was unaffected because it goes through the merging branch, which is why this wasn't caught earlier.

### Fix

Use `updated` in the non-merging branches so the assignment overrides the query string as documented. The merging branch is unchanged.

Added two regression tests covering overriding `searchParams` from a `beforeRequest` hook with both an object and a string. Both fail before the change and pass after. The existing `arguments`, `normalize-arguments`, `hooks`, and `pagination` suites remain green (`tsc --noEmit` and `xo` are also clean).
