### PR TITLE
docs: fix Response class anchor links (#response-1 -> #response-2)

### DIFF
--- a/documentation/2-options.md
+++ b/documentation/2-options.md
@@ -642,7 +642,7 @@ const [response, buffer, json] = await Promise.all([responsePromise, bufferPromi
 **Type: `boolean`**\
 **Default: `false`**
 
-If `true`, the promise will return the [Response body](3-streams.md#response-1) instead of the [Response object](3-streams.md#response-1).
+If `true`, the promise will return the [Response body](3-streams.md#response-2) instead of the [Response object](3-streams.md#response-2).
 
 ```js
 import got from 'got';

--- a/documentation/4-pagination.md
+++ b/documentation/4-pagination.md
@@ -110,7 +110,7 @@ This option represents the `pagination` object.
 **Type: `Function`**\
 **Default: `response => JSON.parse(response.body)`**
 
-A function that transforms [`Response`](3-streams.md#response-1) into an array of items.\
+A function that transforms [`Response`](3-streams.md#response-2) into an array of items.\
 This is where you should do the parsing.
 
 #### `paginate`

--- a/documentation/migration-guides/axios.md
+++ b/documentation/migration-guides/axios.md
@@ -67,11 +67,11 @@ We deeply care about readability, so we renamed these options:
 
 The response object is different as well:
 
-- `response.data` → [`response.body`](../3-streams.md#response-1)
-- `response.status` → [`response.statusCode`](../3-streams.md#response-1)
-- `response.statusText` → [`response.statusMessage`](../3-streams.md#response-1)
-- `response.config` → [`response.request.options`](../3-streams.md#response-1)
-- [`response.request`](../3-streams.md#response-1)
+- `response.data` → [`response.body`](../3-streams.md#response-2)
+- `response.status` → [`response.statusCode`](../3-streams.md#response-2)
+- `response.statusText` → [`response.statusMessage`](../3-streams.md#response-2)
+- `response.config` → [`response.request.options`](../3-streams.md#response-2)
+- [`response.request`](../3-streams.md#response-2)
   - Returns [a Got stream](../3-streams.md).
 
 The `response.headers` object remains the same.

--- a/documentation/quick-start.md
+++ b/documentation/quick-start.md
@@ -11,7 +11,7 @@ const url = 'https://httpbin.org/anything';
 const response = await got(url);
 ```
 
-The call returns a <code>Promise<[Response](3-streams.md#response-1)></code>. If the body contains JSON, it can be retrieved directly:
+The call returns a <code>Promise<[Response](3-streams.md#response-2)></code>. If the body contains JSON, it can be retrieved directly:
 
 ```js
 import got from 'got';


### PR DESCRIPTION
The `## `Response`` class section in `documentation/3-streams.md` is reached via the anchor `#response-2`.

GitHub generates that anchor because two earlier `#### `response`` headings already consume `#response` and `#response-1`:

| Heading in `3-streams.md` | Generated anchor |
| --- | --- |
| `#### `response`` (under `stream.on('response', …)`) | `#response` |
| `#### `response`` (under `stream.on('redirect', …)`) | `#response-1` |
| `## `Response`` (the Response class) | `#response-2` |

Several documentation pages link to `3-streams.md#response-1` when they mean the **Response class** (e.g. `response.body`, `response.statusCode`, `response.statusMessage`, `response.request.options`). `#response-1` actually points at the redirect event's short `#### response` heading, so those links land on the wrong section.

`readme.md` already uses the correct `#response-2` anchor for the Response class, which confirms the intended target.

This PR updates the four affected files to use `#response-2`:
- `documentation/quick-start.md`
- `documentation/2-options.md`
- `documentation/4-pagination.md`
- `documentation/migration-guides/axios.md`

Docs-only change; no code affected.
